### PR TITLE
corrected default algo referenced in Cache() argument description

### DIFF
--- a/man/Cache.Rd
+++ b/man/Cache.Rd
@@ -64,8 +64,8 @@ can be useful when the actual function is not helpful for a user, such as \code{
 return. This is only relevant for list, environment (or similar) objects}
 
 \item{algo}{The algorithms to be used; currently available choices are
-    \code{md5}, which is also the default, \code{sha1}, \code{crc32},
-    \code{sha256}, \code{sha512}, \code{xxhash32}, \code{xxhash64},
+    \code{md5}, \code{sha1}, \code{crc32}, \code{sha256},
+    \code{sha512}, \code{xxhash32}, \code{xxhash64}, which is also the default,
     \code{murmur32}, \code{spookyhash}, \code{blake3}, \code{crc32c},
     \code{xxh3_64}, and \code{xxh3_128}.}
 

--- a/reproducible.Rproj
+++ b/reproducible.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 0ae40516-0dd1-4cb7-b69e-a7df80c3262c
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
did not re-order the listed possible algorithms, simply changed the location of the wording.