### PR TITLE
try dealing with RsaterStack filenames in writeOutputs.Raster (#161)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2020-10-14
-Version: 1.2.1.9007
+Date: 2020-10-21
+Version: 1.2.1.9008
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@canada.ca",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ version 1.2.1.9000
 * moved `paddedFloatToChar` to reproducible from SpaDES.core.
 
 ## Bug fixes
+* fix issue getting and setting filenames for file-backed `RasterStack`s (#161)
 * several minor
 
 version 1.2.1


### PR DESCRIPTION
this fix works for the current issue i.e., LandWeb runs, but is untested more generally.