### PR TITLE
postProcess bugfix: check resolution when assessing whether to project

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2022-11-03
-Version: 1.2.11
+Date: 2022-11-18
+Version: 1.2.12
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Authors@R:
       person(given = "Ceres",
              family = "Barros",
              role = "ctb",
-             email = "cbarros@mail.ubc.ca",
+             email = "ceres.barros@ubc.ca",
              comment = c(ORCID = "0000-0003-4036-977X")),
       person(given = "Ian",
              family = "Eddy",

--- a/R/postProcessTerra.R
+++ b/R/postProcessTerra.R
@@ -318,8 +318,8 @@ projectTo <- function(from, projectTo, method) {
         projectTo <- terra::rast(projectTo)
 
       projectToOrig <- projectTo # keep for below
-
-      if (sf::st_crs(projectTo) == sf::st_crs(from)) {
+      if (sf::st_crs(projectTo) == sf::st_crs(from) &&
+          all(res(projectTo) == res(from))) {
         messagePrepInputs("    projection of from is same as projectTo, not projecting")
       } else {
         messagePrepInputs("    projecting...")


### PR DESCRIPTION
`reproducible` was bypassing the projection when the input raster and RTM have the same CRS but differed in resolution. Presumably this is wrong and the resolution of the RTM should be the one used in the final output layer (even if they have the same CRS to start with)