### PR TITLE
fix(cloud): don't silently invent a Drive folder; skip cloud when no cloudFolderID is set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-04
-Version: 3.1.1.9038
+Version: 3.1.1.9039
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-05
-Version: 3.1.1.9040
+Version: 3.1.1.9041
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-04
-Version: 3.1.1.9039
+Date: 2026-06-05
+Version: 3.1.1.9040
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,16 @@
 
 ## bug fixes
 
+* `Cache(useCloud = TRUE, cloudFolderID = ...)` now **warns** when the supplied
+  `cloudFolderID` cannot be resolved on Google Drive (not found, or not
+  accessible to the authenticated account). Previously this was silent: the code
+  substituted a folder *derived from the local cache path*, which differs from
+  machine to machine, so two machines computing the *identical* `cacheId` would
+  each read/write their own cloud folder and never share — the object would be
+  recomputed and re-uploaded on every machine. The warning tells the user the
+  supplied folder was not used and how to fix it (pass the same accessible Drive
+  folder id on every machine). Resolution behaviour is otherwise unchanged.
+
 * A direct `preProcess()` call no longer prints the target/fun guessing
   messages ("targetFile was not specified...", "Trying `fun` on ...",
   "More than one possible files to load... Picking the last one..."). Because

--- a/NEWS.md
+++ b/NEWS.md
@@ -96,15 +96,26 @@
 
 ## bug fixes
 
-* `Cache(useCloud = TRUE, cloudFolderID = ...)` now **warns** when the supplied
-  `cloudFolderID` cannot be resolved on Google Drive (not found, or not
-  accessible to the authenticated account). Previously this was silent: the code
-  substituted a folder *derived from the local cache path*, which differs from
-  machine to machine, so two machines computing the *identical* `cacheId` would
-  each read/write their own cloud folder and never share — the object would be
-  recomputed and re-uploaded on every machine. The warning tells the user the
-  supplied folder was not used and how to fix it (pass the same accessible Drive
-  folder id on every machine). Resolution behaviour is otherwise unchanged.
+* Cloud caching no longer silently invents a Google Drive folder when none is
+  specified. Previously, `Cache(useCloud = TRUE)` with no `cloudFolderID` (and
+  no `options(reproducible.cloudFolderID)`) **derived a folder name from the
+  local cache path and created/used it**. That derived name differs from machine
+  to machine, so two machines computing the *identical* `cacheId` each read/write
+  their own cloud folder and never share — the object is recomputed and
+  re-uploaded on every machine, silently. Now:
+  - if no `cloudFolderID` is set (neither the argument nor the option), cloud
+    caching is **skipped** (local cache only) with a one-time message, since a
+    `NULL` `cloudFolderID` means "no cloud target", not "make one up";
+  - a `cloudFolderID` argument of `NULL` now falls back to
+    `options(reproducible.cloudFolderID)` (the documented default) before this
+    check, so a globally-set option is honoured;
+  - when a `cloudFolderID` *is* supplied but cannot be resolved on Drive (not
+    found, or not accessible to the authenticated account), a **warning** is now
+    emitted (previously silent) explaining that the supplied folder was not used
+    and how to fix it (pass the same accessible Drive folder id on every
+    machine). To share a cloud cache across machines, set the same explicit
+    folder on each, e.g.
+    `options(reproducible.cloudFolderID = googledrive::as_id("<id>"))`.
 
 * A direct `preProcess()` call no longer prints the target/fun guessing
   messages ("targetFile was not specified...", "Trying `fun` on ...",

--- a/R/GPT2.R
+++ b/R/GPT2.R
@@ -103,6 +103,18 @@ Cache <- function(FUN, ..., dryRun = getOption("reproducible.dryRun", FALSE),
 
   CacheDBFileCheckAndCreate(cachePaths[[1]], drv, conn, verbose = verbose) # checks that we are using multiDBfile backend
 
+  # Cloud caching needs a destination folder. If none was passed, fall back to
+  # the option. If there is still no cloudFolderID, do NOT silently invent one
+  # from the local cache path (a derived folder differs from machine to machine
+  # and silently breaks shared/cloud caching) -- a NULL cloudFolderID means
+  # "no cloud target", so skip cloud caching for this call (local cache only).
+  if (is.null(cloudFolderID))
+    cloudFolderID <- getOption("reproducible.cloudFolderID", NULL)
+  if (cloudWriteOrRead(useCloud) && is.null(cloudFolderID)) {
+    .cloudFolderUnsetMessageOnce(verbose = verbose)
+    useCloud <- FALSE
+  }
+
   if (cloudWrite(useCloud)) {
     cloudFolderID <- checkAndMakeCloudFolderID(cloudFolderID, cachePaths[[1]], create = TRUE, verbose = verbose)
     gdriveLs <- retry(quote(driveLs(cloudFolderID, keyFull$key, cachePath = cachePaths[[1]], verbose = verbose)))

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -28,6 +28,7 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption("reproducible.cl
 
   if (!is(cloudFolderID, "dribble")) {
     isNullCFI <- is.null(cloudFolderID)
+    cloudFolderIDorig <- cloudFolderID # for messaging if it cannot be resolved
     if (isNullCFI) {
       if (is.null(cachePath)) {
         cachePath <- .checkCacheRepo(cachePath, verbose = verbose)
@@ -74,6 +75,25 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption("reproducible.cl
     }
 
     if (NROW(driveLs) == 0) {
+      # An explicit cloudFolderID was supplied but Google Drive could not resolve
+      # it (not found, or not accessible to the authenticated account). The code
+      # below silently substitutes a folder *derived from the local cache path*,
+      # which differs from machine to machine -- so cloud caches will NOT be
+      # shared across machines (the symptom: identical cacheIds, but each machine
+      # recomputes and re-uploads into its own folder). Warn so this is visible.
+      if (!isNullCFI) {
+        warning(
+          "The supplied cloudFolderID (", as.character(cloudFolderIDorig)[1], ") could not be ",
+          "resolved on Google Drive -- it was not found, or is not accessible to the ",
+          "authenticated Google account. ",
+          if (isTRUE(create)) "A folder derived from the local cache path is being used/created instead. " else "",
+          "That derived folder differs between machines, so cloud caches will NOT be shared ",
+          "across machines/operating systems. To share a cloud cache, ensure every machine ",
+          "passes the SAME cloudFolderID (a Drive folder id the authenticated account can ",
+          "access), e.g. options(reproducible.cloudFolderID = googledrive::as_id(\"<id>\")).",
+          call. = FALSE
+        )
+      }
       newcfid <- cloudFolderID
       if (isTRUE(create)) {
         if (isID) {

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -18,6 +18,24 @@ utils::globalVariables(c(
 #' @return
 #' Returns the character string of the cloud folder ID created or reported
 #' @export
+# One-time (per session) notice that cloud caching is being skipped because no
+# cloudFolderID is set. reproducible deliberately does NOT auto-create a cloud
+# folder from the local cache path: that folder differs across machines and
+# would silently break shared/cloud caching.
+.cloudFolderUnsetMessageOnce <- function(verbose = getOption("reproducible.verbose", 1)) {
+  if (isTRUE(.pkgEnv$.cloudFolderUnsetEmitted)) return(invisible())
+  messageCache(
+    "useCloud is on but no cloudFolderID is set (neither the argument nor ",
+    "options(reproducible.cloudFolderID)); skipping cloud caching (local cache ",
+    "only). reproducible does not create a cloud folder automatically. To enable ",
+    "cloud caching, set the same folder on every machine, e.g. ",
+    "options(reproducible.cloudFolderID = googledrive::as_id(\"<id>\")).",
+    verbose = verbose
+  )
+  .pkgEnv$.cloudFolderUnsetEmitted <- TRUE
+  invisible()
+}
+
 checkAndMakeCloudFolderID <- function(cloudFolderID = getOption("reproducible.cloudFolderID", NULL),
                                       cachePath = NULL,
                                       create = FALSE,

--- a/tests/testthat/test-cloudFolderID-offline.R
+++ b/tests/testthat/test-cloudFolderID-offline.R
@@ -20,6 +20,27 @@ test_that("checkAndMakeCloudFolderID warns when an explicit cloudFolderID cannot
   )
 })
 
+test_that(".cloudFolderUnsetMessageOnce emits at most once per session", {
+  withr::defer(assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv))
+  assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv)
+  expect_message(reproducible:::.cloudFolderUnsetMessageOnce(), "no cloudFolderID")
+  expect_no_message(reproducible:::.cloudFolderUnsetMessageOnce()) # not repeated
+})
+
+test_that("useCloud = TRUE with no cloudFolderID skips cloud and caches locally (Option A)", {
+  withr::local_options(
+    reproducible.cloudFolderID = NULL,
+    reproducible.cachePath = withr::local_tempdir(),
+    reproducible.useMemoise = FALSE
+  )
+  withr::defer(assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv))
+  assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv)
+  # If cloud were attempted with no credentials it would error in
+  # googledrive::drive_auth(); reaching a local result proves cloud was skipped.
+  out <- Cache(rnorm, 3, useCloud = TRUE)
+  expect_length(out, 3)
+})
+
 test_that("checkAndMakeCloudFolderID does NOT warn when cloudFolderID is NULL (documented default)", {
   skip_if_not_installed("googledrive")
   skip_if_not_installed("tibble")

--- a/tests/testthat/test-cloudFolderID-offline.R
+++ b/tests/testthat/test-cloudFolderID-offline.R
@@ -1,0 +1,38 @@
+# Offline tests for checkAndMakeCloudFolderID's fallback warning. When an
+# explicit cloudFolderID cannot be resolved on Google Drive (not found, or not
+# accessible to the authenticated account), the code silently substitutes a
+# folder derived from the local cache path -- which differs from machine to
+# machine and so breaks cross-machine/OS cloud caching. It must warn. Google
+# Drive's drive_get is mocked to return an empty result (no network/auth).
+
+test_that("checkAndMakeCloudFolderID warns when an explicit cloudFolderID cannot be resolved", {
+  skip_if_not_installed("googledrive")
+  skip_if_not_installed("tibble")
+  url <- "https://drive.google.com/drive/folders/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?usp=share_link"
+  testthat::with_mocked_bindings(
+    expect_warning(
+      reproducible:::checkAndMakeCloudFolderID(url, cachePath = tempdir(),
+                                               create = FALSE, verbose = 0),
+      "could not be resolved"
+    ),
+    drive_get = function(...) tibble::tibble(name = character(0), id = character(0)),
+    .package = "googledrive"
+  )
+})
+
+test_that("checkAndMakeCloudFolderID does NOT warn when cloudFolderID is NULL (documented default)", {
+  skip_if_not_installed("googledrive")
+  skip_if_not_installed("tibble")
+  # A NULL cloudFolderID deriving a folder from the cache path is the documented
+  # default behaviour, not a surprising substitution -> no warning.
+  testthat::with_mocked_bindings(
+    expect_no_warning(
+      suppressMessages(
+        reproducible:::checkAndMakeCloudFolderID(NULL, cachePath = tempdir(),
+                                                 create = FALSE, verbose = 0)
+      )
+    ),
+    drive_get = function(...) tibble::tibble(name = character(0), id = character(0)),
+    .package = "googledrive"
+  )
+})

--- a/tests/testthat/test-cloudFolderID-offline.R
+++ b/tests/testthat/test-cloudFolderID-offline.R
@@ -7,7 +7,6 @@
 
 test_that("checkAndMakeCloudFolderID warns when an explicit cloudFolderID cannot be resolved", {
   skip_if_not_installed("googledrive")
-  skip_if_not_installed("tibble")
   url <- "https://drive.google.com/drive/folders/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?usp=share_link"
   testthat::with_mocked_bindings(
     expect_warning(
@@ -15,7 +14,7 @@ test_that("checkAndMakeCloudFolderID warns when an explicit cloudFolderID cannot
                                                create = FALSE, verbose = 0),
       "could not be resolved"
     ),
-    drive_get = function(...) tibble::tibble(name = character(0), id = character(0)),
+    drive_get = function(...) data.frame(name = character(0), id = character(0)),
     .package = "googledrive"
   )
 })
@@ -43,7 +42,6 @@ test_that("useCloud = TRUE with no cloudFolderID skips cloud and caches locally 
 
 test_that("checkAndMakeCloudFolderID does NOT warn when cloudFolderID is NULL (documented default)", {
   skip_if_not_installed("googledrive")
-  skip_if_not_installed("tibble")
   # A NULL cloudFolderID deriving a folder from the cache path is the documented
   # default behaviour, not a surprising substitution -> no warning.
   testthat::with_mocked_bindings(
@@ -53,7 +51,7 @@ test_that("checkAndMakeCloudFolderID does NOT warn when cloudFolderID is NULL (d
                                                  create = FALSE, verbose = 0)
       )
     ),
-    drive_get = function(...) tibble::tibble(name = character(0), id = character(0)),
+    drive_get = function(...) data.frame(name = character(0), id = character(0)),
     .package = "googledrive"
   )
 })


### PR DESCRIPTION
## Problem

Cloud caching could **silently** read/write the wrong Google Drive folder, defeating cross-machine sharing — and the symptom looked like a cross-OS `cacheId` mismatch when it wasn't.

Diagnosis of a real case: two machines computed the **identical** `cacheId` (`7c9d201b365d64d0`) for the same call, yet never shared the cloud object. Root cause: cloud caching is gated by **`useCloud`**, not by `cloudFolderID`. So when `cloudFolderID` is `NULL`, reproducible did **not** skip cloud — `checkAndMakeCloudFolderID(NULL, create = TRUE)` **derived a folder name from the local cache path and created it** (`cloudFolderFromCacheRepo(cachePath)` → e.g. `SpaDESworkshop_NACW_test_cache`). One machine passed an explicit folder, the other passed `NULL` → two different folders → no sharing.

## Change (Option A: a NULL cloudFolderID means "no cloud target", not "make one up")

In the `Cache` cloud gate (`GPT2.R`):

1. a `NULL` `cloudFolderID` argument now **falls back to `options(reproducible.cloudFolderID)`** (the documented default) first, so a globally-set option is honoured;
2. if there is **still** no `cloudFolderID`, cloud caching is **skipped** (local cache only) with a **one-time** message, instead of inventing a machine-local folder.

And (from the first commit) when a `cloudFolderID` **is** supplied but **cannot be resolved** on Drive (not found / not accessible to the authenticated account), a **warning** is emitted (previously silent) — it had been falling back to the same cache-path-derived folder.

To share a cloud cache across machines, set the same explicit folder on each:
`options(reproducible.cloudFolderID = googledrive::as_id("<id>"))`.

## Verification

New offline tests in `tests/testthat/test-cloudFolderID-offline.R` (no auth/network; `googledrive::drive_get` mocked where needed):

- `useCloud = TRUE` with no `cloudFolderID` → caches **locally** and does **not** attempt (auth-requiring) cloud access; emits the skip message **once per session**;
- an explicit, unresolvable `cloudFolderID` → **warns** (`"could not be resolved"`);
- a `NULL` `cloudFolderID` (documented default) → does **not** warn.

All pass locally; also confirmed in a clean installed session that `Cache(rnorm, 3, useCloud = TRUE)` with no folder returns a local result with no `drive_auth()` error.

## Note
This was the answer to a long debug: the `cacheId`s were identical (not the bug); the divergence was folder resolution driven by one machine having `cloudFolderID` unset. A separate follow-up (deferred) is the requested base→subfolder design (cloudFolderID as base, `<parentDir>_<cacheDir>` subfolder nested inside) for when a base *is* set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)