### PR TITLE
fix: suppress target/fun guessing messages on direct preProcess()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-01
-Version: 3.1.1.9034
+Date: 2026-06-02
+Version: 3.1.1.9035
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,13 @@
 
 ## bug fixes
 
+* A direct `preProcess()` call no longer prints the target/fun guessing
+  messages ("targetFile was not specified...", "Trying `fun` on ...",
+  "More than one possible files to load... Picking the last one..."). Because
+  `preProcess()` never loads the object into R (it only returns file paths),
+  those messages were misleading. They are still shown when `preProcess()` is
+  called from `prepInputs()` (where a load follows) and are always suppressed
+  when `fun = NA`. The returned `targetFile`/`fun` are unchanged.
 * `prepInputs`/`preProcess` no longer error with
   `missing value where TRUE/FALSE needed` in the remote hash check when the
   remote source advertises no file size (e.g. a server with no

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -174,6 +174,12 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
                        .tempPath, .callingEnv = parent.frame(),
                        ...) {
   st <- Sys.time()
+  ## A direct preProcess() call never loads the object into R (it only returns
+  ## file paths), so the target/fun *guessing* messages emitted in pp_finalize
+  ## ("targetFile was not specified", "Picking the last one", ...) are noise.
+  ## prepInputs always passes `.tempPath`, so a missing `.tempPath` is the
+  ## signal that no load will follow and those messages should be suppressed.
+  directCall <- missing(.tempPath)
   ## URL-log hook fires only on direct preProcess() calls. When called from
   ## prepInputs, the prepInputs head already logged (so the COG fast-path,
   ## which bypasses preProcess, is still covered).
@@ -218,6 +224,10 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
     dots = dots, quick = quick, overwrite = overwrite, purge = purge, verbose = verbose,
     .tempPath = .tempPath, .callingEnv = .callingEnv
   )
+  ## When TRUE, a load will follow (called from prepInputs), so pp_finalize is
+  ## allowed to emit the target/fun guessing messages; a direct preProcess()
+  ## call suppresses them.
+  ctx$loadWillFollow <- !directCall
 
   ctx <- pp_resolve_files(ctx)
   ctx <- pp_checksums_init(ctx)
@@ -1029,7 +1039,8 @@ pp_link_to_destination <- function(ctx) {
 pp_finalize <- function(ctx) {
   targetParams       <- .guessAtTargetAndFun(
     ctx$targetFilePath, ctx$destinationPath,
-    filesExtracted = ctx$filesExtr, ctx$fun, verbose = ctx$verbose
+    filesExtracted = ctx$filesExtr, ctx$fun, verbose = ctx$verbose,
+    messageGuessing = isTRUE(ctx$loadWillFollow)
   )
   ctx[["targetFile"]]     <- makeRelative(targetParams$targetFilePath, ctx$destinationPath)
   ctx$targetFilePath <- targetParams$targetFilePath

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -741,10 +741,21 @@ extractFromArchive <- function(archive,
 #' @param filesExtracted A character vector of all files that have been extracted (e.g.,
 #'                       from an archive)
 #' @param destinationPath Full path of the directory where the target file should be
+#' @param messageGuessing Logical. If `TRUE` (the default, used when a load will
+#'   follow, e.g. from `prepInputs`), emit the messages about the guessed
+#'   `targetFile`/`fun` (e.g. "targetFile was not specified", "Picking the last
+#'   one"). A direct `preProcess()` call sets this to `FALSE` because it never
+#'   loads the object, so those messages would be misleading; the guessing
+#'   itself (and the returned values) is unchanged.
 #' @keywords internal
 .guessAtTargetAndFun <- function(targetFilePath,
                                  destinationPath = getOption("reproducible.destinationPath", "."),
-                                 filesExtracted, fun = NULL, verbose = getOption("reproducible.verbose", 1)) {
+                                 filesExtracted, fun = NULL, verbose = getOption("reproducible.verbose", 1),
+                                 messageGuessing = TRUE) {
+  # `messageGuessing = FALSE` keeps the target/fun guessing (the result still
+  # needs a targetFile + fun) but suppresses the user-facing messages about it.
+  # This is used by direct preProcess() calls, which never load the object, so
+  # "targetFile was not specified", "Picking the last one", etc. are misleading.
   # fun = NA means "don't load anything" — skip all guessing and messaging.
   # Guard is.na() with is.atomic + length-1 so a user-supplied language object
   # (e.g. `fun = sf::st_read(targetFile)`) doesn't trip "is.na() applied to
@@ -837,7 +848,8 @@ extractFromArchive <- function(archive,
           paste(possibleFiles, collapse = "\n")
         )
       }
-      messagePreProcess(c("targetFile was not specified.", secondPartOfMess), verbose = verbose)
+      if (messageGuessing)
+        messagePreProcess(c("targetFile was not specified.", secondPartOfMess), verbose = verbose)
 
       targetFilePath <- if (is.null(fun)) {
         NULL
@@ -853,15 +865,17 @@ extractFromArchive <- function(archive,
         }
       }
       if (length(targetFilePath) > 1) {
-        messagePreProcess("More than one possible files to load:\n", verbose = verbose)
-        if (length(targetFilePath) > 100) {
-          filesForMess <- data.table(Extracted = targetFilePath)
-          messageDF(filesForMess, indent = .message$PreProcessIndent, verbose = verbose)
-        } else {
-          filesForMess <- paste(targetFilePath, collapse = "\n")
-          messagePreProcess(filesForMess)
+        if (messageGuessing) {
+          messagePreProcess("More than one possible files to load:\n", verbose = verbose)
+          if (length(targetFilePath) > 100) {
+            filesForMess <- data.table(Extracted = targetFilePath)
+            messageDF(filesForMess, indent = .message$PreProcessIndent, verbose = verbose)
+          } else {
+            filesForMess <- paste(targetFilePath, collapse = "\n")
+            messagePreProcess(filesForMess)
+          }
+          messagePreProcess("Picking the last one. If not correct, specify a targetFile.", verbose = verbose)
         }
-        messagePreProcess("Picking the last one. If not correct, specify a targetFile.", verbose = verbose)
         targetFilePath <- targetFilePath[length(targetFilePath)]
       }
     }

--- a/man/guessAtTarget.Rd
+++ b/man/guessAtTarget.Rd
@@ -10,7 +10,8 @@
   destinationPath = getOption("reproducible.destinationPath", "."),
   filesExtracted,
   fun = NULL,
-  verbose = getOption("reproducible.verbose", 1)
+  verbose = getOption("reproducible.verbose", 1),
+  messageGuessing = TRUE
 )
 }
 \arguments{
@@ -18,6 +19,13 @@
 
 \item{filesExtracted}{A character vector of all files that have been extracted (e.g.,
 from an archive)}
+
+\item{messageGuessing}{Logical. If \code{TRUE} (the default, used when a load will
+follow, e.g. from \code{prepInputs}), emit the messages about the guessed
+\code{targetFile}/\code{fun} (e.g. "targetFile was not specified", "Picking the last
+one"). A direct \code{preProcess()} call sets this to \code{FALSE} because it never
+loads the object, so those messages would be misleading; the guessing
+itself (and the returned values) is unchanged.}
 }
 \description{
 Try to pick a file to load

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -117,6 +117,52 @@ test_that("guessAtTargetAndFun works correctly", {
   )
 })
 
+test_that("guessAtTargetAndFun: messageGuessing = FALSE suppresses guessing messages", {
+  testInit("terra")
+
+  twoFiles <- c("hi.rds", "hello.rds")
+
+  # messageGuessing = TRUE (the prepInputs path, where a load follows): the
+  # target/fun guessing messages are shown.
+  msgsOn <- capture_messages(
+    resOn <- .guessAtTargetAndFun(
+      targetFilePath = NULL, filesExtracted = twoFiles,
+      fun = "readRDS", messageGuessing = TRUE
+    )
+  )
+  expect_true(any(grepl("targetFile was not specified", msgsOn)))
+  expect_true(any(grepl("More than one possible files to load", msgsOn)))
+  expect_true(any(grepl("Picking the last one", msgsOn)))
+
+  # messageGuessing = FALSE (direct preProcess(), which never loads): the same
+  # messages must be suppressed.
+  msgsOff <- capture_messages(
+    resOff <- .guessAtTargetAndFun(
+      targetFilePath = NULL, filesExtracted = twoFiles,
+      fun = "readRDS", messageGuessing = FALSE
+    )
+  )
+  expect_false(any(grepl("targetFile was not specified", msgsOff)))
+  expect_false(any(grepl("More than one possible files to load", msgsOff)))
+  expect_false(any(grepl("Picking the last one", msgsOff)))
+
+  # ... but the returned targetFile/fun are identical regardless of messaging
+  # (it still picks the last candidate so the result remains usable).
+  expect_identical(resOff$targetFilePath, resOn$targetFilePath)
+  expect_identical(resOff$fun, resOn$fun)
+  expect_identical(resOff$targetFilePath, "hello.rds")
+
+  # fun = NA already short-circuits before any guessing, so no messages regardless.
+  msgsNA <- capture_messages(
+    resNA <- .guessAtTargetAndFun(
+      targetFilePath = NULL, filesExtracted = twoFiles,
+      fun = NA, messageGuessing = TRUE
+    )
+  )
+  expect_false(any(grepl("targetFile was not specified", msgsNA)))
+  expect_false(any(grepl("Picking the last one", msgsNA)))
+})
+
 test_that("unrar is working as expected", {
   testInit("terra", tmpFileExt = c(".tif", ".grd"))
 

--- a/tests/testthat/test-preProcessWorks.R
+++ b/tests/testthat/test-preProcessWorks.R
@@ -686,3 +686,41 @@ test_that("PR#358 if dwnld already exists, was missing nested paths", {
   )
   testthat::expect_true(file.exists(ras$targetFilePath))
 })
+
+test_that("direct preProcess() suppresses target/fun guessing messages; prepInputs keeps them", {
+  testInit("terra")
+
+  # Build a local archive with two same-type candidate files so the target is
+  # ambiguous -> exercises the "Picking the last one" guessing path. No internet
+  # needed (local zip).
+  srcDir <- checkPath(file.path(tmpdir, "guessSrc"), create = TRUE)
+  saveRDS(1:10, file.path(srcDir, "aaa.rds"))
+  saveRDS(11:20, file.path(srcDir, "bbb.rds"))
+  arch <- file.path(tmpdir, "twoFiles.zip")
+  owd <- setwd(srcDir)
+  zipOK <- tryCatch(utils::zip(arch, files = c("aaa.rds", "bbb.rds"), flags = "-q"),
+                    error = function(e) e)
+  setwd(owd)
+  skip_if(is(zipOK, "error") || !file.exists(arch), "zip not available")
+
+  # Direct preProcess() never loads the object into R, so the guessing messages
+  # are noise and must be suppressed -- but the result still resolves.
+  ppMsgs <- capture_messages(
+    pp <- preProcess(archive = arch,
+                     destinationPath = checkPath(file.path(tmpdir, "ppDest"), create = TRUE))
+  )
+  expect_false(any(grepl("targetFile was not specified", ppMsgs)))
+  expect_false(any(grepl("More than one possible files to load", ppMsgs)))
+  expect_false(any(grepl("Picking the last one", ppMsgs)))
+  expect_true(file.exists(pp$targetFilePath))
+
+  # prepInputs() loads the object, so the same guessing messages are relevant
+  # and must still be shown.
+  piMsgs <- capture_messages(
+    pi <- prepInputs(archive = arch,
+                     destinationPath = checkPath(file.path(tmpdir, "piDest"), create = TRUE))
+  )
+  expect_true(any(grepl("targetFile was not specified", piMsgs)))
+  expect_true(any(grepl("Picking the last one", piMsgs)))
+  expect_identical(pi, 11:20) # "Picking the last one" == bbb.rds
+})


### PR DESCRIPTION
## Problem

A direct `preProcess()` call only resolves and returns file paths — it **never loads the object into R**. Yet it still printed the target/fun *guessing* messages, which are only meaningful when a load follows:

```
targetFile was not specified. Trying terra::vect on
  .../NFDB_poly_1972to2020_20250630.shp, .../NFDB_poly_2021to2024_20250630.shp. ...
More than one possible files to load:
  .../NFDB_poly_1972to2020_20250630.shp
  .../NFDB_poly_2021to2024_20250630.shp
Picking the last one. If not correct, specify a targetFile.
```

These appeared (e.g. via `LandR:::.inputObjects` → `preProcess`) even though nothing was being loaded — pure noise.

## Fix

- `.guessAtTargetAndFun()` gains a `messageGuessing` flag (default `TRUE`, so existing callers are unchanged). When `FALSE`, the guessing still runs and the returned `targetFile`/`fun` are **identical** — only the user-facing messages are suppressed.
- `preProcess()` detects a direct call via `missing(.tempPath)` (`prepInputs` always passes `.tempPath`) and threads `messageGuessing = FALSE` through `ctx$loadWillFollow`.

Result:

| Call path | Loads object? | Guessing messages |
|---|---|---|
| `prepInputs()` → `preProcess` + `process` | yes | shown (once) |
| direct `preProcess()` | no | **suppressed** |
| `fun = NA` | no | already suppressed (early return) |

## Tests

- **Unit** (`test-misc.R`): `.guessAtTargetAndFun` with `messageGuessing` TRUE vs FALSE — asserts messages shown/suppressed and that the returned `targetFilePath`/`fun` are identical; plus the `fun = NA` short-circuit.
- **Integration** (`test-preProcessWorks.R`, offline via a local two-file zip): direct `preProcess()` suppresses the messages and still resolves a usable `targetFile`; `prepInputs()` still shows them and loads the last file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)