### PR TITLE
docs(urlLog): document reproducible.urlLog option + NEWS entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-05-26
-Version: 3.1.1.9026
+Date: 2026-06-01
+Version: 3.1.1.9027
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 * development version.
 
+## new features
+
+* `prepInputs()` and `preProcess()` now keep a record of every file and web
+  address (URL) they download. By default, each download is saved as a permanent
+  note on the matching cache entry, which you can look up later with
+  `showCache(userTags = "reproducible.url")`. Set
+  `options(reproducible.urlLog = TRUE)` to also keep an in-memory list for the
+  current session, which you can read with `prepInputsLog()` and empty with
+  `clearUrlLog()`. Set `options(reproducible.urlLog = FALSE)` to turn the
+  recording off. See `?prepInputsLog` and `?reproducibleOptions`.
+
 ## behaviour changes
 
 * `postProcessTo()` is now faster and uses less memory on large rasters.

--- a/R/options.R
+++ b/R/options.R
@@ -208,6 +208,18 @@
 #'     will be wrapped around the download so that it will timeout (and error) after this many
 #'     seconds.
 #'   }
+#'   \item{`urlLog`}{
+#'     Default: `NULL`. Controls whether `prepInputs()` / `preProcess()` keep a
+#'     record of the files and web addresses (URLs) they download. `NULL` (the
+#'     default) records each download as a permanent tag on the matching cache
+#'     entry, which you can look up later with
+#'     `showCache(userTags = "reproducible.url")`; it keeps no in-session list.
+#'     `TRUE` additionally keeps an in-memory list for the current session, which
+#'     you can read with [prepInputsLog()] and empty with [clearUrlLog()].
+#'     `FALSE` turns the recording off completely. Advanced: you may instead
+#'     supply an environment (records are appended to `env$records`, which you
+#'     own and manage) or a function (called once with each record).
+#'   }
 #'   \item{`useCache`}{
 #'     Default: `TRUE`. Used in [Cache()]. If `FALSE`, then the entire
 #'     `Cache` machinery is skipped and the functions are run as if there was no Cache occurring.

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -143,6 +143,23 @@ cues (largely based on \code{memfrac}, \code{maxmem} \code{terraOptions}). This 
 however, if the user has set the \code{terraOptions} away from its default of \code{0.5}. The default
 increases predictability of whether the returned object is on disk or in memory.
 }
+\item{\code{terraMemmax}}{
+Default: \code{2} (gigabytes). Used in \code{\link[=postProcessTo]{postProcessTo()}}.
+Caps \code{terra}'s per-raster memory budget for the duration of a \code{postProcessTo()}
+call by temporarily setting \code{terraOptions(memmax = ...)}, restored via
+\code{on.exit()}. Small values force \code{terra} to process in chunks, which on
+high-RAM machines is substantially faster than letting it pull whole
+rasters into RAM (in benchmarks on a 1TB-RAM machine, \code{memmax = 4} was
+~45\% faster and used ~3x less peak RSS than the unbounded default; the
+2GB default is conservative for shared nodes). Set to \code{NULL} to disable
+and let \code{terra} choose. \strong{Respects user-set values}: if the caller has
+already set \code{terraOptions(memmax = ...)} to a positive finite value,
+\code{postProcessTo()} leaves it alone -- the option only applies when
+\code{terra}'s \code{memmax} is at its default ("ignored": \code{NA}, \code{NULL}, or \verb{<= 0};
+terra's out-of-the-box default is \code{-1}). See also \code{memfrac} in
+\code{\link[terra:terraOptions]{terra::terraOptions()}}; a \code{memfrac} ceiling of \code{0.1} is sensible on
+shared machines.
+}
 \item{\code{memoisePersist}}{
 Default: \code{FALSE}. Used in \code{\link[=Cache]{Cache()}}.
 Should the memoised copy of the Cache objects persist even if \code{reproducible} reloads
@@ -199,6 +216,18 @@ Default \code{12000}. Used in \code{preProcess} when downloading occurs. If a us
 package installed, \code{R.utils::withTimeout(  , timeout = getOption("reproducible.timeout"))}
 will be wrapped around the download so that it will timeout (and error) after this many
 seconds.
+}
+\item{\code{urlLog}}{
+Default: \code{NULL}. Controls whether \code{prepInputs()} / \code{preProcess()} keep a
+record of the files and web addresses (URLs) they download. \code{NULL} (the
+default) records each download as a permanent tag on the matching cache
+entry, which you can look up later with
+\code{showCache(userTags = "reproducible.url")}; it keeps no in-session list.
+\code{TRUE} additionally keeps an in-memory list for the current session, which
+you can read with \code{\link[=prepInputsLog]{prepInputsLog()}} and empty with \code{\link[=clearUrlLog]{clearUrlLog()}}.
+\code{FALSE} turns the recording off completely. Advanced: you may instead
+supply an environment (records are appended to \code{env$records}, which you
+own and manage) or a function (called once with each record).
 }
 \item{\code{useCache}}{
 Default: \code{TRUE}. Used in \code{\link[=Cache]{Cache()}}. If \code{FALSE}, then the entire


### PR DESCRIPTION
Documentation only — no code changes.

The URL-logging feature (`prepInputsLog()`, `clearUrlLog()`, the `reproducible.urlLog` option) is already in `development`, but:
- the `reproducible.urlLog` option had **no entry** in the `reproducibleOptions()` roxygen list (despite `prepInputsLog()` pointing readers there), and
- there was **no NEWS entry** for the feature.

This adds both (plain-language), and regenerates `reproducibleOptions.Rd`.

Recovered from the dangling `prepInputsLog` branch (commit `754eec75`). That commit also rewrote the `cachePath`/`timeout` NEWS bullets, but those have since changed independently in `development`, so that stale part is intentionally **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)