### PR TITLE
feat(digest): reproducible.digestVersion option; default to version 4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-05
-Version: 3.1.1.9042
+Version: 3.1.1.9043
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,21 +4,23 @@
 
 ## new features
 
-* New **opt-in** option `reproducible.digestV4` (default `FALSE`) for a
-  platform-stable digest of `sf` and `SpatVector` objects. The previous
-  algorithm could digest the same vector to different values on Windows vs
-  Linux/macOS, so the same data produced different `cacheId`s on different
-  operating systems — preventing shared and cloud caching of these objects
-  across machines. With `reproducible.digestV4 = TRUE`, geometry is taken as the
-  numeric vertex matrix with coordinates rounded to a fixed precision (plus the
-  geometry type) and the attribute table is
-  sorted, so the `cacheId` is identical across platforms (and `sf` and its
-  `SpatVector` equivalent digest the same). **This is opt-in for now**: turning
-  it on changes the `cacheId` of every `sf`/`SpatVector` object and therefore
-  *invalidates previously cached results that involved them* (they are recomputed
-  once under the new algorithm). The default (`FALSE`) leaves `SpatVector` and
-  `sf` digesting unchanged. Requires the \pkg{terra} package. See
-  `?reproducibleOptions`.
+* New option `reproducible.digestVersion` — a single integer that selects the
+  `cacheId` (digest) algorithm, replacing the per-version booleans
+  `reproducible.digestV3`/`reproducible.digestV4` (which are still honoured when
+  `digestVersion` is unset). It **defaults to `4`**, a platform-stable digest of
+  `sf` and `SpatVector` objects: geometry is the numeric vertex matrix with
+  coordinates rounded to a fixed precision (plus the geometry type), and
+  attributes are kept in feature order with columns sorted locale-independently.
+  The same vector data therefore produces the same `cacheId` on Windows, macOS
+  and Linux (digest version 3 could differ across operating systems, preventing
+  shared/cloud caching of these objects), and an `sf` object and its `SpatVector`
+  equivalent now digest identically. **Because version 4 is the new default, the
+  `cacheId` of every `sf`/`SpatVector` object differs from the `reproducible`
+  package v3.1.1 and earlier**, so cached results that involved such objects are
+  recomputed once under the new algorithm. Set
+  `options(reproducible.digestVersion = 3)` to keep the previous behaviour and
+  avoid that one-time invalidation. Requires the \pkg{terra} package. See the
+  `digestVersion` entry in `?reproducibleOptions` for the full list of versions.
 
 * Downloads can now be transparently redirected to faster mirrors and
   fetched in parallel. Two cooperating, opt-in features:

--- a/R/cache.R
+++ b/R/cache.R
@@ -44,6 +44,12 @@ utils::globalVariables(c(
 #'         call; 3) the default values of the Cache function. See section on *Nested Caching*.
 #' }
 #'
+#' The algorithm used to compute the `cacheId` (the hash of the inputs) is
+#' selectable via the `reproducible.digestVersion` option; see the
+#' `digestVersion` entry in [reproducibleOptions()] for the available versions
+#' and what each changes (notably version `4`, which makes `sf`/`SpatVector`
+#' digests identical across operating systems).
+#'
 #' `Cache` will add a tag to the entry in the cache database called `accessed`,
 #' which will assign the time that it was accessed, either read or write.
 #' That way, cached items can be shown (using `showCache`) or removed (using
@@ -379,7 +385,9 @@ utils::globalVariables(c(
 #'
 #' @seealso [showCache()], [clearCache()], [keepCache()],
 #'   [CacheDigest()] to determine the digest of a given function or expression,
-#'   as used internally within `Cache`, [movedCache()], [.robustDigest()], and
+#'   as used internally within `Cache`, [movedCache()], [.robustDigest()],
+#'   [reproducibleOptions()] (e.g. the `digestVersion` option that selects the
+#'   `cacheId` algorithm), and
 #'   for more advanced uses there are several helper functions,
 #'   e.g., [rmFromCache()], [CacheStorageDir()]
 #'
@@ -1226,7 +1234,7 @@ CacheDigest <- function(objsToDigest, ..., algo = "xxhash64", calledFrom = "Cach
   # preDigest[["._list"]] <- NULL # don't need this for CacheDigest
 
   # don't unname -- Eliot Jan 13, 2025 -- this keeps the outputHash
-  if (getOption("reproducible.digestV3", TRUE)) {
+  if (.digestVersion() >= 3L) {
     res <- .doDigest(preDigest, algo = algo, ...)
   } else {
     res <- .robustDigest(unname(sort(unlist(preDigest))), algo = algo, quick = TRUE, ...)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -775,6 +775,28 @@ detectActiveCores <- function(pattern = "", minCPU = 50) {
   invisible()
 }
 
+# The effective digest version, an integer. `reproducible.digestVersion` is the
+# single going-forward control; it supersedes the (still-honoured) booleans
+# `reproducible.digestV3` and `reproducible.digestV4`. Resolution order:
+#   1. `reproducible.digestVersion`, if set to a valid integer;
+#   2. else derived from the superseded booleans (digestV4 = TRUE -> 4;
+#      digestV3 = FALSE -> 2);
+#   3. else the default, 4.
+# Used as `.digestVersion() >= N` at the points that switch digest behaviour
+# (>= 3: the hash assembly added in the reproducible package v3.x; >= 4:
+# platform-stable sf/SpatVector). N here is the digest-algorithm version, not
+# the reproducible package version.
+.digestVersion <- function() {
+  dv <- getOption("reproducible.digestVersion", NULL)
+  if (!is.null(dv)) {
+    dv <- suppressWarnings(as.integer(dv)[1])
+    if (!is.na(dv)) return(dv)
+  }
+  if (isTRUE(getOption("reproducible.digestV4", FALSE))) return(4L)
+  if (isFALSE(getOption("reproducible.digestV3", TRUE))) return(2L)
+  4L
+}
+
 #' @keywords internal
 .getDestinationPathShared <- function() {
   newVal <- getOption("reproducible.destinationPathShared", NULL)

--- a/R/options.R
+++ b/R/options.R
@@ -299,7 +299,7 @@
 #'   \item{`reproducible.useCacheV3`}{
 #'     Default: `TRUE`. If this is set to `FALSE`, it will use the old `Cache` source
 #'     code. This will only be available for a short period before it is deleted
-#'     from the package. See also `reproducible.digestV3`. It is not guaranteed to
+#'     from the package. See also `reproducible.digestVersion`. It is not guaranteed to
 #'     be identical to using a previous version of `reproducible (<3.0)`.
 #'   }
 #'   \item{`useCloud`}{
@@ -353,29 +353,54 @@
 #'     load the cached copy from the repository.
 #'     This may help diagnosing some problems that may occur.
 #'   }
+#'   \item{`digestVersion`}{
+#'     Default: `NULL` (which resolves to `4`). A single integer that selects the
+#'     digest (i.e. `cacheId`) algorithm used by [Cache()]. This is the
+#'     going-forward control; it supersedes the booleans `digestV3` and
+#'     `digestV4` below (which are still honoured when `digestVersion` is unset).
+#'     Higher numbers are newer; each builds on the previous one. (Note: this is
+#'     the *digest-algorithm* version, **not** the version of the `reproducible`
+#'     **package** — although the lower numbers echo the package generation that
+#'     introduced them. References below to e.g. "the `reproducible` package
+#'     v3.x" mean the package release, not this option.) The versions:
+#'     \describe{
+#'       \item{`2`}{*Some of* the hash assembly used by older `reproducible`
+#'         **package** versions (before package v3.0.0), for partial backwards
+#'         compatibility with caches they created. It cannot be made exact for
+#'         all classes, particularly file-backed objects. (Equivalent to the old
+#'         `digestV3 = FALSE`.)}
+#'       \item{`3`}{The hash assembly introduced in the `reproducible` **package**
+#'         v3.x (the default through package v3.1.1): includes the names of list
+#'         elements and several other tweaks. `sf`/`SpatVector` use the original
+#'         (pre-platform-stable) geometry digest, which could differ across
+#'         operating systems. Set `digestVersion = 3` to reproduce the `cacheId`s
+#'         of the `reproducible` package v3.1.1 and earlier, and to avoid the
+#'         one-time cache invalidation described under `4`.}
+#'       \item{`4`}{**Default.** As `3`, but `sf` and `SpatVector` objects are
+#'         digested with a platform-stable algorithm: the geometry is the numeric
+#'         vertex matrix with coordinates rounded to a fixed precision (plus the
+#'         geometry type), and attributes are kept in feature order with columns
+#'         sorted by a locale-independent method. The same vector data then
+#'         produces the same `cacheId` on Windows, macOS and Linux (digest
+#'         version `3` could differ across operating systems, preventing
+#'         shared/cloud caching of these objects), and an `sf` object and its
+#'         `SpatVector` equivalent digest identically. Requires the \pkg{terra}
+#'         package. **NOTE:** because `4` is now the default, the `cacheId` of
+#'         every `sf`/`SpatVector` object differs from that produced by the
+#'         `reproducible` package v3.1.1 and earlier, so cached results that
+#'         involved such objects are *recomputed once* under the new algorithm.
+#'         Set `digestVersion = 3` to avoid this.}
+#'     }
+#'   }
 #'   \item{`digestV3`}{
-#'     Default: `TRUE`. This uses a digest approach that includes the names of
-#'     list elements and several other tweaks that were created for `reproducible 3.x`.
-#'     Set this to `FALSE` to use *some of* the previous cache digesting to
-#'     achieve some backwards compatibility with the digest algorithms of `reproducible (<3.x)`.
-#'     It will not be possible to get it exact for all classes of objects, particularly
-#'     those with file-backing.
+#'     **Superseded by `digestVersion`** (still honoured when `digestVersion` is
+#'     unset). Default: `TRUE`. `TRUE` leaves the version at its default; `FALSE`
+#'     is equivalent to `digestVersion = 2` (see above).
 #'   }
 #'   \item{`digestV4`}{
-#'     Default: `FALSE`. **Opt-in.** When `TRUE`, `sf` and `SpatVector` objects
-#'     are digested with a new, platform-stable algorithm: the geometry is taken
-#'     as the numeric vertex matrix with coordinates rounded to a fixed
-#'     precision (plus the geometry type), and the
-#'     attribute table is sorted, so that the same vector data produces the same
-#'     `cacheId` on Windows, macOS and Linux (the previous algorithm could differ
-#'     across operating systems, preventing shared/cloud caching of these
-#'     objects). With the default (`FALSE`), `SpatVector` digesting is unchanged
-#'     and `sf` digesting is unchanged, so existing caches are **not** affected.
-#'     **NOTE:** turning this `TRUE` changes the `cacheId` of every `sf`/`SpatVector`
-#'     object, so it *invalidates previously cached results* that involved such
-#'     objects — they will be recomputed once under the new algorithm. It is
-#'     opt-in for now while it is validated; it may become the default in a
-#'     future release. Requires the \pkg{terra} package.
+#'     **Superseded by `digestVersion`** (still honoured when `digestVersion` is
+#'     unset). Default: `FALSE`. `TRUE` is equivalent to `digestVersion = 4`,
+#'     which is now also the default (see above).
 #'   }
 #'
 #' }
@@ -463,8 +488,9 @@ reproducibleOptions <- function() {
     reproducible.useMemoise = FALSE, # memoise
     reproducible.useragent = "https://github.com/PredictiveEcology/reproducible",
     reproducible.verbose = 1,
-    reproducible.digestV3 = TRUE,
-    reproducible.digestV4 = FALSE # opt-in platform-stable sf/SpatVector digest; invalidates prior caches when TRUE
+    reproducible.digestVersion = NULL, # NULL => 4; the going-forward digest-algorithm selector
+    reproducible.digestV3 = TRUE,      # superseded by digestVersion (still honoured when it is unset)
+    reproducible.digestV4 = FALSE      # superseded by digestVersion (still honoured when it is unset)
   )
 }
 

--- a/R/robustDigest.R
+++ b/R/robustDigest.R
@@ -183,16 +183,16 @@ setMethod(
       if (!requireNamespace("terra", quietly = TRUE)) {
         stop("Please install terra package")
       }
-      # Opt-in (`reproducible.digestV4`): platform-stable digest. Default path
-      # (`wrapSpatVector`) is unchanged, so existing caches are not invalidated.
-      forDig <- if (isTRUE(getOption("reproducible.digestV4", FALSE))) {
+      # Digest version >= 4: platform-stable digest. Earlier versions keep the
+      # `wrapSpatVector` path, so existing caches are not invalidated by default.
+      forDig <- if (.digestVersion() >= 4L) {
         digestSpatVector(object)
       } else {
         wrapSpatVector(object)
       }
-    } else if (.isSF(object) && isTRUE(getOption("reproducible.digestV4", FALSE))) {
-      # Only opt-in: route `sf` through the same platform-stable algorithm as
-      # `SpatVector`. With `reproducible.digestV4 = FALSE` (default), `sf` falls
+    } else if (.isSF(object) && .digestVersion() >= 4L) {
+      # Digest version >= 4 only: route `sf` through the same platform-stable
+      # algorithm as `SpatVector`. At earlier versions (the default), `sf` falls
       # through to the generic path below, unchanged, so caches are unaffected.
       if (!requireNamespace("terra", quietly = TRUE)) {
         stop("Please install terra package")
@@ -218,7 +218,7 @@ setMethod(
 )
 
 # Platform-stable digest representation of a SpatVector. Used by .robustDigest()
-# when getOption("reproducible.digestV4") is TRUE (opt-in). The previous
+# when the digest version (.digestVersion()) is >= 4. The previous
 # representation (wrapSpatVector()) could digest the same vector to different
 # values on different operating systems, which broke shared/cloud caching of
 # sf/SpatVector objects across machines. This representation is built to be

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -42,6 +42,9 @@
       "Using reproducible version ",
       utils::packageVersion("reproducible"), ".",
       # "\n  'reproducible' has changed the default database backend.", # Not true yet
+      "\n  cacheId digesting now defaults to version 4 (platform-stable sf/SpatVector,",
+      " consistent across operating systems); set options(reproducible.digestVersion = 3)",
+      " for the previous behaviour.",
       " See ?reproducibleOptions for many possible settings.")
   }
 }

--- a/tests/testthat/test-digestV4.R
+++ b/tests/testthat/test-digestV4.R
@@ -1,25 +1,48 @@
-# Tests for the opt-in `reproducible.digestV4` platform-stable digest of
-# sf / SpatVector objects (R/robustDigest.R). The previous algorithm could
-# digest the same vector differently across operating systems, which broke
-# shared/cloud caching of these objects. digestV4 normalizes geometry (rounded
-# numeric vertex matrix) and attributes so the cacheId is identical across OSes.
+# Tests for `reproducible.digestVersion` 4 -- the platform-stable digest of
+# sf / SpatVector objects (R/robustDigest.R) which is now the default. Earlier
+# versions could digest the same vector differently across operating systems,
+# which broke shared/cloud caching of these objects. Version 4 normalizes
+# geometry (rounded numeric vertex matrix) and attributes so the cacheId is
+# identical across OSes. The superseded booleans digestV3/digestV4 still map to
+# versions (see the back-compat test).
 
-test_that("reproducible.digestV4 defaults to FALSE (opt-in)", {
-  expect_false(isTRUE(reproducibleOptions()[["reproducible.digestV4"]]))
+test_that("the digest version defaults to 4", {
+  withr::local_options(reproducible.digestVersion = NULL,
+                       reproducible.digestV3 = TRUE, reproducible.digestV4 = FALSE)
+  expect_identical(reproducible:::.digestVersion(), 4L)
 })
 
-test_that("digestV4 cacheId is identical across operating systems (golden)", {
+test_that("digestVersion supersedes, but still honours, digestV3/digestV4", {
+  # explicit digestVersion wins
+  expect_identical(withr::with_options(list(reproducible.digestVersion = 3),
+                                       reproducible:::.digestVersion()), 3L)
+  expect_identical(withr::with_options(list(reproducible.digestVersion = 2),
+                                       reproducible:::.digestVersion()), 2L)
+  # back-compat: the old booleans set the version when digestVersion is unset
+  expect_identical(withr::with_options(
+    list(reproducible.digestVersion = NULL, reproducible.digestV4 = TRUE),
+    reproducible:::.digestVersion()), 4L)
+  expect_identical(withr::with_options(
+    list(reproducible.digestVersion = NULL, reproducible.digestV3 = FALSE),
+    reproducible:::.digestVersion()), 2L)
+  # new option overrides the old boolean
+  expect_identical(withr::with_options(
+    list(reproducible.digestVersion = 4, reproducible.digestV4 = FALSE),
+    reproducible:::.digestVersion()), 4L)
+})
+
+test_that("digestVersion 4 cacheId is identical across operating systems (golden)", {
   # The cross-OS guarantee, checked automatically by the multi-OS CI matrix
   # (ubuntu / windows / macOS): a fixed input must hash to a fixed value on every
   # OS, so no human has to run it on each OS and compare.
-  #   * fails on ONE OS but passes on others -> digestV4 is NOT platform-stable
+  #   * fails on ONE OS but passes on others -> digestVersion 4 is NOT platform-stable
   #     (a real bug to fix);
   #   * fails on ALL OSes -> the algorithm or terra's geom() output changed;
   #     recompute `golden` below (it is not OS-specific).
   # The accented PolyID (e-acute) stresses the attribute path; the \u escape keeps
   # the source bytes identical on every OS regardless of file encoding.
   skip_if_not_installed("terra")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   golden <- "fee95802937421d3"
   wkt <- "POLYGON ((0 0, 0 1.1234565, 1 1, 1 0, 0 0))"
   v <- terra::vect(wkt)
@@ -32,20 +55,20 @@ test_that("digestV4 cacheId is identical across operating systems (golden)", {
   expect_identical(reproducible:::.robustDigest(s), golden) # sf == SpatVector, every OS
 })
 
-test_that("digestV4 switches the SpatVector algorithm (FALSE = legacy, TRUE = new)", {
+test_that("digestVersion switches the SpatVector algorithm (3 = legacy, 4 = new)", {
   skip_if_not_installed("terra")
   v <- terra::vect("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
   v$id <- "a"
-  d_off <- withr::with_options(list(reproducible.digestV4 = FALSE),
+  d_off <- withr::with_options(list(reproducible.digestVersion = 3),
                                reproducible:::.robustDigest(v))
-  d_on  <- withr::with_options(list(reproducible.digestV4 = TRUE),
+  d_on  <- withr::with_options(list(reproducible.digestVersion = 4),
                                reproducible:::.robustDigest(v))
-  # Distinct algorithms -> distinct cacheId. (FALSE keeps the legacy
-  # wrapSpatVector path, so existing caches are not invalidated by default.)
+  # Distinct algorithms -> distinct cacheId. (Version 3 keeps the legacy
+  # wrapSpatVector path; version 4 uses the platform-stable one.)
   expect_false(identical(d_off, d_on))
 })
 
-test_that("digestV4 = TRUE: sf and the equivalent SpatVector digest identically", {
+test_that("digestVersion = 4: sf and the equivalent SpatVector digest identically", {
   skip_if_not_installed("terra")
   skip_if_not_installed("sf")
   wkt <- "POLYGON ((0 0, 0 1.123456789, 1 1, 1 0, 0 0))"
@@ -53,40 +76,41 @@ test_that("digestV4 = TRUE: sf and the equivalent SpatVector digest identically"
   v$id <- "a"
   v$n <- 3L
   sfobj <- sf::st_as_sf(data.frame(id = "a", n = 3L, g = wkt), wkt = "g")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   expect_identical(reproducible:::.robustDigest(v), reproducible:::.robustDigest(sfobj))
 })
 
-test_that("digestV4 = TRUE normalizes sub-precision coordinate differences", {
+test_that("digestVersion = 4 normalizes sub-precision coordinate differences", {
   skip_if_not_installed("terra")
   # Differ only in the 7th decimal -> rounded to 6 -> identical digest.
   v1 <- terra::vect("POLYGON ((0 0, 0 1.1234561, 1 1, 1 0, 0 0))")
   v2 <- terra::vect("POLYGON ((0 0, 0 1.1234562, 1 1, 1 0, 0 0))")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   expect_identical(reproducible:::.robustDigest(v1), reproducible:::.robustDigest(v2))
   # Genuinely different geometry must still differ.
   v3 <- terra::vect("POLYGON ((0 0, 0 2, 1 1, 1 0, 0 0))")
   expect_false(identical(reproducible:::.robustDigest(v1), reproducible:::.robustDigest(v3)))
 })
 
-test_that("digestV4 = FALSE leaves sf on the generic (unchanged) path", {
+test_that("digestVersion = 3 leaves sf on the generic (unchanged) path", {
   skip_if_not_installed("terra")
   skip_if_not_installed("sf")
   sfobj <- sf::st_as_sf(data.frame(id = "a", g = "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))"),
                         wkt = "g")
-  d_off <- withr::with_options(list(reproducible.digestV4 = FALSE),
+  d_off <- withr::with_options(list(reproducible.digestVersion = 3),
                                reproducible:::.robustDigest(sfobj))
-  d_on  <- withr::with_options(list(reproducible.digestV4 = TRUE),
+  d_on  <- withr::with_options(list(reproducible.digestVersion = 4),
                                reproducible:::.robustDigest(sfobj))
-  # The opt-in path produces a different digest than the default generic path.
+  # Version 3 leaves sf on the generic path; version 4 digests it via the
+  # SpatVector path -> different digest.
   expect_false(identical(d_off, d_on))
 })
 
-test_that("digestV4 = TRUE keeps attributes bound to their geometry", {
+test_that("digestVersion = 4 keeps attributes bound to their geometry", {
   # Property check: swapping which feature carries which attribute changes the
   # digest (attributes are not sorted independently of the geometry).
   skip_if_not_installed("terra")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   gA <- "POLYGON ((0 0, 0 1, 1 1, 0 0))"
   gB <- "POLYGON ((2 2, 2 3, 3 3, 2 2))"
   v1 <- terra::vect(c(gA, gB)); v1$id <- c("x", "y")
@@ -95,16 +119,16 @@ test_that("digestV4 = TRUE keeps attributes bound to their geometry", {
                          reproducible:::.robustDigest(v2)))
 })
 
-test_that("digestV4 attribute digest is invariant to LC_COLLATE (cross-OS proxy)", {
+test_that("digestVersion 4 attribute digest is invariant to LC_COLLATE (cross-OS proxy)", {
   # The earlier algorithm sorted attribute rows by order(do.call(paste, attrs)),
   # which uses LC_COLLATE -- so accented attribute text ordered (and therefore
-  # digested) differently across OS locales: a cross-OS difference. digestV4
+  # digested) differently across OS locales: a cross-OS difference. version 4
   # leaves rows in feature order, so the digest is collation-invariant. This
   # reproduces the cross-OS condition on a single machine by switching
   # LC_COLLATE (and fails under the old row-sort). It skips where two locales
   # that reorder accented text are not available (e.g. some CI images).
   skip_if_not_installed("terra")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   orig <- Sys.getlocale("LC_COLLATE")
   withr::defer(suppressWarnings(Sys.setlocale("LC_COLLATE", orig)))
   ids <- c("z", "\u00e9", "a") # accented (e-acute) -> collation-sensitive; \u keeps bytes portable
@@ -127,11 +151,11 @@ test_that("digestV4 attribute digest is invariant to LC_COLLATE (cross-OS proxy)
   expect_equal(length(unique(digs)), 1L) # identical under every locale
 })
 
-test_that("digestV4 = TRUE distinguishes geometry type (polygon vs line) with same vertices", {
+test_that("digestVersion = 4 distinguishes geometry type (polygon vs line) with same vertices", {
   skip_if_not_installed("terra")
   poly <- terra::vect("POLYGON ((0 0, 0 1, 1 1, 0 0))")
   line <- terra::vect("LINESTRING (0 0, 0 1, 1 1, 0 0)")
-  withr::local_options(reproducible.digestV4 = TRUE)
+  withr::local_options(reproducible.digestVersion = 4)
   expect_false(identical(reproducible:::.robustDigest(poly),
                          reproducible:::.robustDigest(line)))
 })


### PR DESCRIPTION
## What

Introduces a single integer option **`reproducible.digestVersion`** that selects the `cacheId` (digest) algorithm, replacing the per-version booleans `reproducible.digestV3` / `reproducible.digestV4`, and makes **version 4 the default** (the platform-stable `sf`/`SpatVector` digest from #496, previously opt-in).

Follow-up to #496 (now merged), per request: a clean going-forward selector instead of a growing set of `digestVN` booleans, with 4 as the default ("if a user doesn't want it, set 3").

## Behaviour

`.digestVersion()` resolves the effective version:
1. explicit `reproducible.digestVersion`, if set;
2. else derived from the **still-honoured** booleans (`digestV4 = TRUE` → 4; `digestV3 = FALSE` → 2);
3. else the default, **4**.

Switch points read `.digestVersion() >= 3` (reproducible-3.x hash assembly) and `>= 4` (platform-stable `sf`/`SpatVector`). The versions:
- **2** — partial back-compat with pre-3.0.0 package digests (= old `digestV3 = FALSE`);
- **3** — the reproducible-package-v3.x hash assembly; `sf`/`SpatVector` use the original (OS-dependent) geometry digest;
- **4** (default) — platform-stable `sf`/`SpatVector` geometry (rounded numeric vertex matrix + type; locale-independent attribute handling); identical `cacheId` across Windows/macOS/Linux, and `sf` == its `SpatVector` equivalent.

The old booleans are **soft-deprecated**: kept working (back-compat resolver), documented as superseded — no runtime deprecation message (to avoid noise).

## Cache impact (intentional)

Because **4 is now the default**, the `cacheId` of every `sf`/`SpatVector` object differs from the `reproducible` package v3.1.1 and earlier → those cached results are recomputed **once**. `options(reproducible.digestVersion = 3)` restores the previous behaviour. This is flagged in:
- the **startup message** (brief);
- `NEWS.md`;
- `?reproducibleOptions` (the `digestVersion` entry documents every version — and clarifies the integer is the *digest-algorithm* version, **not** the `reproducible` package version);
- `?Cache` (references the option).

## Tests

- the digest version **defaults to 4**;
- resolver precedence + **back-compat** (`digestV4 = TRUE` → 4, `digestV3 = FALSE` → 2, explicit `digestVersion` overrides the booleans);
- all existing version-4 behaviour (golden cross-OS in the CI matrix, `sf` == `SpatVector`, `LC_COLLATE` invariance, sub-precision, geometry-type, edge cases).

All pass locally (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)