### PR TITLE
workaround for writeTo overwrite error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,8 +19,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2023-02-27
-Version: 1.2.16.9028
+Date: 2023-03-01
+Version: 1.2.16.9029
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/postProcessTerra.R
+++ b/R/postProcessTerra.R
@@ -660,6 +660,8 @@ writeTo <- function(from, writeTo, overwrite, isStack = FALSE, isBrick = FALSE, 
           if (!file.exists(writeTo)) {
             from <- terra::writeRaster(from, filename = writeTo, overwrite = FALSE,
                                        datatype = datatype)
+          } else {
+            stop("File can't be unliked for overwrite")
           }
         } else {
           written <- terra::writeVector(from, filename = writeTo, overwrite = FALSE)

--- a/R/postProcessTerra.R
+++ b/R/postProcessTerra.R
@@ -648,14 +648,19 @@ writeTo <- function(from, writeTo, overwrite, isStack = FALSE, isBrick = FALSE, 
       if (isSpatRaster || isSpatVector(from)) {
         ## trying to prevent write failure and subsequent overwrite error with terra::writeRaster
         if (file.exists(writeTo)) {
-          if (overwrite %in% FALSE) {
+          if (isFALSE(overwrite)) {
             stop(writeTo, " already exists and `overwrite = FALSE`; please set `overwrite = TRUE` and run again.")
           }
           unlink(writeTo, force = TRUE, recursive = TRUE)
         }
         if (isSpatRaster) {
-          from <- terra::writeRaster(from, filename = writeTo, overwrite = FALSE,
-                                   datatype = datatype)
+          ## if the file still exists it's probably already "loaded"
+          ## and `terra` can't overwrite it even if `overwrite = TRUE`
+          ## this can happen when multiple modules touch the same object
+          if (!file.exists(writeTo)) {
+            from <- terra::writeRaster(from, filename = writeTo, overwrite = FALSE,
+                                       datatype = datatype)
+          }
         } else {
           written <- terra::writeVector(from, filename = writeTo, overwrite = FALSE)
         }


### PR DESCRIPTION
When the the object is being touched by R, `unlink` will not work and we can't try to overwrite. This is happening when e.g. multiple modules run `LandR::prepRasterToMatch`