### PR TITLE
feat(cache): reproducible.preDigestDump — dump full preDigest for any Cache() call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-08
-Version: 3.1.1.9046
+Version: 3.1.1.9047
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,17 @@
 
 ## new features
 
+* New diagnostic option **`reproducible.preDigestDump`** (and
+  `reproducible.preDigestDumpPattern`) to dump the full element-by-element
+  `preDigest` (`name = hash`) that produces each `Cache()` `cacheId`. Unlike
+  `showSimilar` (closest prior call only), `dryRun`, or `verbose`, it covers
+  *every* `Cache()` call -- including ones built deep inside other packages (e.g.
+  SpaDES.core events) -- so two machines' dumps can be `diff`ed to find exactly
+  what splits a `cacheId` across machines/OSs (e.g. a cloud cache that will not
+  share). `TRUE` messages each call's sorted list; a directory path writes one
+  `preDigest_<functionName>[_<n>].txt` per call. See `?reproducibleOptions`.
+
+
 * `showSimilar` (the `reproducible.showSimilar` option, also used by dev mode and
   `dryRun`) is now cloud-aware. When `useCloud` is active, `Cache()` previously
   compared the current call only against the *local* cache, so similar artifacts

--- a/R/GPT2.R
+++ b/R/GPT2.R
@@ -1828,6 +1828,10 @@ doDigest <- function(toDigest, .functionName, .objects, length, algo, quick,
                       modifiedDots = toDigest, verbose = verbose, verboseLevel = 3)
 
   names(detailed_key)[[1]] <- "key"
+  # Optional diagnostic dump of the full element-by-element preDigest (off unless
+  # options(reproducible.preDigestDump=) is set); for diffing cacheIds across
+  # machines/OSs. See .dumpPreDigest().
+  .dumpPreDigest(detailed_key, .functionName)
   detailed_key
 }
 

--- a/R/cache-helpers.R
+++ b/R/cache-helpers.R
@@ -358,6 +358,61 @@ copyFile <- Vectorize(copySingleFile, vectorize.args = c("from", "to"))
   obj
 }
 
+#' Dump the element-by-element `preDigest` of a `Cache()` call
+#'
+#' Diagnostic for "why is my `cacheId` different here than there?" -- e.g. why a
+#' cloud cache is not shared across machines/OSs. Unlike `showSimilar` (which only
+#' reports the *closest* prior call's differences) or `dryRun`/`verbose`, this
+#' prints the **full** `name = hash` list that produced the `cacheId`, for *every*
+#' `Cache()` call (including ones constructed deep inside other packages, e.g.
+#' SpaDES.core events), so two machines' dumps can be diffed directly.
+#'
+#' Controlled by options (off by default):
+#' \describe{
+#'   \item{`reproducible.preDigestDump`}{`NULL`/`FALSE` (off); `TRUE` to emit each
+#'     call's sorted `name = hash` list via [messageCache()]; or a directory path
+#'     to write one `preDigest_<functionName>[_<n>].txt` file per call (point it at
+#'     a fresh/empty directory, then diff the directory against the other
+#'     machine's).}
+#'   \item{`reproducible.preDigestDumpPattern`}{optional regular expression matched
+#'     against the call's `.functionName`; only matching calls are dumped (e.g.
+#'     `"init|inputObjects"`).}
+#' }
+#' @param detailed_key The list returned by [CacheDigest()] (has `key`/`outputHash`
+#'   and `preDigest`).
+#' @param .functionName The function name for this `Cache()` call.
+#' @param dump,pattern,verbose Resolved from the options above.
+#' @return `invisible(NULL)`, called for its side effect.
+#' @keywords internal
+#' @rdname dumpPreDigest
+.dumpPreDigest <- function(detailed_key, .functionName,
+                           dump = getOption("reproducible.preDigestDump", NULL),
+                           pattern = getOption("reproducible.preDigestDumpPattern", NULL),
+                           verbose = getOption("reproducible.verbose", 1)) {
+  if (is.null(dump) || isFALSE(dump)) return(invisible())
+  fn <- paste(.functionName, collapse = "")
+  if (!is.null(pattern) && !isTRUE(grepl(pattern, fn))) return(invisible())
+  pd <- unlist(detailed_key[["preDigest"]])
+  if (length(pd)) pd <- pd[order(names(pd))]
+  key <- detailed_key[["key"]]
+  if (is.null(key)) key <- detailed_key[[1]]
+  lines <- c(paste0("# ", fn, "  cacheId=", key),
+             sprintf("%s = %s", names(pd), as.character(pd)))
+  if (is.character(dump)) {
+    checkPath(dump, create = TRUE)
+    safe <- gsub("[^A-Za-z0-9._-]+", "_", fn)
+    f <- file.path(dump, paste0("preDigest_", safe, ".txt"))
+    i <- 1L
+    while (file.exists(f)) {                 # repeated calls to the same fn within a run
+      f <- file.path(dump, sprintf("preDigest_%s_%d.txt", safe, i)); i <- i + 1L
+    }
+    writeLines(lines, f)
+  } else {
+    messageCache(paste(lines, collapse = "\n"), verbose = verbose)
+  }
+  invisible()
+}
+
 #' @keywords internal
 
 #' @keywords internal

--- a/R/options.R
+++ b/R/options.R
@@ -246,6 +246,23 @@
 #'   \item{`showSimilar`}{
 #'     Default `FALSE`. Passed to `Cache`.
 #'   }
+#'   \item{`preDigestDump`}{
+#'     Default: `NULL` (off). A diagnostic for "why is my `cacheId` different on
+#'     this machine than that one?" (e.g. a cloud cache that will not share across
+#'     OSs). Unlike `showSimilar` (closest prior call only) or `dryRun`/`verbose`,
+#'     this dumps the **full** element-by-element `name = hash` list that produced
+#'     the `cacheId`, for *every* `Cache()` call (including ones built inside other
+#'     packages, e.g. SpaDES.core events). Set to `TRUE` to print each call's
+#'     sorted list via `messageCache()`, or to a **directory path** to write one
+#'     `preDigest_<functionName>[_<n>].txt` file per call. Point it at a fresh,
+#'     empty directory on each machine, run, then `diff` the two directories: the
+#'     differing `name = hash` line is exactly what is splitting the `cacheId`.
+#'   }
+#'   \item{`preDigestDumpPattern`}{
+#'     Default: `NULL`. Optional regular expression matched against a call's
+#'     `.functionName`; when set, only matching `Cache()` calls are dumped by
+#'     `reproducible.preDigestDump` (e.g. `"init|inputObjects"`).
+#'   }
 #'   \item{`testCharacterAsFile`}{
 #'     Default `FALSE`. The behaviour of `.robustDigest` on `character` vectors prior to
 #'     `reproducible == 2.1.2` was that the function would test for whether they were
@@ -479,6 +496,8 @@ reproducibleOptions <- function() {
     reproducible.nThreads = 1,
     reproducible.objSize = TRUE,
     reproducible.overwrite = FALSE,
+    reproducible.preDigestDump = NULL,              # NULL/FALSE off; TRUE -> message each call's preDigest; or a dir path -> one file per call
+    reproducible.preDigestDumpPattern = NULL,       # optional regex on .functionName to limit which calls are dumped
     reproducible.parallel.connecttimeout = 30L,     # seconds; per-connection establishment timeout for ranged streams
     reproducible.parallel.maxConnections = NULL,    # max simultaneous connections; NULL => parallelly::availableCores() - 1
     reproducible.parallel.minConcurrentFrac = 0.25, # fall back to single stream if 1st attempt completes < this frac of parts

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -255,6 +255,23 @@ it will use \code{raster::shapefile}
 \item{\code{showSimilar}}{
 Default \code{FALSE}. Passed to \code{Cache}.
 }
+\item{\code{preDigestDump}}{
+Default: \code{NULL} (off). A diagnostic for "why is my \code{cacheId} different on
+this machine than that one?" (e.g. a cloud cache that will not share across
+OSs). Unlike \code{showSimilar} (closest prior call only) or \code{dryRun}/\code{verbose},
+this dumps the \strong{full} element-by-element \code{name = hash} list that produced
+the \code{cacheId}, for \emph{every} \code{Cache()} call (including ones built inside other
+packages, e.g. SpaDES.core events). Set to \code{TRUE} to print each call's
+sorted list via \code{messageCache()}, or to a \strong{directory path} to write one
+\verb{preDigest_<functionName>[_<n>].txt} file per call. Point it at a fresh,
+empty directory on each machine, run, then \code{diff} the two directories: the
+differing \code{name = hash} line is exactly what is splitting the \code{cacheId}.
+}
+\item{\code{preDigestDumpPattern}}{
+Default: \code{NULL}. Optional regular expression matched against a call's
+\code{.functionName}; when set, only matching \code{Cache()} calls are dumped by
+\code{reproducible.preDigestDump} (e.g. \code{"init|inputObjects"}).
+}
 \item{\code{testCharacterAsFile}}{
 Default \code{FALSE}. The behaviour of \code{.robustDigest} on \code{character} vectors prior to
 \verb{reproducible == 2.1.2} was that the function would test for whether they were

--- a/tests/testthat/test-preDigestDump.R
+++ b/tests/testthat/test-preDigestDump.R
@@ -1,0 +1,32 @@
+test_that("reproducible.preDigestDump emits the full preDigest (message + file modes)", {
+  skip_on_cran()
+  testInit(opts = list(reproducible.useDBI = FALSE))
+  cp <- file.path(tempfile("cache_")); dir.create(cp, recursive = TRUE)
+
+  ## message mode: TRUE -> sorted `name = hash` lines via messageCache
+  withr::local_options(reproducible.preDigestDump = TRUE)
+  msgs <- capture_messages(
+    Cache(FUN = rnorm(2), .functionName = "doEvent.myMod::init", cachePath = cp)
+  )
+  expect_true(any(grepl("cacheId=", msgs)))
+  expect_true(any(grepl("= [0-9a-f]{6,}", msgs)))   # at least one name = hash line
+
+  ## directory mode: one file per call, sorted, with a cacheId header
+  dumpDir <- file.path(tempfile("dump_"))
+  withr::local_options(reproducible.preDigestDump = dumpDir)
+  invisible(Cache(FUN = rnorm(2), .functionName = "doEvent.myMod::init",
+                  cachePath = cp, userTags = "two"))
+  f <- list.files(dumpDir, pattern = "^preDigest_doEvent", full.names = TRUE)
+  expect_length(f, 1L)
+  ll <- readLines(f)
+  expect_match(ll[[1]], "^# doEvent.myMod::init  cacheId=")
+  expect_true(all(grepl(" = ", ll[-1])))
+  expect_identical(ll[-1], ll[-1][order(ll[-1])])    # sorted
+
+  ## pattern filter: non-matching .functionName is not dumped
+  dumpDir2 <- file.path(tempfile("dump2_"))
+  withr::local_options(reproducible.preDigestDump = dumpDir2,
+                       reproducible.preDigestDumpPattern = "init|inputObjects")
+  invisible(Cache(FUN = rnorm(2), .functionName = "somethingElse", cachePath = cp, userTags = "three"))
+  expect_false(dir.exists(dumpDir2) && length(list.files(dumpDir2)) > 0)
+})


### PR DESCRIPTION
## Why

A recurring, hard-to-diagnose problem: an identical run produces a **different `cacheId` on a different machine/OS**, so a cloud cache won't share. The existing tools don't expose enough:

- **`showSimilar`** — only the *closest* prior call's differing args.
- **`dryRun` / `reproducible.verbose`** — don't list the full per-element digest.
- **`debugCache`** — only attaches `preDigest` as an attribute on the *returned* object; useless for `Cache()` calls constructed deep inside other packages (e.g. SpaDES.core events).

What's actually needed is the **full element-by-element `name = hash` list** that produced the `cacheId`, for *every* `Cache()` call, so two machines' lists can be `diff`ed. (We did exactly this ad-hoc via `trace(reproducible:::doDigest, ...)` to find that absolute module paths in `sim@modules`/event `moduleName` were splitting an event `cacheId`.)

## What

New options (off by default), implemented in `.dumpPreDigest()` and called from `doDigest()` (where the `preDigest` is computed for every call):

- **`reproducible.preDigestDump`**:
  - `TRUE` → `messageCache()` each call's sorted `name = hash` list (with a `cacheId=` header);
  - a **directory path** → write one `preDigest_<functionName>[_<n>].txt` per call.

  Point both machines at a fresh, empty directory, run, then `diff` the directories — the differing `name = hash` line is exactly what splits the `cacheId`.
- **`reproducible.preDigestDumpPattern`**: optional regex on `.functionName` to limit which calls are dumped (e.g. `"init|inputObjects"`).

Documented under `?reproducibleOptions`.

## Tests

`test-preDigestDump.R`: message mode (sorted `name = hash` + `cacheId=` header), directory mode (one sorted file per call), and the pattern filter. All pass.

> Note: also bumps to `3.1.1.9047` (same as #504, off the same base) — trivial DESCRIPTION/NEWS conflict for whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)