### PR TITLE
ci(test-coverage): run on push to integration branches only, not on PRs

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,9 +1,10 @@
 on:
+  # Run coverage only on push to the integration branches (a PR merge IS a push
+  # to `development`), NOT on pull_request. Running it per-PR meant every update
+  # to the busy `development` base recomputed refs/pull/N/merge and, with
+  # `cancel-in-progress: true`, cancelled the in-progress covr run (exit 143),
+  # so coverage showed spurious red on PRs without ever indicating a real failure.
   push:
-    branches:
-      - master
-      - development
-  pull_request:
     branches:
       - master
       - development

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9052
+Version: 3.1.1.9053
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",


### PR DESCRIPTION
## Problem

`test-coverage` shows spurious red on PRs with `Process completed with exit code 143` ("The runner has received a shutdown signal"). It is **not** a test or coverage failure — the run is being **cancelled**.

The workflow triggers on both `push` and `pull_request`, with:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

For a PR, `github.ref` is `refs/pull/N/merge`, which GitHub **recomputes every time the base branch (`development`) changes**. While `development` is being actively merged into, each base update starts a new coverage run for every open PR and `cancel-in-progress` kills the one already running → exit 143. The slow covr instrumentation widens the cancellation window, so it happens almost every time.

## Fix

Drop the `pull_request` trigger so `test-coverage` runs **only on push to `master`/`development`**. Because merging a PR is itself a push to `development`, the authoritative coverage is still computed on the integrated branch — just once, post-merge, without gating or flaking every PR.

No change to the coverage computation or the codecov upload; only the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)