### PR TITLE
feat!: remove reproducible.gdalwarp option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-05-21
-Version: 3.1.1.9020
+Date: 2026-05-26
+Version: 3.1.1.9021
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,15 @@
 
 ## behaviour changes
 
+* `options("reproducible.gdalwarp")` is removed. The option was a switch
+  for an experimental alternative dispatch in `postProcessTo()` that used
+  `sf::gdal_utils("gdalwarp")` directly. The branch behind the switch had
+  been fully commented out for some time; the live code path was the same
+  whether the option was `TRUE` or `FALSE`. Any existing
+  `options(reproducible.gdalwarp = ...)` calls in user code are now
+  silently ignored and can be deleted. `options("reproducible.gdalwarpThreads")`
+  (the unrelated thread-count knob for `detectThreads()`) is unaffected.
+
 * `options("reproducible.cachePath")` is no longer pre-set to a
   session-tempdir path when the package is loaded; the default is now
   `NULL`. The first call to a user-facing entry point (`Cache()`,

--- a/R/options.R
+++ b/R/options.R
@@ -311,7 +311,6 @@ reproducibleOptions <- function() {
     reproducible.drv = NULL, # RSQLite::SQLite(),
     reproducible.dryRun = FALSE,
     reproducible.futurePlan = FALSE, # future::plan("multisession"), #memoise
-    reproducible.gdalwarp = FALSE,
     reproducible.gdalwarpThreads = 2L,
     reproducible.inputPath = file.path(tempdir(), "reproducible", "input"),
     reproducible.destinationPathShared = NULL,

--- a/R/postProcessTo.R
+++ b/R/postProcessTo.R
@@ -141,8 +141,7 @@
 #'   or `terra::writeRaster` (for `writeTo`) and not used for `cropTo`, as well `postProcess`'s
 #'   `rasterToMatch` and `studyArea` arguments (see below). Commonly used arguments might be
 #'   `method`, `touches`, and `datatype`. If `filename` is passed, it will be ignored; use
-#'   `writeTo = `. If `reproducible.gdalwarp = TRUE`, then these will be passed to the
-#'   `gdal*` functions. See them for details.
+#'   `writeTo = `.
 #' @inheritParams Cache
 #'
 #' @details
@@ -248,43 +247,7 @@ postProcessTo <- function(from, to,
       }
     }
 
-    couldDoGDAL <- .isGridded(from) && .isVector(maskTo) && .isGridded(projectTo)
-    stillNeed <- TRUE
-
-    if (isTRUE(getOption("reproducible.gdalwarp", FALSE)) && couldDoGDAL) {
-      messagePreProcess("option(reproducible.gdalwarp = TRUE) is now defunct; passing to postProcessTo...")
-      # stillNeed <- FALSE
-      # #############################################################
-      # # project resample mask sequence ################################
-      # #############################################################
-      # messagePreProcess("using sf::gdal_utils('warp') because options(\"reproducible.gdalwarp\" = TRUE) ...", appendLF = TRUE, verbose = verbose)
-      # st <- Sys.time()
-      #
-      # withCallingHandlers(
-      #   tryCatch({
-      #     from <- gdalProject(fromRas = from, toRas = projectTo, verbose = verbose, ...)
-      #     from <- gdalResample(fromRas = from, toRas = projectTo, verbose = verbose, ...)
-      #     if (.isGridded(maskTo)) { # won't be used at the moment because couldDoGDAL = FALSE for gridded
-      #       from <- maskTo(from = from, maskTo = maskTo, verbose = verbose, ...)
-      #     } else {
-      #       from <- gdalMask(fromRas = from, maskToVect = maskTo, writeTo = writeTo, verbose = verbose, ...)
-      #     }
-      #   }, error = function(e) {
-      #     stillNeed <<- TRUE
-      #     couldDoGDAL <<- FALSE
-      #     message("Attempted to use gdal* functions, but errors occured; trying without gdal*...")
-      #   }),
-      #   warning = function(w) {
-      #     if (any(grepl("transformer options does not support option NUM_THREADS", w$message)))
-      #       invokeRestart("muffleWarning")
-      #   })
-      #   # from <- setMinMax(from)
-
-    } # else {
-
-    if (stillNeed) {
-      if (couldDoGDAL)
-        message("Try setting options('reproducible.gdalwarp' = TRUE) to use a different, possibly faster, algorithm")
+    {
       #############################################################
       # crop project mask sequence ################################
       #############################################################
@@ -1604,16 +1567,14 @@ isGeomType <- function(geom, type) {
 #' `-dstnodata = NA`, and `-overwrite`.
 #'
 #' @details
-#' These three functions are used within `postProcessTo`, in the sequence:
-#' `gdalProject`, `gdalResample` and `gdalMask`, when `from` and `projectTo` are `SpatRaster` and
-#' `maskTo` is a `SpatVector`, but only if `options(reproducible.gdalwarp = TRUE)` is set.
-#'
-#' This sequence is a slightly different order than the sequence when `gdalwarp = FALSE` or
-#' the arguments do not match the above. This sequence was determined to be faster and
-#' more accurate than any other sequence, including running all three steps in one
-#' `gdalwarp` call (which `gdalwarp` can do). Using one-step `gdalwarp` resulted in
-#' very coarse pixelation when converting from a coarse resolution to fine resolution, which
-#' visually was inappropriate in test cases.
+#' These three functions were an alternative sequence
+#' (`gdalProject`, `gdalResample`, `gdalMask`) for the `from` + `projectTo`
+#' `SpatRaster` / `maskTo` `SpatVector` case in `postProcessTo`. The sequence
+#' was determined to be faster and more accurate than any other ordering,
+#' including running all three steps in one `gdalwarp` call (one-step
+#' `gdalwarp` resulted in very coarse pixelation when converting from a
+#' coarse resolution to fine resolution). They are retained for reference
+#' only; the live `postProcessTo` path no longer dispatches to them.
 #'
 #' @export
 #' @example inst/examples/example_postProcessTo.R

--- a/man/gdalwarpFns.Rd
+++ b/man/gdalwarpFns.Rd
@@ -69,16 +69,14 @@ set, notably, \code{-r} to \code{method} (in the ...), \code{-t_srs} to the crs 
 \code{-te} to the extent of the \code{toRas}, \code{-te_srs} to the \code{crs} of the \code{toRas},
 \code{-dstnodata = NA}, and \code{-overwrite}.
 
-These three functions are used within \code{postProcessTo}, in the sequence:
-\code{gdalProject}, \code{gdalResample} and \code{gdalMask}, when \code{from} and \code{projectTo} are \code{SpatRaster} and
-\code{maskTo} is a \code{SpatVector}, but only if \code{options(reproducible.gdalwarp = TRUE)} is set.
-
-This sequence is a slightly different order than the sequence when \code{gdalwarp = FALSE} or
-the arguments do not match the above. This sequence was determined to be faster and
-more accurate than any other sequence, including running all three steps in one
-\code{gdalwarp} call (which \code{gdalwarp} can do). Using one-step \code{gdalwarp} resulted in
-very coarse pixelation when converting from a coarse resolution to fine resolution, which
-visually was inappropriate in test cases.
+These three functions were an alternative sequence
+(\code{gdalProject}, \code{gdalResample}, \code{gdalMask}) for the \code{from} + \code{projectTo}
+\code{SpatRaster} / \code{maskTo} \code{SpatVector} case in \code{postProcessTo}. The sequence
+was determined to be faster and more accurate than any other ordering,
+including running all three steps in one \code{gdalwarp} call (one-step
+\code{gdalwarp} resulted in very coarse pixelation when converting from a
+coarse resolution to fine resolution). They are retained for reference
+only; the live \code{postProcessTo} path no longer dispatches to them.
 }
 \examples{
 if (require("terra", quietly = TRUE)) {

--- a/man/postProcessTo.Rd
+++ b/man/postProcessTo.Rd
@@ -123,8 +123,7 @@ option, e.g., \verb{options('reproducible.verbose' = 0) to reduce to minimal}}
 or \code{terra::writeRaster} (for \code{writeTo}) and not used for \code{cropTo}, as well \code{postProcess}'s
 \code{rasterToMatch} and \code{studyArea} arguments (see below). Commonly used arguments might be
 \code{method}, \code{touches}, and \code{datatype}. If \code{filename} is passed, it will be ignored; use
-\verb{writeTo = }. If \code{reproducible.gdalwarp = TRUE}, then these will be passed to the
-\verb{gdal*} functions. See them for details.}
+\verb{writeTo = }.}
 
 \item{needBuffer}{Logical. Defaults to \code{FALSE}, meaning nothing is done out
 of the ordinary. If \code{TRUE}, then a buffer around the cropTo, so that if a reprojection


### PR DESCRIPTION
## Summary
- Removes `options(\"reproducible.gdalwarp\")` and the dead branch behind it in `postProcessTo()`. The branch body had been commented out for some time; the option was a setter with no live effect.
- Drops the now-unused `couldDoGDAL` / `stillNeed` locals.
- Cleans up the two roxygen references to the option in `postProcessTo()` and the defunct `gdalwarpFns` group.
- Bumps DESCRIPTION (`3.1.1.9020 -> 3.1.1.9021`, date `2026-05-26`) and adds a NEWS entry under behaviour changes.

## Why
The option was a no-op user-facing switch advertising an alternative algorithm that wasn't actually wired up. It also surfaced a misleading \"Try setting options('reproducible.gdalwarp' = TRUE) to use a different, possibly faster, algorithm\" hint pointing users at an untested path. Cleaner to retire the lot.

`options(\"reproducible.gdalwarpThreads\")` (the threads knob used by `detectThreads()`) is preserved — separate option, still in use.

## Test plan
- [ ] `R CMD check` clean.
- [ ] `grep -r 'reproducible\\.gdalwarp\\b' R/ man/` returns nothing outside the `gdalwarpThreads` matches.
- [ ] An existing `options(reproducible.gdalwarp = TRUE)` in user code no longer emits the \"now defunct\" message (it is silently a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)