### PR TITLE
 postProcess is friendlier to big rasters + fixed  lintr triggers

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14,6 +14,5 @@
 #' readLinesRcpp(system.file(package = "reproducible", "DESCRIPTION"))
 #' @rdname readLinesRcppInternal
 readLinesRcppInternal <- function(path) {
-    .Call('_reproducible_readLinesRcppInternal', PACKAGE = 'reproducible', path)
+    .Call("_reproducible_readLinesRcppInternal", PACKAGE = "reproducible", path)
 }
-

--- a/R/cache-tools.R
+++ b/R/cache-tools.R
@@ -150,7 +150,7 @@ setMethod(
           filesToRemove <- gsub(filesToRemove, pattern = ".{1}$", replacement = "*")
           if (interactive()) {
             dirLs <- dir(dirname(filesToRemove), full.names = TRUE)
-            dirLs <- unlist(lapply(basename(filesToRemove), grep, dirLs, value = TRUE) )
+            dirLs <- unlist(lapply(basename(filesToRemove), grep, dirLs, value = TRUE))
             cacheSize <- sum(cacheSize, file.size(dirLs))
           }
         }
@@ -350,7 +350,8 @@ setMethod(
         if (is(outputToSave, "Raster")) {
           outputToSave <- .prepareFileBackedRaster(outputToSave, repoDir = cacheTo)
         }
-        userTags <- cacheFromList[artifact][!tagKey %in% c("format", "name", "class", "date", "cacheId"),
+        userTags <- cacheFromList[artifact][!tagKey %in%
+                                              c("format", "name", "class", "date", "cacheId"),
                                             list(tagKey, tagValue)]
         userTags <- c(paste0(userTags$tagKey, ":", userTags$tagValue))
         while (!written) {

--- a/R/checksums.R
+++ b/R/checksums.R
@@ -1,5 +1,5 @@
 if (getRversion() >= "3.1.0") {
-  utils::globalVariables(c("checksum.x", "checksum.y", "filesize.x", "filesize.y", "result" ))
+  utils::globalVariables(c("checksum.x", "checksum.y", "filesize.x", "filesize.y", "result"))
 }
 
 
@@ -148,7 +148,7 @@ setMethod(
 
     if (!is.null(txt$algorithm)) {
       if (!write) {
-        dots$algo <- unique(txt[txt$file %in% basename(filesToCheck),"algorithm"])
+        dots$algo <- unique(txt[txt$file %in% basename(filesToCheck), "algorithm"])
         dots$algo <- na.omit(dots$algo)[1]
         if (is.na(dots$algo)) dots$algo <- defaultWriteHashAlgo
       }
@@ -206,9 +206,8 @@ setMethod(
       # txt <- txt[wh,]
 
     }
-    results.df <- out %>%
-      dplyr::mutate(actualFile = file) %>%
-      {
+    results.df <- out %>% #nolint
+      dplyr::mutate(actualFile = file) %>% {
         if (write) {
           dplyr::right_join(txt, ., by = "file")
         } else {
@@ -216,16 +215,14 @@ setMethod(
         }
       } %>%
       dplyr::rename(expectedFile = file) %>%
-      dplyr::group_by(expectedFile) %>%
-      {
+      dplyr::group_by(expectedFile) %>% {
         if (quickCheck) {
           mutate(., result = ifelse(filesize.x != filesize.y, "FAIL", "OK"))
         } else {
           mutate(., result = ifelse(checksum.x != checksum.y, "FAIL", "OK"))
         }
       } %>%
-      dplyr::arrange(desc(result)) %>%
-      {
+      dplyr::arrange(desc(result)) %>% {
         #if (quickCheck) {
         select(
           .,

--- a/R/gis.R
+++ b/R/gis.R
@@ -131,4 +131,3 @@ fastMask <- function(x, y) {
     raster::mask(x, y)
   }
 }
-

--- a/R/packages.R
+++ b/R/packages.R
@@ -118,9 +118,9 @@ Require <- function(packages, packageVersionFile, libPath = .libPaths()[1], # no
 
   # Convert a single name to a character
   subpackages <- substitute(packages)
-  if (is.name(subpackages)) { # single, non quoted object
-    subpackages <- deparse(subpackages)
-    if (!exists(subpackages, envir = parent.frame())) # if it does exist, then it is not a name, but an object
+  if (is.name(subpackages)) {
+    subpackages <- deparse(subpackages) # single, non quoted object
+    if (!exists(subpackages, envir = parent.frame())) # if it exists, its not a name, but an object
       packages <- subpackages
   }
 
@@ -499,8 +499,8 @@ package_dependenciesMem <- memoise(tools::package_dependencies, ~timeout(360)) #
 #' This have a 6 minute memory time window.
 #' @inheritParams utils::available.packages
 #' @keywords internal
-available.packagesMem <- function(contriburl, method, fields, type, filters, repos) {# This will be replaced upon first calls to
-  stop("This function is for internal use only")
+available.packagesMem <- function(contriburl, method, fields, type, filters, repos) {
+  stop("This function is for internal use only")# This will be replaced upon first calls to
   return(invisible(NULL))
 }
 

--- a/R/postProcess.R
+++ b/R/postProcess.R
@@ -411,15 +411,36 @@ projectInputs <- function(x, targetCRS, ...) {
 
 #' @export
 #' @rdname projectInputs
+#' @importFrom raster crs
+#' @importFrom raster res
+#' @importFrom raster dataType
+#' @importFrom gdalUtils gdalwarp
 projectInputs.Raster <- function(x, targetCRS = NULL, rasterToMatch = NULL, ...) {
 
+  dots <- list(...)
   if (!is.null(rasterToMatch)) {
     if (!is.null(targetCRS)) {
       if (!identical(crs(x), targetCRS) |
           !identical(res(x), res(rasterToMatch)) |
           !identical(extent(x), extent(rasterToMatch))) {
         message("    reprojecting ...")
-        x <- projectRaster(from = x, to = rasterToMatch, ...)
+        if(canProcessInMemory(x, 4)){
+          x <- projectRaster(from = x, to = rasterToMatch, ...)
+        } else {
+          message("   large raster: reprojecting after writing to temp drive...")
+          tempRaster <- file.path(tempfile(), ".tif", fsep = "")
+          writeRaster(x, filename = tempRaster, datatype = dataType(x), overwrite = TRUE)
+          gdalUtils::gdalwarp(srcfile = tempRaster,
+                              dstfile = file.path(dots$destinationPath,
+                                paste(x@data@names,"_reproj", ".tif", sep = "")),
+                              s_srs = as.character(crs(x)),
+                              t_srs = as.character(crs(rasterToMatch)),
+                              tr = res(rasterToMatch)
+                              )
+          x <- raster(file.path(dots$destinationPath,
+                                paste(x@data@names,"_reproj", ".tif", sep = "")))
+          file.remove(tempRaster)
+        }
       } else {
         message("    no reprojecting because target characteristics same as input Raster.")
       }


### PR DESCRIPTION
1. projectInputs.raster will use gdalUtils if the raster is very large, writing to tempDrive before projecting. 
2. Misc clean up of comments triggering lintr