### PR TITLE
ci: export PROJ_LIB / PROJ_DATA on macOS runners

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,19 @@ jobs:
 
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
+      - name: Export PROJ data dir on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          PROJ_DATA_DIR="$(brew --prefix proj)/share/proj"
+          if [[ ! -f "$PROJ_DATA_DIR/proj.db" ]]; then
+            echo "ERROR: proj.db not found in $PROJ_DATA_DIR"
+            ls -la "$(brew --prefix proj)/share" || true
+            exit 1
+          fi
+          echo "PROJ_LIB=$PROJ_DATA_DIR" >> "$GITHUB_ENV"
+          echo "PROJ_DATA=$PROJ_DATA_DIR" >> "$GITHUB_ENV"
+
       - uses: r-lib/actions/setup-r@v2
         with:
           http-user-agent: ${{ matrix.config.http-user-agent }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,6 +26,19 @@ jobs:
 
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
 
+      - name: Export PROJ data dir on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          PROJ_DATA_DIR="$(brew --prefix proj)/share/proj"
+          if [[ ! -f "$PROJ_DATA_DIR/proj.db" ]]; then
+            echo "ERROR: proj.db not found in $PROJ_DATA_DIR"
+            ls -la "$(brew --prefix proj)/share" || true
+            exit 1
+          fi
+          echo "PROJ_LIB=$PROJ_DATA_DIR" >> "$GITHUB_ENV"
+          echo "PROJ_DATA=$PROJ_DATA_DIR" >> "$GITHUB_ENV"
+
       - uses: r-lib/actions/setup-r@v2
         with:
           Ncpus: 2


### PR DESCRIPTION
## Summary
- macOS-latest GHA image regressed: terra/PROJ can no longer locate `proj.db`, surfacing as 100+ `PROJ: proj_create_from_name: Cannot find proj.db (GDAL error 1)` warnings on every macOS run, and a hard `[project] input crs is not valid` error in `test-prepInputsCOG.R:51`.
- Yesterday (commit 97f7769e): 0 PROJ warnings on macOS, run passed. Today (commit ceb9c93e on PR #470): 148 PROJ warnings, run failed. Same code, same workflow — so the GHA macOS image got refreshed.
- Fix: after `install-spatial-deps@v0.2` (which installs gdal via brew, pulling proj as a dep), export `PROJ_LIB` and `PROJ_DATA` to `$(brew --prefix proj)/share/proj` via `$GITHUB_ENV`. Step has `if: runner.os == 'macOS'` so Linux/Windows are unaffected.
- Both workflows that target macOS get the step: `R-CMD-check.yaml` and `test-coverage.yaml`. (`update-citation-cff.yaml` and `rhub.yaml` use macOS but don't run terra-dependent code.)
- Step also fails fast with a directory listing if `proj.db` isn't where we expect it, so a future brew layout change is loud rather than silent.

## Test plan
- [ ] R-CMD-check macOS-latest job goes green.
- [ ] test-coverage job goes green.
- [ ] No regression on Linux/Windows matrix jobs.
- [ ] Confirm `proj.db` is found at the expected path (step exits 0 without the failure message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)