### PR TITLE
fixErrors.sf filters out points to avoid mixed geometries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2021-02-17
-Version: 1.2.6.9000
+Version: 1.2.6.9001
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@canada.ca",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,14 +3,14 @@ Known issues: https://github.com/PredictiveEcology/reproducible/issues
 version 1.2.6.9000
 ==============
 
-## Ne features
+## New features
 * none
 
 ## Enhancements
 * none
 
 ## Bug fixees
-* none
+* `fixErrors()` now better handles `sf` polygons with mixed geometries that include points.
 
 version 1.2.6
 ==============
@@ -21,7 +21,7 @@ version 1.2.6
 
 ## Bug fix
 * `RasterStack` objects with a single file (thus acting like a `RasterBrick`) are now handled correctly by `Cache` and `prepInputs` families, especially with new `options("reproducible.useNewDigestAlgorithm" = 2)`, though in tests, it worked with default also
-* Fix issue #185, RSQLite now uses a RNG during dbAppend; this affected 2 tests.
+* `RSQLite` now uses a RNG during `dbAppend`; this affected 2 tests (#185).
 
 version 1.2.4
 ==============

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -798,7 +798,6 @@ extractFromArchive <- function(archive,
   list(moduleName = moduleName, modulePath = modulePath, checkSums = checkSums)
 }
 
-
 .isArchive <- function(filename) {
   if (!is.null(filename)) {
     filename <- if (length(filename)) {


### PR DESCRIPTION
mixed geometry collections cannot be converted back to `sp` objects