### PR TITLE
157 allow use of Google Drive Team Drives

### DIFF
--- a/R/cache-helpers.R
+++ b/R/cache-helpers.R
@@ -895,7 +895,7 @@ copyFile <- Vectorize(copySingleFile, vectorize.args = c("from", "to"))
                               extent(object)), dataSlotsToDigest), length = length, quick = quick,
                   algo = algo) # don't include object@data -- these are volatile
   else {
-    if (!requireNamespace("fastdigest"))
+    if (!requireNamespace("fastdigest", quietly = TRUE))
       stop(requireNamespaceMsg("fastdigest", "to use options('reproducible.useNewDigestAlgorithm' = FALSE"))
     dig <- fastdigest::fastdigest(append(list(dim(object), res(object), crs(object),
                                   extent(object)), dataSlotsToDigest)) # don't include object@data -- these are volatile
@@ -908,7 +908,7 @@ copyFile <- Vectorize(copySingleFile, vectorize.args = c("from", "to"))
     dig2 <- .robustDigest(legendSlotsToDigest, length = length, quick = quick,
                   algo = algo) # don't include object@data -- these are volatile
   else {
-    if (!requireNamespace("fastdigest"))
+    if (!requireNamespace("fastdigest", quietly = TRUE))
       stop(requireNamespaceMsg("fastdigest", "to use options('reproducible.useNewDigestAlgorithm' = FALSE"))
     dig2 <- fastdigest::fastdigest(legendSlotsToDigest) # don't include object@data -- these are volatile
   }
@@ -921,7 +921,7 @@ copyFile <- Vectorize(copySingleFile, vectorize.args = c("from", "to"))
     digFile <- .robustDigest(fileSlotsToDigest, length = length, quick = quick,
                              algo = algo) # don't include object@file -- these are volatile
   else {
-    if (!requireNamespace("fastdigest"))
+    if (!requireNamespace("fastdigest", quietly = TRUE))
       stop(requireNamespaceMsg("fastdigest", "to use options('reproducible.useNewDigestAlgorithm' = FALSE"))
     digFile <- fastdigest::fastdigest(fileSlotsToDigest) # don't include object@file -- these are volatile
   }
@@ -942,7 +942,7 @@ copyFile <- Vectorize(copySingleFile, vectorize.args = c("from", "to"))
   if (isTRUE(getOption("reproducible.useNewDigestAlgorithm")))
     dig <- .robustDigest(unlist(dig), length = length, quick = quick, algo = algo)
   else {
-    if (!requireNamespace("fastdigest"))
+    if (!requireNamespace("fastdigest", quietly = TRUE))
       stop(requireNamespaceMsg("fastdigest", "to use options('reproducible.useNewDigestAlgorithm' = FALSE"))
     dig <- fastdigest::fastdigest(dig)
   }

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -7,14 +7,15 @@ if (getRversion() >= "3.1.0") {
 #' Will check for presence of a \code{cloudFolderID} and make a new one
 #' if one not present on Google Drive, with a warning.
 #'
+#' @inheritParams Cache
 #' @param cloudFolderID The google folder ID where cloud caching will occur.
 #' @param create Logical. If \code{TRUE}, then the \code{cloudFolderID} will be created.
 #'     This should be used with caution as there are no checks for overwriting.
 #'     See \code{googledrive::drive_mkdir}. Default \code{FALSE}.
 #' @param overwrite Logical. Passed to \code{googledrive::drive_mkdir}.
-#' @inheritParams Cache
+#' @param team_drive Logical indicating whether to check team drives.
+#'
 #' @export
-#' @inheritParams Cache
 checkAndMakeCloudFolderID <- function(cloudFolderID = getOption('reproducible.cloudFolderID', NULL),
                                       cacheRepo = NULL,
                                       create = FALSE,

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -22,7 +22,7 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption('reproducible.cl
                                       overwrite = FALSE,
                                       verbose = getOption("reproducible.verbose", 1),
                                       team_drive = NULL) {
-  if (!requireNamespace("googledrive"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
     stop(requireNamespaceMsg("googledrive", "to use google drive files"))
 
   browser(expr = exists("._checkAndMakeCloudFolderID_1"))
@@ -51,7 +51,7 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption('reproducible.cl
           }
           cloudFolderID <- cloudFolderFromCacheRepo(cacheRepo)
         }
-        newDir <- googledrive::drive_mkdir(cloudFolderID, path = "~/", overwrite = overwrite)
+        newDir <- googledrive::drive_mkdir(cloudFolderID, path = NULL, overwrite = overwrite)
         cloudFolderID <- newDir
       }
     } else {
@@ -70,7 +70,8 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption('reproducible.cl
 driveLs <- function(cloudFolderID = NULL, pattern = NULL,
                     verbose = getOption("reproducible.verbose", 1),
                     team_drive = NULL) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
   browser(expr = exists("kkkk"))
 
   if (!is(cloudFolderID, "tbl"))
@@ -108,7 +109,9 @@ driveLs <- function(cloudFolderID = NULL, pattern = NULL,
 #' @param output The output object of FUN that was run in \code{Cache}
 #' @inheritParams Cache
 cloudUpload <- function(isInRepo, outputHash, gdriveLs, cacheRepo, cloudFolderID, output) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+      stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   artifact <- isInRepo[[.cacheTableHashColName()]][1]
   browser(expr = exists("._cloudUpload_1"))
   artifactFileName <- CacheStoredFile(cacheRepo, hash = artifact)
@@ -154,7 +157,9 @@ cloudUpload <- function(isInRepo, outputHash, gdriveLs, cacheRepo, cloudFolderID
 cloudDownload <- function(outputHash, newFileName, gdriveLs, cacheRepo, cloudFolderID,
                           drv = getOption("reproducible.drv", RSQLite::SQLite()),
                           conn = getOption("reproducible.conn", NULL)) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   browser(expr = exists("._cloudDownload_1"))
   messageCache("Downloading cloud copy of ", newFileName,", with cacheId: ", outputHash)
   localNewFilename <- file.path(tempdir2(), basename2(newFileName))
@@ -190,7 +195,9 @@ cloudDownload <- function(outputHash, newFileName, gdriveLs, cacheRepo, cloudFol
 #' @keywords internal
 cloudUploadFromCache <- function(isInCloud, outputHash, cacheRepo, cloudFolderID,
                                  outputToSave, rasters) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   browser(expr = exists("._cloudUploadFromCache_1"))
   if (!any(isInCloud)) {
     cacheIdFileName <- CacheStoredFile(cacheRepo, outputHash)
@@ -211,15 +218,17 @@ cloudUploadFromCache <- function(isInCloud, outputHash, cacheRepo, cloudFolderID
 }
 
 cloudUploadRasterBackends <- function(obj, cloudFolderID) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   browser(expr = exists("._cloudUploadRasterBackends_1"))
   rasterFilename <- Filenames(obj)
   out <- NULL
   if (!is.null(unlist(rasterFilename)) && length(rasterFilename) > 0) {
     allRelevantFiles <- unique(rasterFilename)
     out <- lapply(allRelevantFiles, function(file) {
-      try(retry(quote(googledrive::drive_upload(media = file,  path = cloudFolderID, name = basename(file),
-                               overwrite = FALSE))))
+      try(retry(quote(googledrive::drive_upload(media = file,  path = cloudFolderID,
+                                                name = basename(file), overwrite = FALSE))))
     })
   }
   return(invisible(out))
@@ -228,7 +237,9 @@ cloudUploadRasterBackends <- function(obj, cloudFolderID) {
 cloudDownloadRasterBackend <- function(output, cacheRepo, cloudFolderID,
                                        drv = getOption("reproducible.drv", RSQLite::SQLite()),
                                        conn = getOption("reproducible.conn", NULL)) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   browser(expr = exists("._cloudDownloadRasterBackend_1"))
   rasterFilename <- Filenames(output)
   if (!is.null(unlist(rasterFilename)) && length(rasterFilename) > 0) {

--- a/R/download.R
+++ b/R/download.R
@@ -529,7 +529,8 @@ missingFiles <- function(files, checkSums, targetFile) {
 
 assessGoogle <- function(url, archive = NULL, targetFile = NULL,
                          destinationPath = getOption("reproducible.destinationPath"),
-                         verbose = getOption("reproducible.verbose", 1)) {
+                         verbose = getOption("reproducible.verbose", 1),
+                         team_drive = NULL) {
   if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
   if (.isRstudioServer()) {
     .requireNamespace("httr", stopOnFALSE = TRUE)
@@ -538,7 +539,7 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
   }
 
   if (is.null(archive)) {
-    fileAttr <- retry(quote(googledrive::drive_get(googledrive::as_id(url))))
+    fileAttr <- retry(quote(googledrive::drive_get(googledrive::as_id(url), team_drive = team_drive)))
     fileSize <- fileAttr$drive_resource[[1]]$size
     if (!is.null(fileSize)) {
       fileSize <- as.numeric(fileSize)

--- a/R/download.R
+++ b/R/download.R
@@ -300,7 +300,7 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
     messagePrepInputs("  Downloading from Google Drive.", verbose = verbose)
     fs <- attr(archive, "fileSize")
     if (is.null(fs))
-      fs <- attr(assessGoogle(url, verbose = verbose),"fileSize")
+      fs <- attr(assessGoogle(url, verbose = verbose), "fileSize")
     class(fs) <- "object_size"
     isLargeFile <- if (is.null(fs)) FALSE else fs > 1e6
     if (!isWindows() && requireNamespace("future", quietly = TRUE) && isLargeFile &&

--- a/R/download.R
+++ b/R/download.R
@@ -284,7 +284,8 @@ downloadFile <- function(archive, targetFile, neededFiles,
 #'
 dlGoogle <- function(url, archive = NULL, targetFile = NULL,
                      checkSums, skipDownloadMsg, destinationPath,
-                     overwrite, needChecksums, verbose = getOption("reproducible.verbose", 1)) {
+                     overwrite, needChecksums, verbose = getOption("reproducible.verbose", 1),
+                     team_drive = NULL) {
   .requireNamespace("googledrive", stopOnFALSE = TRUE)
 
   if (missing(destinationPath)) {
@@ -293,16 +294,19 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   downloadFilename <- assessGoogle(url = url, archive = archive,
                                    targetFile = targetFile,
                                    destinationPath = destinationPath,
-                                   verbose = verbose)
+                                   verbose = verbose,
+                                   team_drive = NULL)
 
   destFile <- file.path(destinationPath, basename(downloadFilename))
   if (!isTRUE(checkSums[checkSums$expectedFile ==  basename(destFile), ]$result == "OK")) {
     messagePrepInputs("  Downloading from Google Drive.", verbose = verbose)
     fs <- attr(archive, "fileSize")
     if (is.null(fs))
-      fs <- attr(assessGoogle(url, verbose = verbose), "fileSize")
-    class(fs) <- "object_size"
-    isLargeFile <- if (is.null(fs)) FALSE else fs > 1e6
+      fs <- attr(assessGoogle(url, verbose = verbose, team_drive = team_drive), "fileSize")
+    if (!is.null(fs))
+      class(fs) <- "object_size"
+
+    isLargeFile <- ifelse(is.null(fs), FALSE, fs > 1e6)
     if (!isWindows() && requireNamespace("future", quietly = TRUE) && isLargeFile &&
         !.isFALSE(getOption("reproducible.futurePlan"))) {
       messagePrepInputs("Downloading a large file", verbose = verbose)
@@ -316,8 +320,8 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
       }
       a <- future::future({
         googledrive::drive_deauth()
-        retry(quote(googledrive::drive_download(googledrive::as_id(url), path = destFile, overwrite = overwrite,
-                                   verbose = TRUE)))
+        retry(quote(googledrive::drive_download(googledrive::as_id(url), path = destFile,
+                                                overwrite = overwrite, verbose = TRUE)))
         },
         globals = list(drive_download = googledrive::drive_download,
                        as_id = googledrive::as_id,
@@ -340,7 +344,7 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
       cat("\nDone!\n")
     } else {
       a <- retry(quote(googledrive::drive_download(googledrive::as_id(url), path = destFile,
-                                                   overwrite = overwrite, verbose = TRUE)))
+                                                   overwrite = overwrite, verbose = TRUE))) ## TODO: unrecognized type "shp"
     }
   } else {
     messagePrepInputs(skipDownloadMsg, verbose = verbose)
@@ -397,6 +401,8 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
             add = TRUE)
   }
 
+  dots <- list(...)
+
   if (!is.null(url) || !is.null(dlFun)) { # if no url, no download
     #if (!is.null(fileToDownload)  ) { # don't need to download because no url --- but need a case
       if (!isTRUE(tryCatch(is.na(fileToDownload), warning = function(x) FALSE)))  {
@@ -406,10 +412,10 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
           dlFun <- .extractFunction(dlFun)
           fun <- .fnCleanup(dlFun, callingFun = "downloadRemote")
           forms <- .argsToRemove
-          dots <- list(...)
+          #dots <- list(...)
           overlappingForms <- fun$formalArgs[fun$formalArgs %in% forms]
           overlappingForms <- grep("\\.\\.\\.", overlappingForms, invert = TRUE, value = TRUE)
-          dots <- list(...)
+
           # remove arguments that are in .argsToRemove, i.e., the sequence
           args <- if (length(overlappingForms)) {
             append(list(...), mget(overlappingForms))
@@ -445,7 +451,9 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
           downloadResults <- list(out = out, destFile = normPath(destFile), needChecksums = 2)
         } else if (grepl("drive.google.com", url)) {
           browser(expr = exists("._downloadRemote_2"))
-          if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+          if (!requireNamespace("googledrive", quietly = TRUE))
+            stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
           downloadResults <- dlGoogle(
             url = url,
             archive = archive,
@@ -455,7 +463,8 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
             destinationPath = .tempPath,
             overwrite = overwrite,
             needChecksums = needChecksums,
-            verbose = verbose
+            verbose = verbose,
+            team_drive = dots[["team_drive"]]
           )
 
         } else if (grepl("dl.dropbox.com", url)) {
@@ -531,7 +540,8 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
                          destinationPath = getOption("reproducible.destinationPath"),
                          verbose = getOption("reproducible.verbose", 1),
                          team_drive = NULL) {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
   if (.isRstudioServer()) {
     .requireNamespace("httr", stopOnFALSE = TRUE)
     opts <- options(httr_oob_default = TRUE)
@@ -540,7 +550,7 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
 
   if (is.null(archive)) {
     fileAttr <- retry(quote(googledrive::drive_get(googledrive::as_id(url), team_drive = team_drive)))
-    fileSize <- fileAttr$drive_resource[[1]]$size
+    fileSize <- fileAttr$drive_resource[[1]]$size ## TODO: not returned with team drive (i.e., NULL)
     if (!is.null(fileSize)) {
       fileSize <- as.numeric(fileSize)
       class(fileSize) <- "object_size"
@@ -574,7 +584,6 @@ requireNamespaceMsg <- function(pkg, extraMsg = character(), minVersion = NULL) 
     mess <- paste(mess, extraMsg)
   mess
 }
-
 
 .isRstudioServer <- function() {
   isRstudioServer <- FALSE

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -157,9 +157,9 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   checkSumFilePath <- file.path(destinationPath, "CHECKSUMS.txt")
 
   if (is.null(targetFile)) {
-    fileGuess <- .guessAtFile(url = url, archive = archive,
-                              targetFile = targetFile,
-                              destinationPath = destinationPath, verbose = verbose)
+    fileGuess <- .guessAtFile(url = url, archive = archive, targetFile = targetFile,
+                              destinationPath = destinationPath, verbose = verbose,
+                              team_drive = dots[["team_drive"]])
     if (is.null(archive))
       archive <- .isArchive(fileGuess)
     archive <- moveAttributes(fileGuess, archive)
@@ -259,7 +259,7 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
         #   an archive, either remotely, in the case of google or from the basename of url
         fileGuess <- .guessAtFile(url = url, archive = archive,
                                   targetFile = targetFile, destinationPath = destinationPath,
-                                  verbose = verbose)
+                                  verbose = verbose, team_drive = dots[["team_drive"]])
         archive <- .isArchive(fileGuess)
         # The fileGuess MAY have a fileSize attribute, which can be attached to "archive"
         archive <- moveAttributes(fileGuess, receiving = archive)
@@ -274,7 +274,6 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
                                       checkSums = checkSums,
                                       verbose = verbose)
       }
-
     }
   }
 
@@ -297,7 +296,7 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   # Deal with "similar" in alsoExtract -- maybe this is obsolete with new feature that uses file_name_sans_ext
   if (is.null(alsoExtract)) {
     filesInsideArchive <- .listFilesInArchive(archive)
-    if (isTRUE(length(filesInsideArchive)>0)) {
+    if (isTRUE(length(filesInsideArchive) > 0)) {
       checkSums <- .checkSumsUpdate(destinationPath, file.path(destinationPath, filesInsideArchive),
                                     checkSums = checkSums)
     }
@@ -396,8 +395,8 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   )
 
   downloadFileResult <- .fixNoFileExtension(downloadFileResult = downloadFileResult,
-                      targetFile = targetFile, archive = archive,
-                      destinationPath = destinationPath, verbose = verbose)
+                                            targetFile = targetFile, archive = archive,
+                                            destinationPath = destinationPath, verbose = verbose)
 
   # Post downloadFile -- put objects into this environment
   if (!is.null(downloadFileResult$targetFilePath))
@@ -676,14 +675,14 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
 }
 
 #' @keywords internal
-.guessAtFile <- function(url, archive, targetFile, destinationPath, verbose = getOption("reproducible.verbose", 1)) {
+.guessAtFile <- function(url, archive, targetFile, destinationPath,
+                         verbose = getOption("reproducible.verbose", 1), team_drive = NULL) {
   guessedFile <- if (!is.null(url)) {
     if (grepl("drive.google.com", url)) {
       ie <- isTRUE(internetExists())
       if (ie) {
-        assessGoogle(url = url, archive = archive,
-                     targetFile = targetFile,
-                     destinationPath = destinationPath, verbose = verbose)
+        assessGoogle(url = url, archive = archive, targetFile = targetFile,
+                     destinationPath = destinationPath, verbose = verbose, team_drive = NULL)
       } else {
         # likely offline
         file.path(destinationPath, .basename(url))

--- a/R/robustDigest.R
+++ b/R/robustDigest.R
@@ -365,7 +365,7 @@ setMethod(
     out <- if (cacheSpeed == 1) {
       digest(x, algo = algo)
     } else if (cacheSpeed == 2) {
-      if (!requireNamespace("fastdigest"))
+      if (!requireNamespace("fastdigest", quietly = TRUE))
         stop(requireNamespaceMsg("fastdigest", "to use options('reproducible.useNewDigestAlgorithm' = FALSE"))
       fastdigest::fastdigest(x)
     } else {

--- a/man/checkAndMakeCloudFolderID.Rd
+++ b/man/checkAndMakeCloudFolderID.Rd
@@ -9,7 +9,8 @@ checkAndMakeCloudFolderID(
   cacheRepo = NULL,
   create = FALSE,
   overwrite = FALSE,
-  verbose = getOption("reproducible.verbose", 1)
+  verbose = getOption("reproducible.verbose", 1),
+  team_drive = NULL
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ See \code{googledrive::drive_mkdir}. Default \code{FALSE}.}
 Default is 1. Above 3 will output much more information about the internals of
 Caching, which may help diagnose Caching challenges. Can set globally with an
 option, e.g., \code{options('reproducible.verbose' = 0) to reduce to minimal}}
+
+\item{team_drive}{Logical indicating whether to check team drives.}
 }
 \description{
 Will check for presence of a \code{cloudFolderID} and make a new one

--- a/man/dlGoogle.Rd
+++ b/man/dlGoogle.Rd
@@ -13,7 +13,8 @@ dlGoogle(
   destinationPath,
   overwrite,
   needChecksums,
-  verbose = getOption("reproducible.verbose", 1)
+  verbose = getOption("reproducible.verbose", 1),
+  team_drive = NULL
 )
 }
 \arguments{

--- a/tests/testthat/test-cloud.R
+++ b/tests/testthat/test-cloud.R
@@ -1,5 +1,7 @@
 test_that("test Cache(useCloud=TRUE, ...)", {
-  if (!requireNamespace("googledrive")) stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
   skip_if_no_token()
   if (interactive()) {
 
@@ -224,7 +226,5 @@ test_that("test Cache(useCloud=TRUE, ...) with raster-backed objs -- brick", {
 
     testRasterInCloud(".tif", cloudFolderID = cloudFolderID, numRasterFiles = 1, tmpdir = tmpdir,
                       type = "Brick")
-
   }
 })
-

--- a/tests/testthat/test-cloud.R
+++ b/tests/testthat/test-cloud.R
@@ -228,3 +228,25 @@ test_that("test Cache(useCloud=TRUE, ...) with raster-backed objs -- brick", {
                       type = "Brick")
   }
 })
+
+test_that("prepInputs works with team drives", {
+  if (!requireNamespace("googledrive", quietly = TRUE))
+    stop(requireNamespaceMsg("googledrive", "to use google drive files"))
+
+  skip_if_no_token()
+  if (interactive()) {
+    testInitOut <- testInit(
+      "googledrive",
+      opts = list("reproducible.cachePath" = file.path(tempdir(), rndstr(1, 7)),
+                  "reproducible.ask" = FALSE)
+    )
+    # googledrive::drive_auth("predictiveecology@gmail.com")
+    on.exit({
+      testOnExit(testInitOut)
+    }, add = TRUE)
+
+    zipUrl <- "https://drive.google.com/file/d/1zRX2c55ebJbQtjijCErEfGxhsa7Ieph2"
+    wb <- prepInputs(targetFile = "WB_BCR.shp", destinationPath = tmpdir, url = zipUrl,
+                     alsoExtract = "similar", fun = "shapefile", team_drive = TRUE)
+  }
+})

--- a/tests/testthat/test-cloud.R
+++ b/tests/testthat/test-cloud.R
@@ -15,7 +15,7 @@ test_that("test Cache(useCloud=TRUE, ...)", {
     }, add = TRUE)
     clearCache(x = tmpCache)
     testsForPkgs <- "testsForPkgs"
-    df <- googledrive::drive_find(pattern = testsForPkgs)
+    df <- googledrive::drive_find(pattern = testsForPkgs, team_drive = NULL)
     if (NROW(df) == 0)
       testsForPkgsDir <- retry(quote(googledrive::drive_mkdir(name = testsForPkgs)))
     newDir <- retry(quote(googledrive::drive_mkdir(name = rndstr(1, 6), path = testsForPkgs)))


### PR DESCRIPTION
`prepInputs` and `preProcess` can now work with Google Drive Team Drives by passing `team_drive = TRUE` (#157)