### PR TITLE
fix(digest): realize deferred-string ALTREP in .robustDigest (v4) for cross-platform cacheId

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-05
-Version: 3.1.1.9043
+Version: 3.1.1.9044
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,16 @@
   avoid that one-time invalidation. Requires the \pkg{terra} package. See the
   `digestVersion` entry in `?reproducibleOptions` for the full list of versions.
 
+* Digest version 4 also realizes "deferred-string" ALTREP character vectors before
+  hashing, so character content digests identically regardless of its internal
+  representation. A deferred string (e.g. produced by `rbind`-ing many data.frames,
+  `as.character()` of a factor, etc.) serializes differently from its realized form
+  — and differently across R versions/platforms — which could give the same
+  character content a different `cacheId` on, e.g., Linux vs Windows (seen as a
+  module's parameter table splitting the `.inputObjects` `cacheId`). The
+  realization is a no-op for already-materialized vectors, so existing `cacheId`s
+  are unchanged.
+
 * Downloads can now be transparently redirected to faster mirrors and
   fetched in parallel. Two cooperating, opt-in features:
   * **URL remap hook** — a new option `reproducible.urlRemap` accepts a

--- a/R/robustDigest.R
+++ b/R/robustDigest.R
@@ -308,6 +308,17 @@ setMethod(
   definition = function(object, .objects, length, algo, quick, classOptions) {
     object <- .removeCacheAtts(object)
 
+    # Realize a deferred-string ALTREP so it digests identically to its
+    # materialized form. A "deferred string" (e.g. produced by rbind of many
+    # data.frames, as.character of a factor, etc.) serializes differently from a
+    # plain STRSXP -- and differently across R versions/platforms -- so the same
+    # character content can yield different cacheIds on, say, Linux vs Windows.
+    # `object[]` realizes it; it is a no-op for an already-materialized vector
+    # (identical content/serialization, names preserved), so existing cacheIds are
+    # unchanged for non-ALTREP data. Gated to the platform-stable digest version,
+    # consistent with the sf/SpatVector treatment.
+    if (.digestVersion() >= 4L) object <- object[]
+
     simpleDigest <- TRUE # default -- only as character vector
     if (inherits(object, "fs_path")) {
       return(.robustDigest(asPath(object)))

--- a/tests/testthat/test-robustDigest.R
+++ b/tests/testthat/test-robustDigest.R
@@ -51,3 +51,20 @@ test_that("test ALTREP integers", {
 
   }
 })
+
+test_that(".robustDigest realizes deferred-string ALTREP for a stable cross-platform digest (v4)", {
+  withr::local_options(reproducible.digestVersion = 4L)
+  ## A character vector must digest identically whether it is a plain STRSXP or a
+  ## deferred-string ALTREP. A deferred string serializes differently from its
+  ## realized form -- and differently across R versions/platforms -- which is what
+  ## split .inputObjects cacheIds between Linux and Windows. The fix realizes it via
+  ## `object[]`; it is a no-op for an already-materialized vector (so existing
+  ## cacheIds are unchanged). On platforms that don't create the ALTREP these are
+  ## already identical; the invariant must hold everywhere.
+  x <- c("alpha", ".useCache", "beta", "gamma")
+  expect_identical(.robustDigest(x), .robustDigest(x[]))
+  ## same content nested in a data.frame column (the parameter-table path)
+  df1 <- data.frame(p = x, stringsAsFactors = FALSE)
+  df2 <- df1; df2$p <- df2$p[]
+  expect_identical(.robustDigest(df1), .robustDigest(df2))
+})


### PR DESCRIPTION
## Problem
A **deferred-string ALTREP** (produced by e.g. `rbind`-ing many data.frames, or `as.character()` of a factor) serializes differently from its realized `STRSXP` — and differently across R versions/platforms. So identical character content can produce a **different `cacheId` on Linux vs Windows**.

Found while chasing a `SpaDES.core` module whose `.inputObjects` cacheId differed across OS. Intercepting `CacheDigest`'s `preDigest`, the only differing key was the module's parameter-definition table. Drilling in:

```r
digest::digest(p$paramName)        # differs across OS
digest::digest(p$paramName[1:32])  # identical across OS  (the materialized form)
attributes(p$paramName)            # NULL on both -> not an attribute
lapply(p, \(x) x[])                # materializing makes ALL columns digest identically
```

i.e. the column was a deferred-string ALTREP on one machine and a plain `STRSXP` on the other.

## Fix
The `character` `.robustDigest` method now realizes the vector with `object[]` before hashing, gated to the platform-stable digest version (`>= 4`), consistent with the `sf`/`SpatVector` treatment. Because the method is reached recursively, this also stabilizes strings nested inside list-columns (a parameters table's `default`/`min`/`max`).

## Safety / no invalidation
`object[]` is a **no-op for already-materialized vectors** (identical content + serialization, names preserved), so existing `cacheId`s are unchanged for non-ALTREP data. Confirmed: `test-robustDigest` (6), `test-cache` (304), `test-digestV4` (18), `test-cacheHelpers` (43) all pass unchanged. Only character columns are touched (compact integer/numeric ALTREPs are left alone, so they aren't force-expanded).

## Test
`test-robustDigest.R`: a character vector digests identically to its materialized form under v4, including nested in a data.frame column. (The discriminating ALTREP case is platform/R-version-specific and not reproducible on the CI runner; validated on the reporting user's Windows machine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)