### PR TITLE
filename2 fix

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -1045,7 +1045,7 @@ Cache <-
 #' @keywords internal
 .namesPostProcessFormals <- function() {
   c(
-    "x", "filename1", "filename2", "studyArea", "rasterToMatch",
+    "x", "filename1", "writeTo", "studyArea", "rasterToMatch",
     "overwrite", "useSAcrs", "useCache", "verbose"
   )
 }

--- a/R/postProcessTo.R
+++ b/R/postProcessTo.R
@@ -1273,6 +1273,11 @@ remapOldArgs <- function(..., fn = sys.function(sys.parent()), envir = parent.fr
                          verbose = getOption("reproducible.verbose")) {
   forms <- formals(fn)
   dots <- list(...)
+
+  if (!is.null(dots$filename2)) {
+    stop("filename2 arg is deprecated - please pass 'writeTo' instead (see `reproducible::writeTo`")
+  }
+
   dots <- dots[!vapply(dots, is.null, FUN.VALUE = logical(1))]
 
   ret <- list()

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1,5 +1,6 @@
 utils::globalVariables(c(
-  "reproducible.inputPaths", "successfulCheckSumFilePath", "successfulDir"
+  "reproducible.inputPaths", "successfulCheckSumFilePath", "successfulDir",
+  "destinationPathUser"
 ))
 
 #' @param n Number of non-null arguments passed to `preProcess`.

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -45,8 +45,7 @@ utils::globalVariables(c(
 #'     \item Crop using [cropTo()];
 #'     \item Project using [projectTo()];
 #'     \item Mask using [maskTo()];
-#'     \item Determine file name [determineFilename()] via `filename2`;
-#'     \item Optionally, write that file name to disk via [writeTo()].
+#'     \item write the file to disk via [writeTo()].
 #'    }
 #'
 #'   NOTE: checksumming does not occur during the post-processing stage, as
@@ -311,7 +310,7 @@ utils::globalVariables(c(
 #'         studyArea = studyArea,
 #'         fun = "terra::vect",
 #'         destinationPath = dPath,
-#'         filename2 = "EcozoneFile.shp"
+#'         writeTo = "EcozoneFile.shp"
 #'       ) # passed to determineFilename
 #'
 #'       terra::plot(shpEcozone[, 1])

--- a/man/prepInputs.Rd
+++ b/man/prepInputs.Rd
@@ -332,7 +332,7 @@ if (requireNamespace("terra", quietly = TRUE) &&
         studyArea = studyArea,
         fun = "terra::vect",
         destinationPath = dPath,
-        filename2 = "EcozoneFile.shp"
+        writeTo = "EcozoneFile.shp"
       ) # passed to determineFilename
 
       terra::plot(shpEcozone[, 1])

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1717,7 +1717,7 @@ test_that("Issue 316 - writeOutputs in a non getwd dir", {
   rasterToMatchLarge <- list()
   for (i in 1:2) {
     rasterToMatchLarge[[i]] <- Cache(writeOutputs, rasterToMatch,
-                                     filename2 = .suffix(
+                                     writeTo = .suffix(
                                        file.path(tmpdir, "rasterToMatchLarge.tif"),
                                        paste0("_", studyAreaName)
                                      ), datatype = "INT2U",

--- a/tests/testthat/test-postProcess.R
+++ b/tests/testthat/test-postProcess.R
@@ -79,17 +79,17 @@ test_that("prepInputs doesn't work (part 3)", {
   expect_equal(s1[], b1[], ignore_attr = TRUE)
 
   b <- writeRaster(b, filename = tmpfile[1], overwrite = TRUE)
-  b1 <- postProcess(b, studyArea = ncSmall, useCache = FALSE, filename2 = tmpfile[2], overwrite = TRUE)
+  b1 <- postProcess(b, studyArea = ncSmall, useCache = FALSE, writeTo = tmpfile[2], overwrite = TRUE)
   expect_true(inherits(b1, "SpatRaster"))
 
-  s1 <- postProcess(s, studyArea = ncSmall, useCache = FALSE, filename2 = tmpfile[2], overwrite = TRUE)
+  s1 <- postProcess(s, studyArea = ncSmall, useCache = FALSE, writeTo = tmpfile[2], overwrite = TRUE)
   expect_true(inherits(s1, "SpatRaster"))
 
   # Test datatype setting
   dt1 <- "INT2U"
   s <- writeRaster(s, filename = tmpfile[2], overwrite = TRUE)
   s1 <- postProcess(s,
-    studyArea = ncSmall, useCache = FALSE, filename2 = tmpfile[1], overwrite = TRUE,
+    studyArea = ncSmall, useCache = FALSE, writeTo = tmpfile[1], overwrite = TRUE,
     datatype = dt1
   )
   expect_identical(terra::datatype(s1), rep(dt1, terra::nlyr(s)))
@@ -99,7 +99,7 @@ test_that("prepInputs doesn't work (part 3)", {
   s <- writeRaster(s, filename = tmpfile[1], overwrite = TRUE)
   warns <- capture_error({
     s1 <- postProcess(s,
-      studyArea = ncSmall, useCache = FALSE, filename2 = tmpfile[2], overwrite = TRUE,
+      studyArea = ncSmall, useCache = FALSE, writeTo = tmpfile[2], overwrite = TRUE,
       datatype = dt1
     )
   })
@@ -108,7 +108,7 @@ test_that("prepInputs doesn't work (part 3)", {
   dt1 <- "INT4U"
   b <- writeRaster(b, filename = tmpfile[2], overwrite = TRUE)
   b1 <- postProcess(b,
-    studyArea = ncSmall, useCache = FALSE, filename2 = tmpfile[1], overwrite = TRUE,
+    studyArea = ncSmall, useCache = FALSE, writeTo = tmpfile[1], overwrite = TRUE,
     datatype = dt1
   )
   expect_identical(terra::datatype(b1), rep(dt1, terra::nlyr(b1)))
@@ -203,16 +203,20 @@ test_that("prepInputs doesn't work (part 3)", {
   expect_false(terra::is.valid(p6))
   # projectInputs pass through
   expect_error(projectInputs(x = 1), "argument .+ is missing")
+
+  #using deprecated filename2 arg
+  expect_error(cropInputs(ncSmall, studyArea = ncSmallShifted, filename2 = "use_WriteTo_Instead.shp"))
+
 })
 
-test_that("writeOutputs with non-matching filename2", {
+test_that("writeOutputs with non-matching writeTo", {
   testInit(c("terra"), tmpFileExt = c(".grd", ".tif"))
 
   r <- terra::rast(terra::ext(0, 10, 0, 10), vals = rnorm(100))
   r <- terra::writeRaster(r, filename = tmpfile[1], overwrite = TRUE)
   r[] <- r[]
   warn <- capture_warnings({
-    r1 <- writeOutputs(r, filename2 = tmpfile[2])
+    r1 <- writeOutputs(r, writeTo = tmpfile[2])
   })
   r2 <- terra::rast(Filenames(r1))
   vals1 <- r2[]
@@ -304,7 +308,7 @@ test_that("maskInputs errors when x is Lat-Long", {
         useCache = FALSE,
         fun = "sf::st_read",
         destinationPath = tmpdir,
-        filename2 = "miniRoad.shp"
+        writeTo = "miniRoad.shp"
       )
     )
   )

--- a/tests/testthat/test-prepInputs.R
+++ b/tests/testthat/test-prepInputs.R
@@ -118,7 +118,7 @@ test_that("prepInputs doesn't work (part 1)", {
             alsoExtract = reproducible::asPath(ecozoneFiles),
             studyArea = StudyArea,
             destinationPath = dPath,
-            filename2 = "EcozoneFile.shp",
+            writeTo = "EcozoneFile.shp",
             useCache = TRUE # with useTerra = TRUE, this is only for loading, not postProcess
           ),
           quick = "destinationPath"
@@ -168,6 +168,13 @@ test_that("prepInputs doesn't work (part 1)", {
     )
   )
   expect_true(is(shpEcozone, vectorType()))
+
+  #stops if deprecated arguments used
+  expect_error(prepInputs(destinationPath = dPath,
+                          url = "http://sis.agr.gc.ca/cansis/nsdb/ecostrat/zone/ecozone_shp.zip",
+                          archive = file.path(dPath, "ecozone_shp.zip"),
+                          filename2 = "use_writeTo_instead.shp"))
+
 })
 
 test_that("interactive prepInputs", {

--- a/tests/testthat/test-prepInputs.R
+++ b/tests/testthat/test-prepInputs.R
@@ -95,7 +95,7 @@ test_that("prepInputs doesn't work (part 1)", {
               alsoExtract = reproducible::asPath(ecozoneFiles),
               studyArea = StudyArea,
               destinationPath = dPath,
-              filename2 = "EcozoneFile.shp",
+              writeTo = "EcozoneFile.shp",
               useCache = FALSE
             ),
             quick = "destinationPath"
@@ -1866,7 +1866,7 @@ test_that("writeOutputs saves factor rasters with .grd class to preserve levels"
   tifTmp <- normPath(tifTmp)
 
   b1 <- suppressWarnings(terra::writeRaster(a, filename = tifTmp, overwrite = TRUE)) # the GDAL>6 issue
-  b1a <- writeOutputs(a, filename2 = tifTmp)
+  b1a <- writeOutputs(a, writeTo = tifTmp)
   expect_equivalent(b1, b1a)
   expect_equivalent(b1[], b1a[])
 
@@ -1903,7 +1903,7 @@ test_that("rasters aren't properly resampled", {
       targetFile = tiftemp1, rasterToMatch = terra::rast(tiftemp2),
       destinationPath = dirname(tiftemp1), method = "bilinear",
       datatype = "INT2S",
-      filename2 = tempfile(tmpdir = tmpdir, fileext = ".tif")
+      writeTo = tempfile(tmpdir = tmpdir, fileext = ".tif")
     )
   }) # about "raster layer has integer values"
 
@@ -1919,7 +1919,7 @@ test_that("rasters aren't properly resampled", {
     out3 <- prepInputs(
       targetFile = tiftemp3, rasterToMatch = terra::rast(tiftemp2),
       destinationPath = dirname(tiftemp3),
-      filename2 = tempfile(tmpdir = tmpdir, fileext = ".tif")
+      writeTo = tempfile(tmpdir = tmpdir, fileext = ".tif")
     )
     expect_true(dataType2(out3) == "FLT4S")
 
@@ -1934,7 +1934,7 @@ test_that("rasters aren't properly resampled", {
     out3 <- prepInputs(
       targetFile = tiftemp4, rasterToMatch = terra::rast(tiftemp2),
       destinationPath = dirname(tiftemp3),
-      filename2 = tempfile(tmpdir = tmpdir, fileext = ".tif")
+      writeTo = tempfile(tmpdir = tmpdir, fileext = ".tif")
     )
     expect_true(is(out3, rasterType()))
     expect_true(identical(length(Filenames(out3)), 1L))
@@ -1947,7 +1947,7 @@ test_that("rasters aren't properly resampled", {
           targetFile = tiftemp4, rasterToMatch = terra::rast(tiftemp2),
           destinationPath = dirname(tiftemp3),
           fun = rasterStackFn,
-          filename2 = c(
+          writeTo = c(
             tempfile(tmpdir = tmpdir, fileext = ".grd"),
             tempfile(tmpdir = tmpdir, fileext = ".grd")
           )
@@ -1971,7 +1971,7 @@ test_that("rasters aren't properly resampled", {
           targetFile = tiftemp5, rasterToMatch = terra::rast(tiftemp2),
           destinationPath = dirname(tiftemp3),
           fun = rasterStackFn,
-          filename2 = c(
+          writeTo = c(
             tempfile(tmpdir = tmpdir, fileext = ".grd"),
             tempfile(tmpdir = tmpdir, fileext = ".grd"),
             tempfile(tmpdir = tmpdir, fileext = ".tif")
@@ -1987,7 +1987,7 @@ test_that("rasters aren't properly resampled", {
           targetFile = tiftemp4, rasterToMatch = terra::rast(tiftemp2),
           destinationPath = dirname(tiftemp3),
           fun = rasterStackFn,
-          filename2 = c(
+          writeTo = c(
             tempfile(tmpdir = tmpdir, fileext = ".grd"),
             tempfile(tmpdir = tmpdir, fileext = ".grd")
           )

--- a/tests/testthat/test-prepInputs.R
+++ b/tests/testthat/test-prepInputs.R
@@ -173,6 +173,7 @@ test_that("prepInputs doesn't work (part 1)", {
   expect_error(prepInputs(destinationPath = dPath,
                           url = "http://sis.agr.gc.ca/cansis/nsdb/ecostrat/zone/ecozone_shp.zip",
                           archive = file.path(dPath, "ecozone_shp.zip"),
+                          studyArea = StudyArea,
                           filename2 = "use_writeTo_instead.shp"))
 
 })


### PR DESCRIPTION
adds stop in remapOldArgs if `filename2` used, avoiding error where spatRasters write to and from the same file in postProcess