### PR TITLE
fix(download): short connect timeout for single-stream download (was up to 3.3h)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-08
-Version: 3.1.1.9045
+Version: 3.1.1.9046
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -124,6 +124,17 @@
 
 ## bug fixes
 
+* The **single-stream `preProcess`/`prepInputs` download no longer hangs for
+  hours on a slow or flaky connection**. It was setting curl's `connecttimeout`
+  (the cap on *establishing* a connection) to `reproducible.timeout` — the
+  overall download budget, which defaults to `12000` seconds (3.3 h). A stalled
+  TLS handshake (e.g. a transient `SSL_connect` failure to `opendata.nfis.org`)
+  therefore froze the session for many minutes before erroring. The connect
+  timeout is now a short, dedicated cap, new option `reproducible.connecttimeout`
+  (default `30L` seconds), mirroring `reproducible.parallel.connecttimeout` for
+  the parallel ranged path; `reproducible.timeout` still governs the overall
+  download.
+
 * Parallel ranged downloads are now used **only for URLs that the
   `reproducible.urlRemap` hook actually redirected** to a mirror, matching the
   documented intent. Previously, once a remap hook was set, the parallel path

--- a/R/download.R
+++ b/R/download.R
@@ -752,9 +752,18 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   if (.requireNamespace("httr2") && .requireNamespace("curl")) {
     for (i in 1:2) {
       totalTimeout <- getOption("reproducible.timeout", 12000)
+      # `connecttimeout` is the cap on *establishing* the connection (TLS
+      # handshake etc.), NOT the overall download time. It must stay short so a
+      # stalled/flaky handshake fails quickly and gets retried, instead of hanging
+      # for the full `reproducible.timeout` (which can be hours -- a slow/failing
+      # SSL connect was freezing sessions for many minutes). Mirrors the parallel
+      # path's `reproducible.parallel.connecttimeout`. The overall request timeout
+      # (`req_timeout`) stays at `totalTimeout`.
       req <- httr2::request(url) |>
         httr2::req_timeout(totalTimeout) |>
-        httr2::req_options(connecttimeout = totalTimeout)
+        httr2::req_options(
+          connecttimeout = as.integer(getOption("reproducible.connecttimeout", 30L))[1]
+        )
       if (i == 1) # only try on first run through, in case this is the cause of failure; which it is on some sites
         req <- req |> httr2::req_user_agent(getOption("reproducible.useragent"))
       if (verbose > 0) {

--- a/R/options.R
+++ b/R/options.R
@@ -259,6 +259,14 @@
 #'     behaviour will return, where it tries to guess whether a character vector
 #'     is filenames or not, and if it is, then digest the file content.
 #'   }
+#'   \item{`connecttimeout`}{
+#'     Default: `30L`, in seconds. The per-connection establishment (TLS
+#'     handshake) timeout for the single-stream download in `preProcess`. This is
+#'     distinct from `reproducible.timeout` (the overall download budget, which
+#'     may be hours): a short, dedicated cap so a stalled or flaky connect fails
+#'     quickly and is retried rather than hanging for the full timeout. Mirrors
+#'     `reproducible.parallel.connecttimeout` for the parallel ranged path.
+#'   }
 #'   \item{`timeout`}{
 #'     Default `12000`. Used in `preProcess` when downloading occurs. If a user has `R.utils`
 #'     package installed, `R.utils::withTimeout(  , timeout = getOption("reproducible.timeout"))`
@@ -447,6 +455,7 @@ reproducibleOptions <- function() {
     reproducible.cachePath = NULL,
     reproducible.cacheSaveFormat = .rdsFormat,
     reproducible.cacheSpeed = "slow",
+    reproducible.connecttimeout = 30L,              # seconds; single-stream connect/handshake cap (NOT the overall download timeout)
     reproducible.conn = NULL,
     reproducible.destinationPath = NULL,
     reproducible.drv = NULL, # RSQLite::SQLite(),

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -268,6 +268,14 @@ either \code{asPath} or \code{fs::as_fs_path}. Or set this option to \code{TRUE}
 behaviour will return, where it tries to guess whether a character vector
 is filenames or not, and if it is, then digest the file content.
 }
+\item{\code{connecttimeout}}{
+Default: \code{30L}, in seconds. The per-connection establishment (TLS
+handshake) timeout for the single-stream download in \code{preProcess}. This is
+distinct from \code{reproducible.timeout} (the overall download budget, which
+may be hours): a short, dedicated cap so a stalled or flaky connect fails
+quickly and is retried rather than hanging for the full timeout. Mirrors
+\code{reproducible.parallel.connecttimeout} for the parallel ranged path.
+}
 \item{\code{timeout}}{
 Default \code{12000}. Used in \code{preProcess} when downloading occurs. If a user has \code{R.utils}
 package installed, \code{R.utils::withTimeout(  , timeout = getOption("reproducible.timeout"))}


### PR DESCRIPTION
## Problem

A single-stream `preProcess()`/`prepInputs()` download could **hang for many minutes** (observed ~17 min, and apparent full freezes on Windows) on a slow or flaky connection. Example from a user log:

```
09:22:06 Downloading https://opendata.nfis.org/.../CA_FAO_forest_2019.zip ...
   <~17 minutes of nothing>
Error ... curl::curl_fetch_disk(): SSL connect error ... SSL_connect: SSL_ERROR_SYSCALL
```

## Cause

The single-stream httr2 path set curl's **`connecttimeout`** — the cap on *establishing* a connection (TLS handshake) — to `reproducible.timeout`, which is the **overall download budget** and defaults to **12000 s (3.3 h)**:

```r
# R/download.R (before)
totalTimeout <- getOption("reproducible.timeout", 12000)
req <- httr2::request(url) |>
  httr2::req_timeout(totalTimeout) |>
  httr2::req_options(connecttimeout = totalTimeout)   # <- 3.3h to give up on a handshake
```

So a stalled/flaky connect blocked for up to 3.3 h before failing. The **parallel ranged path already got this right** (`reproducible.parallel.connecttimeout`, 30 s, with a comment explaining the distinction); the single-stream path was just never updated.

## Fix

Give the connect its own short, dedicated cap via a new option **`reproducible.connecttimeout`** (default **30 s**):

```r
httr2::req_options(
  connecttimeout = as.integer(getOption("reproducible.connecttimeout", 30L))[1]
)
```

`req_timeout(totalTimeout)` still governs the overall download, so legitimate large/slow downloads are unaffected — only a stalled handshake now fails fast (~30 s) and is retried instead of hanging.

Documents the new option (`reproducibleOptions` + `.Rd`), registers its default, adds a NEWS entry, bumps version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)