### PR TITLE
tolerate different resolutions between RTM and output raster when `useSAcrs = TRUE`

### DIFF
--- a/R/postProcess.R
+++ b/R/postProcess.R
@@ -437,7 +437,10 @@ projectInputs.Raster <- function(x, targetCRS = NULL, rasterToMatch = NULL, ...)
         warnings(warn)
         ## projectRaster doesn't always ensure equal res (floating point number issue)
         ## if resolutions are close enough, re-write res(x)
-        if (any(res(x) != res(rasterToMatch))) {
+        ## note that when useSAcrs = TRUE, the different resolutions may be due to
+        ## the different projections (e.g. degree based and meter based). This should be fine
+        if (crs(res) == crs(rasterToMatch) &
+            any(res(x) != res(rasterToMatch))) {
           if (all(res(x) %==% res(rasterToMatch))) {
             res(x) <- res(rasterToMatch)
           } else {

--- a/R/postProcess.R
+++ b/R/postProcess.R
@@ -213,8 +213,6 @@ postProcess.spatialObjects <- function(x, filename1 = NULL, filename2 = TRUE,
 
       # filename
       newFilename <- determineFilename(filename1 = filename1, filename2 = filename2, ...)
-      if (!is.null(dots$filename1)) stop("Can't pass filename1; use filename2")
-      if (!is.null(dots$filename2)) dots$filename2 <- NULL
 
       # writeOutputs
       x <- do.call(writeOutputs, append(list(x = x, filename2 = newFilename,
@@ -270,14 +268,13 @@ cropInputs.default <- function(x, studyArea, rasterToMatch, ...) {
 #'                      passed.
 #' @param extentCRS     Optional. Can pass a \code{crs} here with an extent to
 #'                      \code{extentTomatch} instead of \code{rasterToMatch}
-cropInputs.spatialObjects <- function(x, studyArea, rasterToMatch = NULL, extentToMatch = NULL,
+cropInputs.spatialObjects <- function(x, studyArea = NULL, rasterToMatch = NULL, extentToMatch = NULL,
                                       extentCRS = NULL, ...) {
-
 
   if (!is.null(studyArea) ||
       !is.null(rasterToMatch) || !is.null(extentToMatch)) {
-    rasterToMatch <- if (!is.null(extentToMatch)) {
-      raster(extentToMatch, crs = extentCRS)
+    if (!is.null(extentToMatch)) {
+      rasterToMatch <- raster(extentToMatch, crs = extentCRS)
     }
     cropTo <-
       if (!is.null(rasterToMatch)) {
@@ -409,6 +406,13 @@ projectInputs <- function(x, targetCRS, ...) {
   UseMethod("projectInputs")
 }
 
+
+#' @export
+#' @rdname projectInputs
+projectInputs.default <- function(x, targetCRS, ...) {
+  x
+}
+
 #' @export
 #' @rdname projectInputs
 #' @importFrom fpCompare %==%
@@ -418,45 +422,47 @@ projectInputs.Raster <- function(x, targetCRS = NULL, rasterToMatch = NULL, ...)
 
   dots <- list(...)
   if (!is.null(rasterToMatch)) {
-    if (!is.null(targetCRS)) {
-      if (!identical(crs(x), targetCRS) |
-          !identical(res(x), res(rasterToMatch)) |
-          !identical(extent(x), extent(rasterToMatch))) {
-        message("    reprojecting ...")
-        if (canProcessInMemory(x, 4)) {
-          tempRas <- projectExtent(object = rasterToMatch, crs = targetCRS) ## make a template RTM, with targetCRS
-          x <- projectRaster(from = x, to = tempRas, ...)
-          ## projectRaster doesn't always ensure equal res (floating point number issue)
-          ## if resolutions are close enough, re-write res(x)
-          if (any(res(x) != res(rasterToMatch))) {
-            if (all(res(x) %==% res(rasterToMatch))) {
-              res(x) <- res(rasterToMatch)
-            } else {
-              stop(paste0("Error: input and output resolutions are not similar after using projectRaster.\n",
-                   "You can try increasing error tolerance in options('fpCompare.tolerance')."))
-            }
+    if (is.null(targetCRS)) {
+      targetCRS <- crs(rasterToMatch)
+    }
+
+    if (!identical(crs(x), targetCRS) |
+        !identical(res(x), res(rasterToMatch)) |
+        !identical(extent(x), extent(rasterToMatch))) {
+      message("    reprojecting ...")
+      if (canProcessInMemory(x, 4)) {
+        tempRas <- projectExtent(object = rasterToMatch, crs = targetCRS) ## make a template RTM, with targetCRS
+        warn <- capture_warnings(x <- projectRaster(from = x, to = tempRas, ...))
+        warn <- warn[!grepl("no non-missing arguments to m.*; returning .*Inf", warn)] # This is a bug in raster
+        warnings(warn)
+        ## projectRaster doesn't always ensure equal res (floating point number issue)
+        ## if resolutions are close enough, re-write res(x)
+        if (any(res(x) != res(rasterToMatch))) {
+          if (all(res(x) %==% res(rasterToMatch))) {
+            res(x) <- res(rasterToMatch)
+          } else {
+            stop(paste0("Error: input and output resolutions are not similar after using projectRaster.\n",
+                 "You can try increasing error tolerance in options('fpCompare.tolerance')."))
           }
-        } else {
-          message("   large raster: reprojecting after writing to temp drive...")
-          tempSrcRaster <- file.path(tempfile(), ".tif", fsep = "")
-          tempDstRaster <- file.path(dirname(tempfile()),
-                                     paste0(x@data@names,"_reproj", ".tif"))
-          writeRaster(x, filename = tempSrcRaster, datatype = assessDataType(x), overwrite = TRUE)
-          gdalUtils::gdalwarp(srcfile = tempSrcRaster,
-                              dstfile = tempDstRaster,
-                              s_srs = as.character(crs(x)),
-                              t_srs = as.character(targetCRS),
-                              tr = res(rasterToMatch),
-                              tap = TRUE, overwrite = TRUE)
-          x <- raster(tempDstRaster)
-          x[] <- x[]    ## bring it to memory to update metadata
-          file.remove(c(tempSrcRaster, tempDstRaster))
         }
       } else {
-        message("    no reprojecting because target characteristics same as input Raster.")
+        message("   large raster: reprojecting after writing to temp drive...")
+        tempSrcRaster <- file.path(tempfile(), ".tif", fsep = "")
+        tempDstRaster <- file.path(dirname(tempfile()),
+                                   paste0(x@data@names,"_reproj", ".tif"))
+        writeRaster(x, filename = tempSrcRaster, datatype = assessDataType(x), overwrite = TRUE)
+        gdalUtils::gdalwarp(srcfile = tempSrcRaster,
+                            dstfile = tempDstRaster,
+                            s_srs = as.character(crs(x)),
+                            t_srs = as.character(targetCRS),
+                            tr = res(rasterToMatch),
+                            tap = TRUE, overwrite = TRUE)
+        x <- raster(tempDstRaster)
+        x[] <- x[]    ## bring it to memory to update metadata
+        file.remove(c(tempSrcRaster, tempDstRaster))
       }
     } else {
-      message("    no reprojecting because rasterToMatch is missing & useSAcrs is FALSE.")
+      message("    no reprojecting because target characteristics same as input Raster.")
     }
   } else {
     if (!is.null(targetCRS)) {

--- a/R/postProcess.R
+++ b/R/postProcess.R
@@ -439,7 +439,7 @@ projectInputs.Raster <- function(x, targetCRS = NULL, rasterToMatch = NULL, ...)
         ## if resolutions are close enough, re-write res(x)
         ## note that when useSAcrs = TRUE, the different resolutions may be due to
         ## the different projections (e.g. degree based and meter based). This should be fine
-        if (crs(x) == crs(rasterToMatch) &
+        if (identical(crs(x), crs(rasterToMatch)) &
             any(res(x) != res(rasterToMatch))) {
           if (all(res(x) %==% res(rasterToMatch))) {
             res(x) <- res(rasterToMatch)

--- a/R/postProcess.R
+++ b/R/postProcess.R
@@ -439,7 +439,7 @@ projectInputs.Raster <- function(x, targetCRS = NULL, rasterToMatch = NULL, ...)
         ## if resolutions are close enough, re-write res(x)
         ## note that when useSAcrs = TRUE, the different resolutions may be due to
         ## the different projections (e.g. degree based and meter based). This should be fine
-        if (crs(res) == crs(rasterToMatch) &
+        if (crs(x) == crs(rasterToMatch) &
             any(res(x) != res(rasterToMatch))) {
           if (all(res(x) %==% res(rasterToMatch))) {
             res(x) <- res(rasterToMatch)


### PR DESCRIPTION
Bugfix when checking resolutions in `.projectInputs`:
- when using `rasterToMatch` and `useSAcrs`, it can occur that the final resolutions differ due to the different CRS (e.g. when `studyArea` crs is in degree units and `rasterToMatch `is in meters)
- in this case different resolutions should be tolerated