### PR TITLE
fix(download): parallel only for redirected URLs; fast fallback on concurrency cap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-05
-Version: 3.1.1.9043
+Version: 3.1.1.9044
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,20 @@
 
 ## bug fixes
 
+* Parallel ranged downloads are now used **only for URLs that the
+  `reproducible.urlRemap` hook actually redirected** to a mirror, matching the
+  documented intent. Previously, once a remap hook was set, the parallel path
+  engaged for *any* range-capable URL — including direct origin servers that
+  were never redirected. Some such servers (e.g. `opendata.nfis.org`) cap
+  concurrent connections per IP, so most of the parallel streams stalled with 0
+  bytes and timed out, making the download far slower than a single stream before
+  eventually falling back. Two changes: (1) a non-redirected URL now downloads
+  single-stream directly; (2) a redirected mirror that nonetheless caps
+  concurrency is detected on the *first* attempt and falls back to a single
+  stream immediately instead of grinding through every retry. The new threshold
+  for (2) is `reproducible.parallel.minConcurrentFrac` (default `0.25`; `0`
+  disables it).
+
 * Cloud caching no longer silently invents a Google Drive folder when none is
   specified. Previously, `Cache(useCloud = TRUE)` with no `cloudFolderID` (and
   no `options(reproducible.cloudFolderID)`) **derived a folder name from the

--- a/R/download.R
+++ b/R/download.R
@@ -695,24 +695,33 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   }
 
   haveTarget <- !is.null(targetFile) && length(targetFile) == 1 && nzchar(targetFile)
+  # `wasRemapped` records whether this URL came from the `reproducible.urlRemap`
+  # hook -- either remapped here, or handed in already-remapped via
+  # `applyRemap = FALSE` (the only such caller is the Google Drive path recursing
+  # with its mirror URL). The parallel ranged path is used ONLY for remapped
+  # (mirror) URLs, never for an arbitrary range-capable origin server: such a
+  # server may cap concurrent connections per IP, in which case parallel streams
+  # all stall and the download is far slower than a single stream.
+  wasRemapped <- !isTRUE(applyRemap)
   if (isTRUE(applyRemap)) {
     filename <- if (haveTarget) basename2(targetFile) else basename2(url)
-    url <- .applyUrlRemap(url, filename, verbose = verbose)
+    remappedUrl <- .applyUrlRemap(url, filename, verbose = verbose)
+    wasRemapped <- !identical(remappedUrl, url)
+    url <- remappedUrl
   }
 
   bn <- if (haveTarget) basename2(targetFile) else basename2(url)
   bn <- gsub("\\?|\\&", "_", bn) # causes errors with ? and maybe &
   destFile <- file.path(destinationPath, bn)
 
-  # Feature A: parallel ranged download. Gated on the opt-in
-  # `reproducible.urlRemap` being set (no remap set => never parallel, even at
-  # streams = 48). When opted in, this engages if the server advertises
+  # Feature A: parallel ranged download. Used ONLY for URLs that the
+  # `reproducible.urlRemap` hook redirected to a (Range-capable) mirror -- see
+  # `wasRemapped` above. When eligible, it engages if the server advertises
   # `Accept-Ranges: bytes` and the file exceeds the threshold; it can be forced
-  # off with `reproducible.parallel.streams = 1L`. Any failure falls through to
-  # the single-stream path below, which is byte-for-byte unchanged. The assembled
-  # file is byte-identical to a single-stream download, so checksums are
-  # unaffected.
-  pp <- .useParallelDownload(url, verbose = verbose)
+  # off with `reproducible.parallel.streams = 1L`. Any failure (including a mirror
+  # that turns out to cap concurrency) falls through to the single-stream path
+  # below, which is byte-for-byte unchanged, so checksums are unaffected.
+  pp <- if (isTRUE(wasRemapped)) .useParallelDownload(url, verbose = verbose) else list(use = FALSE, info = NULL)
   if (isTRUE(pp$use)) {
     streams <- as.integer(getOption("reproducible.parallel.streams", 48L))
     messagePreProcess("Downloading ", url, " using ", streams,
@@ -1053,12 +1062,25 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   showProgress <- verbose > 0 && interactive()
   todo <- seq_len(nParts)
   maxAttempts <- 3L
+  # If the FIRST concurrent attempt completes fewer than this fraction of parts,
+  # the (mirror) server is not honouring the requested concurrency -- e.g. it
+  # caps connections per IP, so most parts stall with 0 bytes and burn the
+  # connect timeout. Retrying is then futile and slow, so bail out immediately
+  # and let the caller fall back to a single stream.
+  minConcurrentFrac <- getOption("reproducible.parallel.minConcurrentFrac", 0.25)
   for (attempt in seq_len(maxAttempts)) {
     unlink(partFiles[todo]) # clear any partial bytes before (re)fetching
     okPart[todo] <- FALSE
     fetchParts(todo, showProgress = isTRUE(showProgress) && attempt == 1L)
     todo <- badParts()
     if (!length(todo)) break
+    if (attempt == 1L && (nParts - length(todo)) < ceiling(nParts * minConcurrentFrac)) {
+      messagePreProcess("Only ", nParts - length(todo), " of ", nParts,
+                        " parts completed concurrently (reason(s): ", reasonSummary(todo),
+                        "); the server appears to limit concurrent connections. ",
+                        "Falling back to single stream.", verbose = verbose)
+      return(FALSE)
+    }
     if (attempt < maxAttempts) {
       messagePreProcess("Retrying ", length(todo), " incomplete download part(s) (attempt ",
                         attempt + 1L, " of ", maxAttempts, "); reason(s): ",

--- a/R/options.R
+++ b/R/options.R
@@ -176,11 +176,18 @@
 #'     large HTTPS file is split into. **This has no effect unless you have opted
 #'     in by setting `reproducible.urlRemap`** (see below): if no remap is set,
 #'     downloads are always single-stream, regardless of this value. Once opted
-#'     in, a download that gets redirected to a Range-capable mirror is split
-#'     into this many parts — but only when the server advertises
-#'     `Accept-Ranges: bytes` and the file is larger than
+#'     in, the parallel path is used **only for a URL that the `urlRemap` hook
+#'     actually redirected** to a (Range-capable) mirror — *not* for arbitrary
+#'     range-capable origin servers reached without a redirect, since those may
+#'     cap concurrent connections per IP (in which case parallel streams all
+#'     stall and the download is slower than a single stream). For an eligible,
+#'     redirected URL the file is split into this many parts — but only when the
+#'     server advertises `Accept-Ranges: bytes` and the file is larger than
 #'     `reproducible.parallel.threshold`; otherwise, and on any failure, it
-#'     falls back transparently to a single stream. Splitting into many small
+#'     falls back transparently to a single stream. (A redirected mirror that
+#'     *does* turn out to cap concurrency is detected on the first attempt — see
+#'     `reproducible.parallel.minConcurrentFrac` — and also falls back.)
+#'     Splitting into many small
 #'     parts keeps retries cheap (a dropped connection costs only one
 #'     part re-fetch). The number that download *at once* is separately capped by
 #'     `reproducible.parallel.maxConnections`. Especially useful on networks that
@@ -206,6 +213,14 @@
 #'     overall download timeout, which may be hours): a short, dedicated cap so a
 #'     stalled handshake fails its own part quickly and is retried rather than
 #'     hanging.
+#'   }
+#'   \item{`parallel.minConcurrentFrac`}{
+#'     Default: `0.25`. A guard against a redirected mirror that advertises Range
+#'     support but actually caps concurrent connections per IP. If the *first*
+#'     concurrent attempt completes fewer than this fraction of the parts (most
+#'     having stalled at 0 bytes), the parallel path gives up immediately and
+#'     falls back to a single stream, instead of grinding through every retry.
+#'     Set to `0` to disable the early fallback.
 #'   }
 #'   \item{`parallel.threshold`}{
 #'     Default: `10 * 1024^2` (10 MiB), in bytes. Files at or below this size are
@@ -457,7 +472,8 @@ reproducibleOptions <- function() {
     reproducible.overwrite = FALSE,
     reproducible.parallel.connecttimeout = 30L,     # seconds; per-connection establishment timeout for ranged streams
     reproducible.parallel.maxConnections = NULL,    # max simultaneous connections; NULL => parallelly::availableCores() - 1
-    reproducible.parallel.streams = 48L,            # number of ranged parts; opt-in is via urlRemap
+    reproducible.parallel.minConcurrentFrac = 0.25, # fall back to single stream if 1st attempt completes < this frac of parts
+    reproducible.parallel.streams = 48L,            # number of ranged parts; used only for urlRemap-redirected URLs
     reproducible.parallel.threshold = 10 * 1024^2,  # bytes; only files larger use the parallel path
     reproducible.quick = FALSE,
     reproducible.rasterRead = getEnv("R_REPRODUCIBLE_RASTER_READ",

--- a/tests/testthat/test-parallel-download-remap.R
+++ b/tests/testthat/test-parallel-download-remap.R
@@ -141,9 +141,15 @@ test_that(".remapUrlEarly resolves a Drive URL's filename then remaps to a mirro
 # Feature A: opt-in gating policy (.useParallelDownload) -- all offline
 # ---------------------------------------------------------------------------
 
-# A remap function that observes nothing -- just marks the opt-in as "set" so
-# the parallel gate is reachable. (Returning NULL means "don't actually redirect".)
+# A remap function that observes nothing -- just marks the opt-in as "set".
+# Returning NULL means "don't actually redirect", so the parallel path is NOT
+# used for that URL (parallel is only for URLs the hook redirects to a mirror).
 optedIn <- function(url, filename) NULL
+
+# A remap function that DOES redirect to a (non-resolvable) mirror, so the
+# parallel path is eligible. ".invalid" is a reserved TLD -> any single-stream
+# fallback fails deterministically without touching the network.
+redirected <- function(url, filename) paste0("http://mirror.invalid/", filename)
 
 test_that("parallel path is GATED OFF when urlRemap is unset, even at streams = 48", {
   withr::local_options(
@@ -270,8 +276,9 @@ test_that(".parallelRangedDownload reports failure reasons and returns FALSE whe
     reproducible.parallel.maxConnections = 2L
   )
   # Non-routable port -> every ranged part fails at connection time. The reason
-  # must be surfaced (not silently swallowed) and the function must return FALSE
-  # so the caller can fall back to a single stream.
+  # must be surfaced (not silently swallowed), and because the *first* attempt
+  # completes 0 parts the function must fast-fall-back (without grinding through
+  # all retries) and return FALSE so the caller can use a single stream.
   msgs <- testthat::capture_messages(
     ok <- reproducible:::.parallelRangedDownload(
       "http://127.0.0.1:1/nope.bin", dest, size = 3000, n = 3L, verbose = 1)
@@ -279,7 +286,9 @@ test_that(".parallelRangedDownload reports failure reasons and returns FALSE whe
   expect_false(ok)
   joined <- paste(msgs, collapse = "\n")
   expect_match(joined, "reason\\(s\\)")
+  expect_match(joined, "limit concurrent connections") # fast fallback on attempt 1
   expect_match(joined, "Falling back to single stream")
+  expect_false(grepl("attempt 3 of 3", joined)) # did NOT grind through all retries
   expect_false(file.exists(dest)) # nothing assembled on failure
 })
 
@@ -287,13 +296,13 @@ test_that(".parallelRangedDownload reports failure reasons and returns FALSE whe
 # Feature A: dlGeneric dispatch -- offline via mocking of the mechanism
 # ---------------------------------------------------------------------------
 
-test_that("dlGeneric takes the parallel path and returns its file when opted in", {
+test_that("dlGeneric takes the parallel path when the URL was redirected by the remap", {
   skip_if_not_installed("curl")
   skip_if_not_installed("httr2")
   withr::local_options(
     reproducible.parallel.streams = 8L,
     reproducible.parallel.threshold = 1L,
-    reproducible.urlRemap = optedIn # opt-in set (no actual redirect)
+    reproducible.urlRemap = redirected # hook redirects -> parallel eligible
   )
   dp <- withr::local_tempdir()
   called <- FALSE
@@ -311,13 +320,39 @@ test_that("dlGeneric takes the parallel path and returns its file when opted in"
   expect_identical(basename(res$destFile), "big.tif")
 })
 
+test_that("dlGeneric does NOT use the parallel path when the URL was not redirected", {
+  skip_if_not_installed("curl")
+  skip_if_not_installed("httr2")
+  withr::local_options(
+    reproducible.parallel.streams = 8L,
+    reproducible.parallel.threshold = 1L,
+    reproducible.urlRemap = optedIn # opt-in set, but returns NULL (no redirect)
+  )
+  dp <- withr::local_tempdir()
+  called <- FALSE
+  testthat::local_mocked_bindings(
+    .probeRange = function(...) list(size = 1e6, acceptRanges = TRUE),
+    .parallelRangedDownload = function(url, destFile, size, n, verbose) {
+      called <<- TRUE
+      TRUE
+    }
+  )
+  # Not redirected -> parallel must be skipped; the single-stream path then errors
+  # on the non-routable host. The point is that .parallelRangedDownload is never
+  # reached for an origin server the user did not redirect.
+  try(suppressWarnings(
+    reproducible:::dlGeneric("http://127.0.0.1:1/big.tif", destinationPath = dp, verbose = 0)
+  ), silent = TRUE)
+  expect_false(called)
+})
+
 test_that("dlGeneric falls back to single-stream when the parallel attempt fails", {
   skip_if_not_installed("curl")
   skip_if_not_installed("httr2")
   withr::local_options(
     reproducible.parallel.streams = 8L,
     reproducible.parallel.threshold = 1L,
-    reproducible.urlRemap = optedIn # opt-in set (no actual redirect)
+    reproducible.urlRemap = redirected # redirects -> parallel eligible
   )
   dp <- withr::local_tempdir()
   called <- FALSE
@@ -328,11 +363,11 @@ test_that("dlGeneric falls back to single-stream when the parallel attempt fails
       FALSE # simulate a partial failure -> caller must fall back
     }
   )
-  # The fallback single-stream then targets a non-routable address and errors;
-  # the point is that control proceeded PAST the parallel block (no early return).
+  # The fallback single-stream then targets the (non-resolvable) mirror and
+  # errors; the point is that control proceeded PAST the parallel block.
   expect_error(
     suppressWarnings(
-      reproducible:::dlGeneric("http://127.0.0.1:1/big.tif", destinationPath = dp, verbose = 0)
+      reproducible:::dlGeneric("http://x/big.tif", destinationPath = dp, verbose = 0)
     )
   )
   expect_true(called)


### PR DESCRIPTION
## Problem

"`reproducible.parallel.streams` not working on Windows." The diagnostic added in #494 finally shows the cause — and it's **not Windows or reproducible**:

```
Downloading https://opendata.nfis.org/.../CA_forest_VLCE2_2020.zip using 48 ranged parts (capped at 31 concurrent connections) ...
  30.5 Mb of 1.4 Gb via 31 concurrent ranged streams | elapsed: 35s | ETA: 27m46s
Retrying 47 incomplete download part(s) (attempt 2 of 3); reason(s): Timeout was reached ...
  Operation timed out after 30000 milliseconds with 0 bytes received (x47)
```

`opendata.nfis.org` **caps concurrent connections per IP**: ~1 of the 31 streams gets served, the other 30 stall with **0 bytes** and each burns the full 30 s connect timeout, then the retry loop grinds through 3 attempts (~3 min) before falling back. (The 5 "Failed writing … to disk" errors were a secondary Windows file-write hiccup, only in the late attempts.)

The deeper issue: `.useParallelDownload`'s own comment says parallel "exists ONLY to accelerate downloads that the user has redirected to a Range-capable mirror" — but the code engaged for **any** range-capable URL once `urlRemap` was set, including `opendata.nfis.org`, which the user's remap never redirected.

## Fixes (both, per request)

1. **Only-remap gating.** `dlGeneric` now tracks `wasRemapped` and uses the parallel path **only for URLs the `urlRemap` hook actually redirected** to a mirror. A non-redirected origin server downloads single-stream directly. (`applyRemap = FALSE` — the sole such caller is the Google-Drive→mirror recursion — counts as already-redirected.)

2. **Fast fallback.** If the **first** concurrent attempt completes fewer than `reproducible.parallel.minConcurrentFrac` (default **0.25**) of the parts — i.e. a *redirected mirror* that nonetheless caps concurrency — the parallel path gives up immediately and falls back to a single stream, instead of grinding through every retry. This also sidesteps the late-attempt disk-write errors. Set the option to `0` to disable.

## Tests

- parallel **engages** for a redirected URL;
- parallel is **skipped** for a non-redirected URL (single-stream; `.parallelRangedDownload` never reached);
- `.parallelRangedDownload` **fast-falls-back** when the first attempt completes no parts (asserts the "limit concurrent connections" message and that it did *not* reach "attempt 3 of 3");
- existing offline/gating/network tests updated. All pass locally.

Docs updated: `parallel.streams` (now explicit that it's only for redirected URLs) and the new `parallel.minConcurrentFrac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)