### PR TITLE
ci(test-downstream): check out SpaDES.core at development, not release

### DIFF
--- a/.github/workflows/test-downstream.yaml
+++ b/.github/workflows/test-downstream.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: PredictiveEcology/SpaDES.core
+          ref: development
           path: SpaDES.core
 
       - name: Checkout SpaDES.project

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-02
-Version: 3.1.1.9035
+Date: 2026-06-03
+Version: 3.1.1.9036
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",


### PR DESCRIPTION
## Problem

`test-downstream` has been failing on `development` (and on every PR) with a SpaDES.core vignette error:

```
Quitting from iii-cache.Rmd:71-86 [examples] / ii-modules.Rmd:187-213 [passing-params]
Error in `.local()`: ! Invalid path: cannot be NULL.
```

## Root cause

The `Checkout SpaDES.core` step had **no `ref:`**, so it used SpaDES.core's default branch (`main` = released **3.1.2**), whereas `Checkout SpaDES.project` is pinned to `ref: development`. So the job tested `reproducible@development` against the **released** SpaDES.core, which lacks the coordinated development-branch fix.

The CI log confirms it built `SpaDES.core 3.1.2` (release), not `3.1.2.9007` (development):

```
✔ Got SpaDES.core 3.1.2 (source)
```

The failure is `setPaths()` → `checkPath(NULL)` in SpaDES.core; `setPaths` only applies a default when a path arg is `missing()`, not when it's `NULL`. SpaDES.core's `development` (3.1.2.9007) resolves this.

## Verification

Built both failing vignettes locally with `reproducible@development` (3.1.1.9037) + **SpaDES.core@development** (3.1.2.9007): both render cleanly. The same reproducible code + SpaDES.core **3.1.2 release** is what CI exercised and what fails — i.e. a release-vs-development mismatch, not a regression in either development branch.

## Fix

Pin the SpaDES.core checkout to `ref: development`, matching SpaDES.project, so the job tests the coordinated development branches together.

### Note / alternative
If the intent was deliberately to test `reproducible@development` against the **released** SpaDES.core (to catch breakage for current CRAN users), then this is the wrong fix and instead reproducible would need backward compatibility with SpaDES.core 3.1.2's `setPaths`, or SpaDES.core would need a patch release. Given SpaDES.project already uses `development` and these packages develop in lockstep, dev-vs-dev is the assumed intent — easy to revert if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)