### PR TITLE
fix(preProcess): preserve local file path when skipping download for non-archive sources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-05-20
-Version: 3.1.1.9003
+Version: 3.1.1.9004
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -258,7 +258,7 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
     reproducible.inputPaths = NULL, successfulDir = NULL,
     successfulCheckSumFilePath = NULL,
     downloadResult = NULL, funChar = NULL,
-    skipDownload = FALSE, remoteMetadata = NULL,
+    skipDownload = FALSE, skipDownloadFile = NULL, remoteMetadata = NULL,
     hashVerified = character(),
     verboseCFS = verbose
   )
@@ -609,7 +609,8 @@ pp_remote_hash_check <- function(ctx) {
       "Skipping download; local file matches remote version (cached): ",
       .messageFunctionFn(basename(localFile)), verbose = ctx$verbose
     )
-    ctx$skipDownload <- TRUE
+    ctx$skipDownload     <- TRUE
+    ctx$skipDownloadFile <- localFile
     ctx$hashVerified <- unique(c(ctx$hashVerified, localFile))
     if (is.null(ctx$archive) && !is.null(.isArchive(localFile)))
       ctx$archive <- localFile
@@ -660,7 +661,8 @@ pp_remote_hash_check <- function(ctx) {
         "Skipping download; local file matches remote version: ",
         .messageFunctionFn(basename(localFile)), verbose = ctx$verbose
       )
-      ctx$skipDownload   <- TRUE
+      ctx$skipDownload     <- TRUE
+      ctx$skipDownloadFile <- localFile
       ctx$remoteMetadata <- remoteMetadata
       ctx$hashVerified   <- unique(c(ctx$hashVerified, localFile))
       if (is.null(ctx$archive) && !is.null(.isArchive(localFile)))
@@ -713,7 +715,8 @@ pp_remote_hash_check <- function(ctx) {
     "Skipping download; local file matches remote version: ",
     .messageFunctionFn(basename(localFile)), verbose = ctx$verbose
   )
-  ctx$skipDownload   <- TRUE
+  ctx$skipDownload     <- TRUE
+  ctx$skipDownloadFile <- localFile
   ctx$remoteMetadata <- remoteMetadata
   ctx$hashVerified   <- unique(c(ctx$hashVerified, localFile))
   if (is.null(ctx$archive) && !is.null(.isArchive(localFile)))
@@ -732,8 +735,17 @@ pp_download <- function(ctx) {
   # .checkForSimilar / filesToChecksum logic below works unchanged.
   # ------------------------------------------------------------------
   if (isTRUE(ctx$skipDownload)) {
+    # When archive = NA (regular non-archive file), ctx$archive is NA — fall
+    # back to the verified local file path recorded by pp_remote_hash_check so
+    # downloaded carries the actual file, not NA. Without this, NA propagates
+    # into ctx$filesToChecksum and pollutes downstream checkSums lookups.
+    downloadedFile <- if (isTRUE(is.na(ctx$archive)) || is.null(ctx$archive)) {
+      if (!is.null(ctx$skipDownloadFile)) ctx$skipDownloadFile else ctx$archive
+    } else {
+      ctx$archive
+    }
     downloadFileResult <- list(
-      downloaded    = ctx$archive,
+      downloaded    = downloadedFile,
       archive       = ctx$archive,
       neededFiles   = ctx$neededFiles,
       checkSums     = ctx$checkSums,

--- a/tests/testthat/test-pp_remote_hash_check.R
+++ b/tests/testthat/test-pp_remote_hash_check.R
@@ -53,3 +53,60 @@ test_that("pp_remote_hash_check tolerates a remote with no advertised file size"
   )
   expect_false(isTRUE(res2$skipDownload))
 })
+
+test_that("sidecar fast-path records skipDownloadFile so pp_download keeps a real path", {
+  # Regression: when archive = NA (regular non-archive file like RTM.tif) and
+  # the sidecar fast-path skips download, pp_download synthesised
+  #   downloaded = ctx$archive  (= NA)
+  # which propagated NA into ctx$filesToChecksum and polluted downstream
+  # checkSums lookups (eventually crashing with a data.table length-mismatch).
+  # Now pp_remote_hash_check records the verified localFile in skipDownloadFile,
+  # and pp_download uses it when ctx$archive is NA.
+  testInit("terra", verbose = -1)
+
+  localFile <- file.path(tmpdir, "RTM.tif")
+  writeLines("not a real tif, just bytes", localFile)
+  url <- "https://drive.google.com/open?id=10hnvjk8k9wYGgyZ7dBp7JvxKY0mblI4R"
+
+  reproducible:::makeRemoteHashFile(
+    url, tmpdir, basename(localFile),
+    remoteHash = "fake-hash", algorithm = "md5", write = TRUE
+  )
+
+  ctx <- list(
+    url              = url,
+    archive          = NA,
+    neededFiles      = localFile,
+    destinationPath  = tmpdir,
+    checkSumFilePath = file.path(tmpdir, "CHECKSUMS.txt"),
+    checkSums        = reproducible:::.emptyChecksumsResult,
+    needChecksums    = 0L,
+    verbose          = -1,
+    hashVerified     = character(),
+    skipDownload     = FALSE,
+    skipDownloadFile = NULL,
+    remoteMetadata   = NULL
+  )
+
+  res <- reproducible:::pp_remote_hash_check(ctx)
+  expect_true(isTRUE(res$skipDownload))
+  expect_identical(res$skipDownloadFile, localFile)
+
+  # pp_download fast-path must surface localFile as `downloaded` and propagate
+  # it (not NA) into filesToChecksum.
+  res$.callingEnv <- environment()
+  res$verboseCFS  <- -1
+  res$dlFunCaptured <- NULL
+  res$dots        <- list()
+  res$alsoExtract <- NULL
+  res$targetFile  <- basename(localFile)
+  res$.tempPath   <- tempdir2(rndstr(1, 6))
+  on.exit(unlink(res$.tempPath, recursive = TRUE), add = TRUE)
+  res$quick       <- TRUE
+  res$overwrite   <- FALSE
+  res$purge       <- FALSE
+
+  out <- reproducible:::pp_download(res)
+  expect_identical(out$filesToChecksum, localFile)
+  expect_false(any(is.na(out$filesToChecksum)))
+})


### PR DESCRIPTION
## Summary
- `pp_remote_hash_check` now records the verified `localFile` in `ctx$skipDownloadFile` at all three skip sites (sidecar fast-path, sidecar+remote-hash match, freshly-digested match).
- `pp_download`'s skip fast-path falls back to `ctx$skipDownloadFile` when `ctx$archive` is `NA`, so `downloaded` carries the actual file path instead of `NA`.

## Why
When `prepInputs(..., archive = NA)` re-runs against a cached non-archive file (e.g. a bare `.tif`), the sidecar fast-path skipped the download but `pp_download` synthesised `downloaded = ctx$archive` — which is `NA`. That `NA` propagated into `ctx$filesToChecksum`, polluted `.compareChecksumsAndFilesAddDirs` joins, and eventually crashed downstream with:

```
Error in `[.data.table`(x, i, which = TRUE) :
  i evaluates to a logical vector length 12 but there are 2 rows.
```

Reported by Ceres on a `Cache(prepInputs, url=..., archive = NA, targetFile = "RTM.tif", ...)` call where the local file already matched the remote sidecar.

## Test plan
- [x] New regression test in `tests/testthat/test-pp_remote_hash_check.R` writes a sidecar, runs `pp_remote_hash_check` with `archive = NA`, asserts `skipDownloadFile == localFile`, then runs `pp_download` and asserts `filesToChecksum == localFile` (not `NA`).
- [x] Full `test-pp_remote_hash_check.R` suite passes (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)