### PR TITLE
fix(cache): portable file-backed objects across machines/users (cloud cache)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9049
+Version: 3.1.1.9050
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9048
+Version: 3.1.1.9049
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,30 @@
 
 * development version.
 
+## bug fixes
+
+* File-backed objects (e.g. a `terra` `SpatRaster`) are now restored **portably**
+  when a cache entry is shared between machines or users (notably a cloud cache).
+  A file-backed raster embeds an *absolute* path to its backing `.tif`; previously,
+  when another user retrieved such an entry, `Cache()` tried to recreate that path
+  on their machine — e.g. `cannot create dir '/home/<producer>' ... Operation not
+  supported` followed by `[rast] file does not exist`. Three defects in the
+  existing relative-path machinery caused this: `relativeToWhat()` used an inverted
+  "is the file under this anchor?" test (so a raster even one directory below the
+  working directory was stored with its *absolute* path); `unwrapSpatRaster()`
+  reused the producer's embedded path on the normal load path instead of the
+  stored relative tags; and `remapFilenames()` had no safe fallback for an
+  unresolved/absolute path. Now the backing file is stored relative to the most
+  specific matching anchor and rebuilt under the *receiver's* anchor of the same
+  name; when no anchor resolves, the object is made self-contained under the
+  receiver's `cachePath` rather than the producing machine's absolute path.
+
+* New option **`reproducible.fileBackedAnchors`** — a named list of project
+  "anchor" directories (e.g. SpaDES `paths(sim)`) consulted at both cache *save*
+  and *load* so file-backed objects can be stored relative to a semantic,
+  machine-independent anchor (e.g. `inputPath`) and restored to the equivalent
+  location on another machine. See `?reproducibleOptions`.
+
 ## new features
 
 * New diagnostic option **`reproducible.preDigestDump`** (and

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,14 @@
   machine-independent anchor (e.g. `inputPath`) and restored to the equivalent
   location on another machine. See `?reproducibleOptions`.
 
+* `getRelative()` no longer returns `"NA/<basename>"` when a path *is* (or is
+  fully contained in) `relativeToPath`; it now correctly returns `"."`. The old
+  result came from `(max(id) + 1):length(a)` counting backwards when the path
+  matched `relativeToPath` exactly, producing `file.path(NA, last)`. This
+  corrupted the relativized paths stored by `SpaDES.core::saveSimList()` and, now
+  that file-backed objects anchor to those paths, would otherwise surface as an
+  `NA` path segment when restoring a file-backed object.
+
 ## new features
 
 * New diagnostic option **`reproducible.preDigestDump`** (and

--- a/R/exportedMethods.R
+++ b/R/exportedMethods.R
@@ -101,11 +101,15 @@ modifyListPaths <- function(cachePath = getOption("reproducible.cachePath"), ...
     possRelPaths <- modifyList(possRelPaths, anchors)
   }
   possRelPaths <- append(possRelPaths, list(getwd = getwd()))
-  # Drop anchors that are NULL or empty so they can never match spuriously.
-  #   An anchor may hold several directories (e.g. modulePath), so test element-wise.
-  keep <- !vapply(possRelPaths,
-                  function(x) is.null(x) || length(x) == 0L || all(!nzchar(x)),
-                  logical(1))
+  # Drop NULL/NA/empty anchor directories so they can never match spuriously or
+  #   leak an "NA" path segment into a rebuilt filename. An anchor may hold several
+  #   directories (e.g. modulePath), so clean element-wise. NB: nzchar(NA) is TRUE,
+  #   so NA must be removed explicitly.
+  possRelPaths <- lapply(possRelPaths, function(x) {
+    if (is.null(x)) return(x)
+    x[!is.na(x) & nzchar(x)]
+  })
+  keep <- vapply(possRelPaths, function(x) length(x) > 0L, logical(1))
   possRelPaths[keep]
 }
 
@@ -725,6 +729,16 @@ remapFilenames <- function(obj, tags, cachePath = getOption("reproducible.cacheP
     if (length(relToWhere) == 1L && length(origRelName) > 1L)
       relToWhere <- rep(relToWhere, length(origRelName))
 
+    # Base for files whose anchor doesn't resolve / that are orphans. Prefer the
+    #   cache (so a shared/cloud-cache entry becomes self-contained under the
+    #   receiver's cache), but fall back to the first available anchor when there
+    #   is no cache (cachePath = NULL) -- e.g. saveSimList()/loadSimList(), which
+    #   anchor to projectPath/getwd, not a cache.
+    haveCache <- !is.null(cachePath) && length(cachePath) && !is.na(cachePath[[1]]) &&
+      nzchar(cachePath[[1]])
+    fallbackBase <- if (isTRUE(haveCache)) cachePath[[1]]
+      else if (length(possRelPaths)) possRelPaths[[1]][[1]] else getwd()
+
     newName <- vapply(seq_along(origRelName), function(i) {
       x <- origRelName[[i]]
       anchorNm <- if (length(relToWhere) >= i) relToWhere[[i]] else ""
@@ -749,7 +763,7 @@ remapFilenames <- function(obj, tags, cachePath = getOption("reproducible.cacheP
         while (any(grepl(grepStartsTwoDots, rel))) {
           rel <- gsub(paste0(grepStartsTwoDots, "|(\\\\|/)"), "", rel)
         }
-        as.character(fs::path_norm(fs::path_join(c(cachePath, rel))))
+        as.character(fs::path_norm(fs::path_join(c(fallbackBase, rel))))
       }
     }, character(1))
   } else {

--- a/R/exportedMethods.R
+++ b/R/exportedMethods.R
@@ -78,7 +78,7 @@ absoluteBase <- function(relToWhere, cachePath = getOption("reproducible.cachePa
 #' @importFrom utils modifyList
 modifyListPaths <- function(cachePath = getOption("reproducible.cachePath"), ...) {
   possRelPaths <- list()
-  if (!missing(cachePath))
+  if (!missing(cachePath) && !is.null(cachePath))
     possRelPaths$cachePath <- cachePath
   dots <- list(...)
   if (length(dots)) {
@@ -88,53 +88,70 @@ modifyListPaths <- function(cachePath = getOption("reproducible.cachePath"), ...
       possRelPaths <- modifyList(dots[[1]], possRelPaths)
     }
   }
+  # Semantic, machine-independent project anchors (e.g. SpaDES `paths(sim)`).
+  #   Read from the option so the *same* named anchors are available at both
+  #   save (wrapSpatRaster -> relativeToWhat) and load (unwrapSpatRaster ->
+  #   remapFilenames) without threading them through every call signature.
+  #   This is what lets a file-backed object be stored relative to e.g.
+  #   `inputPath` on one machine and restored under another machine's
+  #   `inputPath`. `cachePath`/`getwd` remain fallback anchors.
+  anchors <- getOption("reproducible.fileBackedAnchors", NULL)
+  if (is.list(anchors) && length(anchors) && !is.null(names(anchors))) {
+    anchors <- anchors[nzchar(names(anchors))]
+    possRelPaths <- modifyList(possRelPaths, anchors)
+  }
   possRelPaths <- append(possRelPaths, list(getwd = getwd()))
+  # Drop anchors that are NULL or empty so they can never match spuriously.
+  #   An anchor may hold several directories (e.g. modulePath), so test element-wise.
+  keep <- !vapply(possRelPaths,
+                  function(x) is.null(x) || length(x) == 0L || all(!nzchar(x)),
+                  logical(1))
+  possRelPaths[keep]
 }
 
 relativeToWhat <- function(file, cachePath = getOption("reproducible.cachePath"), ...) {
   possRelPaths <- modifyListPaths(cachePath, ...)
 
-  foundAbs <- FALSE
-  dirnameFile <- dirname(file)
-  whSame <- rep(FALSE, length(file))
-  pc <- rep("", length(file))
-  for (nams in names(possRelPaths)) {
-    pc[!whSame] <- mapply(fn = file[!whSame], function(fn)
-      fs::path_common(c(dirname(fn), possRelPaths[[nams]]))
-    )
+  # Flatten anchors to (name, dir) pairs: a single anchor (e.g. modulePath) may hold
+  #   several directories. Prefer the most specific (longest) anchor dir, so a nested
+  #   anchor (e.g. `inputPath`) wins over a parent that also contains the file (e.g. a
+  #   `projectPath` or `getwd`); otherwise the file would be stored relative to the
+  #   broadest anchor and lose the semantic location it actually lived in.
+  flatNames <- rep(names(possRelPaths), lengths(possRelPaths))
+  flatPaths <- as.character(fs::path_norm(unlist(possRelPaths, use.names = FALSE)))
+  ord <- order(nchar(flatPaths), decreasing = TRUE)
+  flatNames <- flatNames[ord]
+  flatPaths <- flatPaths[ord]
 
-    out <- sapply(possRelPaths[[nams]], fs::path_rel, path = pc) |> as.character()
-    whSame <- pc == dirnameFile
-    if (all(whSame)) {
-      out <- list(out)
-      names(out) <- nams
-      foundAbs <- TRUE
-      break
-    }
-  }
-  if (isFALSE(foundAbs)) {
-    for (nams in names(possRelPaths)) {
-      out <- dirname(file)
-      names(out) <- ""
-      if (FALSE) { # this is for rebuilding relative against
-        # poss <- fs::path_common(c(file, possRelPaths[nams]))
-        # if (!identical(poss, possRelPaths[nams])) {
-        #   fileRel <- makeRelative(file, poss)
-        #   rel <- makeRelative(possRelPaths[nams], poss)
-        #   relWithDots <- rep("..", length(strsplit(rel, "/|\\\\")[[1]]))
-        #   poss <- file.path(paste(relWithDots, collapse = "/"), dirname(fileRel))
-        #   out <- poss
-        #   out <- list(out)
-        #   names(out) <- nams
-        #   foundAbs <- TRUE
-        #   break
-        # }
-        # names(out) <- nams
+  dirnameFile <- as.character(fs::path_norm(dirname(file)))
+  relName <- character(length(file))
+  whichAnchor <- character(length(file))
+  for (i in seq_along(file)) {
+    found <- FALSE
+    for (j in seq_along(flatPaths)) {
+      anchor <- flatPaths[[j]]
+      # The file is *under* (or at) the anchor when their common ancestor is the
+      #   anchor itself. (The previous test, `common == dirname(file)`, was inverted:
+      #   it only matched when the anchor sat inside the file's own directory.)
+      # NB: coerce path_common()'s fs_path to plain character so identical() compares
+      #   values, not classes (flatPaths is plain character).
+      if (identical(as.character(fs::path_common(c(dirnameFile[i], anchor))), anchor)) {
+        relName[i] <- as.character(fs::path_rel(dirnameFile[i], start = anchor))
+        whichAnchor[i] <- flatNames[[j]]
+        found <- TRUE
+        break
       }
     }
+    if (!found) {
+      # Orphan: the file lives under no known anchor. Record its absolute directory
+      #   with an empty anchor name; remapFilenames() will make this self-contained
+      #   under the receiver's cache rather than resurrecting a foreign absolute path.
+      relName[i] <- dirnameFile[i]
+      whichAnchor[i] <- ""
+    }
   }
-
-  out
+  names(relName) <- whichAnchor
+  relName
 }
 
 ## non-exported wrap functions --------------------------------------------------
@@ -221,8 +238,12 @@ unwrapSpatRaster <- function(obj, cachePath = getOption("reproducible.cachePath"
         feObjs <- file.exists(obj)
         if (any(feObjs))
           unlink(obj[feObjs])
-        # fnToLoad <- fns
-        newFiles <- remapFilenames(fns, tags, cachePath, ...)
+        # Rebuild the destination from the stored *relative* tags (anchor + relName)
+        #   rather than reusing `fns` (the producing machine's embedded absolute path).
+        #   Passing `fns` as `obj` here short-circuited remapFilenames() to the verbatim
+        #   producer path, which is what made a cloud-cached raster try to write back to
+        #   e.g. /home/<producer>/... on a different user's machine.
+        newFiles <- remapFilenames(tags = tags, cachePath = cachePath, ...)
         fromFiles <- unlist(filenameInCache)
       } else {
         newFiles <- remapFilenames(tags = tags, cachePath = cachePath, ...)
@@ -699,25 +720,36 @@ remapFilenames <- function(obj, tags, cachePath = getOption("reproducible.cacheP
     }
 
     possRelPaths <- modifyListPaths(cachePath, ...)
-    relToWhereInPossRelPaths <- relToWhere %in% names(possRelPaths)
-    if (isTRUE(any(relToWhereInPossRelPaths))) {
-      absBase <- absoluteBase(relToWhere, cachePath, ...)
-    } else {
-      absBase <- possRelPaths[[1]]
-      isOutside <- grepl(grepStartsTwoDots, origRelName)
-      if (isTRUE(any(isOutside))) {
-        ## means the relative path is "outside" of something;
-        ## strip all ".." if relToWhere doesn't exist
-        while (any(grepl(grepStartsTwoDots, origRelName))) {
-          origRelName <- gsub(paste0(grepStartsTwoDots, "|(\\\\|/)"), "", origRelName)
-        }
-      }
-    }
-    newName <- vapply(origRelName, function(x) {
-      if (fs::is_absolute_path(x)) {
+    # relToWhere is per-file (the anchor name each file was stored relative to);
+    #   recycle a scalar to match origRelName so we can resolve element-by-element.
+    if (length(relToWhere) == 1L && length(origRelName) > 1L)
+      relToWhere <- rep(relToWhere, length(origRelName))
+
+    newName <- vapply(seq_along(origRelName), function(i) {
+      x <- origRelName[[i]]
+      anchorNm <- if (length(relToWhere) >= i) relToWhere[[i]] else ""
+      anchorResolves <- nzchar(anchorNm) && anchorNm %in% names(possRelPaths) &&
+        !fs::is_absolute_path(x)
+      if (isTRUE(anchorResolves)) {
+        # The anchor exists on this machine: restore the file to its original
+        #   *relative* location under the receiver's own anchor (e.g. their inputPath).
+        #   An anchor may map to several dirs (e.g. modulePath); use the first.
+        absBase <- absoluteBase(anchorNm, cachePath, ...)[[1]]
+        as.character(fs::path_norm(fs::path_join(c(absBase, x))))
+      } else if (fs::is_absolute_path(x) && file.exists(x)) {
+        # Genuinely present on this machine (same-machine save/load): keep as-is.
         x
       } else {
-        fs::path_join(c(absBase, x)) |> fs::path_norm()
+        # Anchor missing on this machine, or a foreign/orphan absolute path: make the
+        #   object self-contained under THIS machine's cache. Never resurrect a path
+        #   from the producing machine (the cause of the cross-user cloud-cache crash:
+        #   "cannot create dir '/home/<producer>' ... Operation not supported").
+        rel <- x
+        if (fs::is_absolute_path(rel)) rel <- basename(rel)
+        while (any(grepl(grepStartsTwoDots, rel))) {
+          rel <- gsub(paste0(grepStartsTwoDots, "|(\\\\|/)"), "", rel)
+        }
+        as.character(fs::path_norm(fs::path_join(c(cachePath, rel))))
       }
     }, character(1))
   } else {

--- a/R/options.R
+++ b/R/options.R
@@ -74,6 +74,23 @@
 #'   \item{dryRun}{
 #'     Default: `FALSE`.
 #'   }
+#'   \item{`fileBackedAnchors`}{
+#'     Default: `NULL`. A named list of "anchor" directories (e.g. the result of
+#'     SpaDES `paths(sim)`: `cachePath`, `inputPath`, `outputPath`, `modulePath`,
+#'     ...) used to make *file-backed* objects (such as a `terra` `SpatRaster`)
+#'     portable across machines and users. A file-backed object embeds an
+#'     *absolute* path to its backing file; when stored relative to a named anchor
+#'     here, `Cache` records the anchor name plus the path relative to it, and on
+#'     load rebuilds the file under the *receiver's* anchor of the same name. Each
+#'     entry may hold one or more directories, and the most specific (longest)
+#'     matching anchor wins. The same named list must be set on both the machine
+#'     that writes the cache entry and the one that reads it (e.g. a shared cloud
+#'     cache). When the file lives under no anchor, or the anchor name is not set
+#'     on the receiver, the object is restored *self-contained under the
+#'     receiver's `cachePath`* rather than the producing machine's absolute path.
+#'     `cachePath` and the current working directory are always available as
+#'     fallback anchors.
+#'   }
 #'   \item{`futurePlan`}{
 #'     Default: `FALSE`. On Linux OSes, `Cache` and `cloudCache` have some
 #'     functionality that uses the `future` package.
@@ -477,6 +494,7 @@ reproducibleOptions <- function() {
     reproducible.destinationPath = NULL,
     reproducible.drv = NULL, # RSQLite::SQLite(),
     reproducible.dryRun = FALSE,
+    reproducible.fileBackedAnchors = NULL, # named list of semantic project paths (e.g. SpaDES paths(sim)); used to store/restore file-backed object paths *relative* to a portable anchor
     reproducible.futurePlan = FALSE, # future::plan("multisession"), #memoise
     reproducible.gdalwarpThreads = 2L,
     reproducible.inputPath = file.path(tempdir(), "reproducible", "input"),

--- a/R/paths.R
+++ b/R/paths.R
@@ -341,7 +341,14 @@ getRelative <- function(path, relativeToPath) {
       id <- which(a %in% b)
       if (length(id) > 0) {
         ## assume most internal subdirectory is the matching one
-        relPath <- do.call(file.path, as.list(a[(max(id) + 1):length(a)]))
+        start <- max(id) + 1L
+        if (start > length(a)) {
+          ## the path *is* (or is fully contained in) relativeToPath. Guard against
+          ## `(n+1):n` counting backwards -- it yielded `file.path(NA, last)` = "NA/last".
+          relPath <- "."
+        } else {
+          relPath <- do.call(file.path, as.list(a[start:length(a)]))
+        }
       } else {
         relPath <- p
       }

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -79,6 +79,23 @@ Only tested with \code{RSQLite::SQLite()} and \code{RPostgres::Postgres()}.
 \item{dryRun}{
 Default: \code{FALSE}.
 }
+\item{\code{fileBackedAnchors}}{
+Default: \code{NULL}. A named list of "anchor" directories (e.g. the result of
+SpaDES \code{paths(sim)}: \code{cachePath}, \code{inputPath}, \code{outputPath}, \code{modulePath},
+...) used to make \emph{file-backed} objects (such as a \code{terra} \code{SpatRaster})
+portable across machines and users. A file-backed object embeds an
+\emph{absolute} path to its backing file; when stored relative to a named anchor
+here, \code{Cache} records the anchor name plus the path relative to it, and on
+load rebuilds the file under the \emph{receiver's} anchor of the same name. Each
+entry may hold one or more directories, and the most specific (longest)
+matching anchor wins. The same named list must be set on both the machine
+that writes the cache entry and the one that reads it (e.g. a shared cloud
+cache). When the file lives under no anchor, or the anchor name is not set
+on the receiver, the object is restored \emph{self-contained under the
+receiver's \code{cachePath}} rather than the producing machine's absolute path.
+\code{cachePath} and the current working directory are always available as
+fallback anchors.
+}
 \item{\code{futurePlan}}{
 Default: \code{FALSE}. On Linux OSes, \code{Cache} and \code{cloudCache} have some
 functionality that uses the \code{future} package.

--- a/tests/testthat/test-fileBackedPortability.R
+++ b/tests/testthat/test-fileBackedPortability.R
@@ -1,0 +1,97 @@
+# Portability of file-backed objects (e.g. SpatRaster) across machines/users.
+#
+# A file-backed raster embeds an *absolute* path to its backing .tif. When a
+# cache entry is shared (e.g. cloud cache) and retrieved by another user, that
+# absolute path (e.g. /home/<producer>/.../inputs/x.tif) does not exist on the
+# receiver. The fix stores the backing file's location *relative* to a named,
+# machine-independent anchor (reproducible.fileBackedAnchors, e.g. SpaDES
+# paths(sim)) and rebuilds it under the receiver's own anchor on load. When no
+# anchor resolves, the object is made self-contained under the receiver's cache
+# rather than resurrecting the producer's path.
+
+## Relocate a whole cache (DB + storage dir) from one cachePath to another, as a
+##   cloud download effectively does.
+relocateCache <- function(fromCache, toCache) {
+  dir.create(toCache, recursive = TRUE, showWarnings = FALSE)
+  file.copy(list.files(fromCache, full.names = TRUE), toCache, recursive = TRUE)
+  fromStore <- reproducible:::CacheStorageDir(fromCache)
+  toStore <- reproducible:::CacheStorageDir(toCache)
+  dir.create(toStore, recursive = TRUE, showWarnings = FALSE)
+  file.copy(list.files(fromStore, full.names = TRUE), toStore, recursive = TRUE)
+}
+
+test_that("file-backed raster is restored under the receiver's anchor", {
+  skip_if_not_installed("terra")
+  testInit("terra")
+  cId <- "abcabcabcabcabcabcabcabcabcabc01"
+
+  ## ---- producer ----
+  prodIn <- normPath(file.path(tmpdir, "producer", "inputs"))
+  prodCache <- normPath(file.path(tmpdir, "producer", "cache"))
+  dir.create(prodIn, recursive = TRUE, showWarnings = FALSE)
+  tif <- file.path(prodIn, "rstLCC.tif")
+  terra::writeRaster(terra::rast(nrows = 8, ncols = 8, vals = 1:64), tif, overwrite = TRUE)
+  rr <- terra::rast(tif)
+
+  withr::local_options(reproducible.fileBackedAnchors = list(
+    inputPath = prodIn, cachePath = prodCache
+  ))
+  # NB: the cache lookup keys on the function's name; producer and receiver must
+  #   use the same symbol (`f`) so the relocated entry is found by `cacheId`.
+  f <- function() rr
+  Cache(f, cachePath = prodCache, cacheId = cId)
+
+  ## ---- transport: relocate cache, delete producer entirely ----
+  consIn <- normPath(file.path(tmpdir, "consumer", "inputs"))
+  consCache <- normPath(file.path(tmpdir, "consumer", "cache"))
+  dir.create(consIn, recursive = TRUE, showWarnings = FALSE)
+  relocateCache(prodCache, consCache)
+  unlink(file.path(tmpdir, "producer"), recursive = TRUE)
+
+  ## ---- receiver: different inputPath, producer paths gone ----
+  withr::local_options(reproducible.fileBackedAnchors = list(
+    inputPath = consIn, cachePath = consCache
+  ))
+  f <- function() stop("must not recompute")
+  out <- Cache(f, cachePath = consCache, cacheId = cId)
+
+  expect_true(inherits(out, "SpatRaster"))
+  expect_identical(as.numeric(out[64][1, 1]), 64)
+  # restored under the RECEIVER's inputPath, never the producer's tree
+  expect_true(startsWith(normPath(terra::sources(out)), consIn))
+  expect_false(dir.exists(file.path(tmpdir, "producer")))
+})
+
+test_that("file-backed raster with an unresolved anchor falls back to the cache", {
+  skip_if_not_installed("terra")
+  testInit("terra")
+  cId <- "abcabcabcabcabcabcabcabcabcabc02"
+
+  ## producer stores relative to a named anchor the receiver will NOT have
+  prodScratch <- normPath(file.path(tmpdir, "producer", "scratch"))
+  prodCache <- normPath(file.path(tmpdir, "producer", "cache"))
+  dir.create(prodScratch, recursive = TRUE, showWarnings = FALSE)
+  tif <- file.path(prodScratch, "rstLCC.tif")
+  terra::writeRaster(terra::rast(nrows = 8, ncols = 8, vals = 1:64), tif, overwrite = TRUE)
+  rr <- terra::rast(tif)
+
+  withr::local_options(reproducible.fileBackedAnchors = list(
+    scratchPath = prodScratch, cachePath = prodCache
+  ))
+  f <- function() rr
+  Cache(f, cachePath = prodCache, cacheId = cId)
+
+  consCache <- normPath(file.path(tmpdir, "consumer", "cache"))
+  relocateCache(prodCache, consCache)
+  unlink(file.path(tmpdir, "producer"), recursive = TRUE)
+
+  ## receiver has no scratchPath anchor -> must not crash, must be self-contained
+  withr::local_options(reproducible.fileBackedAnchors = list(cachePath = consCache))
+  f <- function() stop("must not recompute")
+  out <- Cache(f, cachePath = consCache, cacheId = cId)
+
+  expect_true(inherits(out, "SpatRaster"))
+  expect_identical(as.numeric(out[64][1, 1]), 64)
+  expect_true(startsWith(normPath(terra::sources(out)), consCache))
+  expect_false(dir.exists(file.path(tmpdir, "producer")))
+})

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -47,5 +47,25 @@ test_that("relativeToWhat can handle multiple paths", {
       )
     )
   })
-  expect_identical(res, list(outputPath = "."))
+  # relativeToWhat() returns a named character vector: name = the (most specific)
+  #   anchor the file lives under, value = the file's directory relative to it.
+  expect_identical(res, c(outputPath = "."))
+})
+
+test_that("relativeToWhat picks the most specific anchor and a true relative path", {
+  paths <- list(
+    cachePath = "/proj/cache",
+    projectPath = "/proj",
+    inputPath = "/proj/inputs"
+  )
+  # file several levels under inputPath -> relative to inputPath (most specific),
+  #   NOT projectPath; and certainly not stored as an absolute path.
+  res <- relativeToWhat("/proj/inputs/sub/dir/r.tif", cachePath = NULL, paths)
+  expect_identical(names(res), "inputPath")
+  expect_identical(unname(res), "sub/dir")
+
+  # a file under no anchor -> empty anchor name + absolute dir (an "orphan")
+  res2 <- relativeToWhat("/elsewhere/x/r.tif", cachePath = NULL, paths)
+  expect_identical(names(res2), "")
+  expect_true(fs::is_absolute_path(unname(res2)))
 })

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -69,3 +69,13 @@ test_that("relativeToWhat picks the most specific anchor and a true relative pat
   expect_identical(names(res2), "")
   expect_true(fs::is_absolute_path(unname(res2)))
 })
+
+test_that("getRelative returns '.' when the path is (or is within) relativeToPath", {
+  # regression: identical paths returned "NA/<basename>" because `(n+1):n`
+  #   counts backward, yielding file.path(NA, last). This corrupted the paths
+  #   that saveSimList()/loadSimList() store, surfacing as an "NA" path segment
+  #   when restoring a file-backed object anchored to such a path.
+  expect_identical(as.character(getRelative("/a/b/proj", "/a/b/proj")), ".")
+  expect_identical(as.character(getRelative("/a/b/proj/inputs/x.tif", "/a/b/proj")),
+                   "inputs/x.tif")
+})


### PR DESCRIPTION
## Problem

A file-backed object (e.g. a `terra` `SpatRaster`) embeds an **absolute** path to its backing `.tif`. When a cache entry is shared between machines/users — notably a **cloud cache** — retrieving it tried to recreate the *producing* machine's path on the receiver:

```
Error : [rast] file does not exist: /home/<producer>/.../inputs/rstLCC_dehchoN_2020.tif
Warning: cannot create dir '/home/<producer>', reason 'Operation not supported'
```

followed by the cache being declared corrupt and (in SpaDES.core) a `simNestingRevert` error.

## Root cause

The package already had a relative-path mechanism (`relToWhere` + `origRelName`, rebuilt by `remapFilenames`). Cloud caching exposed three latent defects that local caching never hit:

1. **`relativeToWhat()` used an inverted test** (`common(dir, anchor) == dirname(file)`), so it only matched when an anchor sat *inside* the file's own directory — a raster even one level below the working dir was stored with its **absolute** path.
2. **`unwrapSpatRaster()` bypassed the remap** on the normal (`cachePath` non-`NULL`) load path, reusing the producer's embedded path instead of the stored relative tags.
3. **`remapFilenames()` had no safe fallback** — an absolute `origRelName` was resurrected verbatim.

## Fix

- `relativeToWhat()` now detects file-under-anchor correctly (`common(dir, anchor) == anchor`), flattens multi-dir anchors, and prefers the **most-specific (longest)** matching anchor (so `cachePath` is just another anchor and nesting resolves correctly). Stores a true relative path.
- `unwrapSpatRaster()` rebuilds the destination from the stored relative tags.
- `remapFilenames()` restores to the receiver's anchor of the same name; when no anchor resolves (or a foreign absolute path is encountered), the object is made **self-contained under the receiver's `cachePath`** rather than the producing machine's absolute path.
- New option **`reproducible.fileBackedAnchors`** — a named list of project anchor directories (e.g. SpaDES `paths(sim)`) consulted at both save and load via `modifyListPaths()`. SpaDES.core will set this automatically (companion PR).

## Behavior

| Receiver state | Restored to |
|---|---|
| Anchor name set + matches (e.g. `inputPath`) | receiver's **real** location |
| Saved under `getwd` | relative to receiver's `getwd` |
| Anchor name not set on receiver | receiver's **cache** (self-contained) |
| Orphan (under no anchor) | receiver's **cache** (self-contained) |

Same-machine local caching is unchanged.

## Tests

- `tests/testthat/test-fileBackedPortability.R` — cross-machine producer→receiver round-trips via a relocated cache (anchor-matched + anchor-missing→cache fallback).
- `tests/testthat/test-paths.R` — updated `relativeToWhat()` return type (now a named character vector) + most-specific-anchor / orphan unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)