### PR TITLE
test: skip transient httr2 streaming-download failures (req_perform_connection)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9051
+Version: 3.1.1.9052
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/helper-allEqual.R
+++ b/tests/testthat/helper-allEqual.R
@@ -27,6 +27,10 @@ skip_if_service_account <- function() {
   "Connection reset by peer", "Connection refused",
   "TLS connect error", "SSL connect error",
   "Recv failure", "Resolving timed out",
+  # httr2::req_perform_connection() (the streaming download path, .dlHttr2Stream)
+  #   surfaces a transient connection failure with these messages, which the
+  #   curl-style phrases above don't cover.
+  "Failed to perform HTTP request", "cannot open the connection",
   sep = "|"
 )
 


### PR DESCRIPTION
## Problem

`development` R CMD check fails one test — `test-download.R:7` ("dlGeneric works") — even though it already wraps the download in `skip_on_transient_http()`:

```
Error in `httr2::req_perform_connection(req)`: Failed to perform HTTP request.
! cannot open the connection
  reproducible:::.dlHttr2Stream(reqq, destFile, ...) -> httr2::req_perform_connection(req)
[ FAIL 1 | PASS 1229 ]
```

The test downloads from a flaky federal server (`sis.agr.gc.ca`). `skip_on_transient_http()` skips when the error message matches `.transientNetworkPattern`, but the **streaming** download path (`.dlHttr2Stream` → `httr2::req_perform_connection`, added with the download-progress feature in #503) surfaces a transient connection failure as `"Failed to perform HTTP request"` / `"cannot open the connection"` — phrases the curl-style entries in the pattern didn't cover. So a transient upstream failure hard-fails R CMD check instead of skipping.

It hit only some Ubuntu jobs (release/oldrel-1) while devel/oldrel-2/all Windows/macOS passed — the usual flaky-network signature.

## Fix

Add `"Failed to perform HTTP request"` and `"cannot open the connection"` to `.transientNetworkPattern` (test helper only — no package code changes). Verified the pattern flips from non-matching to matching for this error, so the test now `skip()`s on a transient failure as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)