### PR TITLE
fix(cloud): never abort a run when cloud upload finds missing predicted files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-08
-Version: 3.1.1.9046
+Version: 3.1.1.9047
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,6 +133,16 @@
 
 ## bug fixes
 
+* **A best-effort cloud cache upload no longer aborts the run.** When caching an
+  object whose stored form does not include every file `CacheStoredFile()`
+  predicts from `Filenames()` (e.g. a cached `simList` that *references* its
+  `SpatRaster` backends rather than copying them under the `cacheId`),
+  `cloudUploadFromCache()` previously `stop()`ed with "File(s) to upload are not
+  available" -- crashing a long, already-locally-saved run during the upload
+  step. It now uploads the files that are present, warns about any it skips, and
+  never errors (the local cache is intact regardless).
+
+
 * The **single-stream `preProcess`/`prepInputs` download no longer hangs for
   hours on a slow or flaky connection**. It was setting curl's `connecttimeout`
   (the cap on *establishing* a connection) to `reproducible.timeout` — the

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -372,7 +372,25 @@ cloudUploadFromCache <- function(isInCloud, outputHash, cachePath, cloudFolderID
     } else {
       cacheDB <- CacheDBFileSingle(cachePath, outputHash)
     }
-    if (all(file.exists(cacheIdFileName))) {
+    # Only upload the cache files that are actually on disk. CacheStoredFile(...,
+    # "check", obj = ) *predicts* extra file-backed sidecars from Filenames(obj)
+    # (e.g. SpatRaster backends of a cached simList), but those are not always
+    # written under the cacheId in the cache folder -- a cached simList commonly
+    # *references* its rasters at their existing locations rather than copying
+    # them. Previously a single predicted-but-absent file made this stop() and
+    # abort the whole (already locally-saved) run. Cloud upload is best-effort:
+    # upload what exists, warn about the rest, and never crash the caller.
+    filesExist <- file.exists(cacheIdFileName)
+    if (any(filesExist)) {
+      if (!all(filesExist)) {
+        messageCache(
+          "Some predicted cache file(s) are not on disk; uploading the ",
+          sum(filesExist), " present file(s) and skipping:\n",
+          paste(basename2(cacheIdFileName[!filesExist]), collapse = "\n"),
+          verbose = verbose
+        )
+      }
+      cacheIdFileName <- cacheIdFileName[filesExist]
       newFileName <- basename2(cacheIdFileName)
 
       cloudFolderID <- checkAndMakeCloudFolderID(cloudFolderID = cloudFolderID, cachePath = cachePath, create = TRUE)
@@ -400,7 +418,11 @@ cloudUploadFromCache <- function(isInCloud, outputHash, cachePath, cloudFolderID
         return(du)
       }
     } else {
-      stop("File(s) to upload are not available")
+      # Nothing on disk to push: do not abort the run -- the local cache is
+      # intact; cloud upload is best-effort.
+      messageCache("No cache file(s) available on disk to upload for cacheId ",
+                   outputHash, "; skipping cloud upload (local cache is intact).",
+                   verbose = verbose)
     }
   }
   # cloudUploadRasterBackends(obj = outputToSave, cloudFolderID)

--- a/tests/testthat/test-cloudUploadNonFatal.R
+++ b/tests/testthat/test-cloudUploadNonFatal.R
@@ -1,0 +1,20 @@
+test_that("cloudUploadFromCache does not abort when predicted files are absent", {
+  skip_on_cran()
+  skip_if_not_installed("googledrive")
+  testInit(opts = list(reproducible.useDBI = FALSE))
+  cp <- file.path(tempfile("cache_")); dir.create(cp, recursive = TRUE)
+  ## A cacheId with no files on disk in the cache folder (emulates a cached
+  ## simList whose predicted raster-backend sidecars were never written under
+  ## the cacheId). Previously this stop()ped and crashed the whole run; now it
+  ## must warn and skip the (best-effort) cloud upload, never error.
+  expect_no_error(
+    msgs <- capture_messages(
+      reproducible:::cloudUploadFromCache(
+        isInCloud = FALSE, outputHash = "0123456789abcdef",
+        cachePath = cp, cloudFolderID = NULL,
+        outputToSave = NULL, rasters = NULL, verbose = 1
+      )
+    )
+  )
+  expect_true(any(grepl("skipping cloud upload", msgs)))
+})


### PR DESCRIPTION
## Problem

Caching an **event that returns a `simList`** with cloud enabled (e.g. `doEvent.Biomass_borealDataPrep::init`) crashed the whole run *after* the work had already been saved locally:

```
Saved! Cache file: e16edcf430c5a814.rds; fn: doEvent.Biomass_borealDataPrep::init
Error in cloudUploadFromCache(...) : File(s) to upload are not available
```

(Full traceback: `doSaveToCache` → `cloudUploadFromCache` → `stop()`.)

## Cause

`cloudUploadFromCache()` derives its upload list from `CacheStoredFile(cachePath, outputHash, "check", obj = outputToSave)`, which **predicts** extra file-backed sidecars from `Filenames(obj)` — the `SpatRaster` backends of the cached `simList`. But a cached `simList` commonly **references** its rasters at their existing locations (inner caches / outputs) rather than copying them into the cache folder under the outer `cacheId`. So those predicted sidecars aren't present, `all(file.exists(...))` is `FALSE`, and the function `stop()`ed — aborting an already-completed, locally-saved run during a *best-effort* upload.

## Fix

Cloud upload is best-effort and must never crash the caller:
- upload the cache files that are **actually on disk**,
- **warn** about any predicted-but-absent ones,
- if nothing is present, warn and **skip** — never `stop()`.

The local cache is intact regardless.

## Tests / scope

- New regression test `test-cloudUploadNonFatal.R`: `cloudUploadFromCache()` with an absent `cacheId` no longer errors and emits a skip message. `test-cloud-helpers.R` (18) still pass.
- I can't exercise the live Google Drive round-trip here (no auth), but this change only converts a previously-fatal `stop()` into best-effort upload-what-exists + warn, so it can't be worse than the crash.
- **Separate, follow-up concern:** whether a cloud-cached `simList` that references *external* raster backends reloads correctly on another machine. Those backends are cloud-managed by their own inner `Cache()` calls, so uploading the outer `.rds` is likely sufficient — but worth verifying cross-machine with cloud access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)