### PR TITLE
fix(prepInputs): resolve public Google Drive metadata without an OAuth prompt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9052
+Version: 3.1.1.9053
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 * development version.
 
+## bug fixes
+
+* A **public** Google Drive file no longer triggers an interactive OAuth prompt
+  ("Is it OK to cache OAuth access credentials ...") during `prepInputs()` /
+  `preProcess()` when no `googledrive` token is loaded. The no-auth download path
+  (added previously) was defeated by the *metadata* read in `assessGoogle()`:
+  `googledrive::drive_get()` with no cached token launches interactive OAuth even
+  for an "Anyone with the link" file, and that read happens before the download.
+  `assessGoogle()` now deauthorizes `googledrive` for that read when there is no
+  token (the typical "cloud reader" case) or when `reproducible.gdriveNoAuth =
+  TRUE`, so a public file's metadata resolves anonymously via an API key. A
+  loaded token (a "cloud writer", who needs auth to write a shared cloud cache)
+  is left intact; in the edge case of `gdriveNoAuth = TRUE` with a token present,
+  the token is restored after the read.
+
 ## new features
 
 * `reproducible.urlRemap` now accepts the mirror **manifest directly**, not only a

--- a/R/download.R
+++ b/R/download.R
@@ -618,6 +618,39 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   isTRUE(tryCatch(googledrive::drive_has_token(), error = function(e) FALSE))
 }
 
+# Should a Google Drive *metadata* read (drive_get/drive_ls in assessGoogle) be
+# done anonymously, i.e. without triggering interactive OAuth? TRUE when no token
+# is loaded -- the typical "cloud reader" / public-file case -- or when the user
+# opted in via `reproducible.gdriveNoAuth`. A loaded token (a "cloud writer", who
+# needs auth to write the shared cache) otherwise keeps the existing behaviour.
+.gdriveShouldGoAnon <- function(hadToken = .gdriveHasToken()) {
+  isTRUE(getOption("reproducible.gdriveNoAuth", FALSE)) || !isTRUE(hadToken)
+}
+
+# Put googledrive into anonymous (deauthorized) mode so a metadata read of a
+# public ("Anyone with the link") file resolves via an API key instead of
+# launching an interactive OAuth flow. Without this, `googledrive::drive_get()`
+# with no cached token PROMPTS ("Is it OK to cache OAuth credentials ...") even
+# for a public file. Returns a small list the caller uses to restore state:
+#   - deauthed: did we deauthorize?
+#   - token:    the previously-loaded token (or NULL) to restore on.exit, used
+#               only in the edge case of `gdriveNoAuth = TRUE` *with* a token
+#               present (so a cloud writer's token is never clobbered).
+# A no-token deauthorization is left in place (there was nothing to restore, and
+# the session was already token-less). No-op when googledrive is unavailable.
+.gdriveDeauthForPublic <- function() {
+  if (!requireNamespace("googledrive", quietly = TRUE)) return(list(deauthed = FALSE))
+  hadToken <- .gdriveHasToken()
+  if (!.gdriveShouldGoAnon(hadToken)) return(list(deauthed = FALSE))
+  tok <- if (isTRUE(hadToken)) {
+    tryCatch(googledrive::drive_token(), error = function(e) NULL)
+  } else {
+    NULL
+  }
+  try(googledrive::drive_deauth(), silent = TRUE)
+  list(deauthed = TRUE, token = tok)
+}
+
 # Does the downloaded file look like Google's HTML interstitial (sign-in page or
 # virus-scan-warning download form) rather than the requested bytes?
 .looksLikeGoogleInterstitial <- function(file) {
@@ -1770,7 +1803,19 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
   if (.isRstudioServer()) {
     .requireNamespace("httr", stopOnFALSE = TRUE)
     opts <- options(httr_oob_default = TRUE)
-    on.exit(options(opts))
+    on.exit(options(opts), add = TRUE)
+  }
+
+  # Resolve a PUBLIC file's metadata without launching interactive OAuth. With no
+  # cached token, `drive_get()`/`drive_ls()` below would otherwise prompt ("Is it
+  # OK to cache OAuth credentials ...") even for an "Anyone with the link" file --
+  # the metadata read happens before (and so defeats) the no-auth download path.
+  # Deauthorizing makes googledrive use an API key, so a public file resolves
+  # anonymously. A loaded token (cloud writer) is preserved; in the edge case of
+  # `gdriveNoAuth = TRUE` with a token present, it is restored on exit.
+  .anonRead <- .gdriveDeauthForPublic()
+  if (isTRUE(.anonRead$deauthed) && !is.null(.anonRead$token)) {
+    on.exit(try(googledrive::drive_auth(token = .anonRead$token), silent = TRUE), add = TRUE)
   }
 
   # Cache the drive_get / drive_ls result indefinitely. The Cache key

--- a/R/options.R
+++ b/R/options.R
@@ -120,12 +120,17 @@
 #'   }
 #'   \item{`gdriveNoAuth`}{
 #'     Default: `FALSE`. Used in [prepInputs()] and [preProcess()].
-#'     When `TRUE`, Google Drive files are downloaded over plain HTTPS without a
-#'     `googledrive` token (i.e. no `drive_auth()`). This only works for files
-#'     shared as "Anyone with the link". The same no-auth path is taken
-#'     automatically — regardless of this option — when the supplied `url` is the
-#'     public web-download form, e.g.
-#'     `https://drive.google.com/uc?export=download&id=<ID>`.
+#'     When `TRUE`, Google Drive files are accessed without a `googledrive` token
+#'     (i.e. no `drive_auth()`): both the *metadata* read in `assessGoogle()` and
+#'     the download itself are done anonymously (the metadata read by
+#'     deauthorizing `googledrive` so it uses an API key). This only works for
+#'     files shared as "Anyone with the link". The same no-auth path is taken
+#'     automatically — regardless of this option — when no Drive token is loaded
+#'     (the common "cloud reader" case) or when the supplied `url` is the public
+#'     web-download form, e.g.
+#'     `https://drive.google.com/uc?export=download&id=<ID>`. A loaded token (a
+#'     "cloud writer" who needs auth to write a shared cloud cache) is left
+#'     intact.
 #'   }
 #'   \item{`destinationPathShared`}{
 #'     Default: `NULL`. Used in [prepInputs()] and [preProcess()].

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -125,12 +125,17 @@ Previously set \verb{-wo NUM_THREADS=} for \code{gdalProject}.
 }
 \item{\code{gdriveNoAuth}}{
 Default: \code{FALSE}. Used in \code{\link[=prepInputs]{prepInputs()}} and \code{\link[=preProcess]{preProcess()}}.
-When \code{TRUE}, Google Drive files are downloaded over plain HTTPS without a
-\code{googledrive} token (i.e. no \code{drive_auth()}). This only works for files
-shared as "Anyone with the link". The same no-auth path is taken
-automatically — regardless of this option — when the supplied \code{url} is the
-public web-download form, e.g.
-\verb{https://drive.google.com/uc?export=download&id=<ID>}.
+When \code{TRUE}, Google Drive files are accessed without a \code{googledrive} token
+(i.e. no \code{drive_auth()}): both the \emph{metadata} read in \code{assessGoogle()} and
+the download itself are done anonymously (the metadata read by
+deauthorizing \code{googledrive} so it uses an API key). This only works for
+files shared as "Anyone with the link". The same no-auth path is taken
+automatically — regardless of this option — when no Drive token is loaded
+(the common "cloud reader" case) or when the supplied \code{url} is the public
+web-download form, e.g.
+\verb{https://drive.google.com/uc?export=download&id=<ID>}. A loaded token (a
+"cloud writer" who needs auth to write a shared cloud cache) is left
+intact.
 }
 \item{\code{destinationPathShared}}{
 Default: \code{NULL}. Used in \code{\link[=prepInputs]{prepInputs()}} and \code{\link[=preProcess]{preProcess()}}.

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -1,0 +1,68 @@
+# assessGoogle() resolves a PUBLIC Google Drive file's metadata without launching
+# interactive OAuth. The decision + deauthorize helpers are tested offline by
+# mocking the token check and googledrive's auth functions.
+
+test_that(".gdriveShouldGoAnon: anonymous when no token or when gdriveNoAuth", {
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  # no token -> anonymous (the typical cloud-reader / public-file case)
+  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
+  # token present -> keep existing (authenticated) behaviour
+  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
+
+  # explicit opt-in forces anonymous even when a token is present
+  withr::local_options(reproducible.gdriveNoAuth = TRUE)
+  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
+  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
+})
+
+test_that(".gdriveDeauthForPublic deauthorizes when there is no token", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  testthat::local_mocked_bindings(
+    drive_deauth = function(...) deauthed <<- TRUE,
+    drive_token = function(...) stop("must not fetch a token"),
+    .package = "googledrive"
+  )
+
+  res <- reproducible:::.gdriveDeauthForPublic()
+  expect_true(res$deauthed)
+  expect_null(res$token)        # nothing to restore (there was no token)
+  expect_true(deauthed)         # googledrive::drive_deauth() was called
+})
+
+test_that(".gdriveDeauthForPublic is a no-op when a token is present (no opt-in)", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(.gdriveHasToken = function() TRUE)
+  testthat::local_mocked_bindings(
+    drive_deauth = function(...) deauthed <<- TRUE,
+    .package = "googledrive"
+  )
+
+  res <- reproducible:::.gdriveDeauthForPublic()
+  expect_false(res$deauthed)
+  expect_false(deauthed)        # a cloud writer's token is left untouched
+})
+
+test_that(".gdriveDeauthForPublic preserves a token to restore when gdriveNoAuth forces anon", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = TRUE)
+
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(.gdriveHasToken = function() TRUE)
+  testthat::local_mocked_bindings(
+    drive_deauth = function(...) deauthed <<- TRUE,
+    drive_token = function(...) "TOKEN",
+    .package = "googledrive"
+  )
+
+  res <- reproducible:::.gdriveDeauthForPublic()
+  expect_true(res$deauthed)
+  expect_identical(res$token, "TOKEN")  # caller restores this on.exit
+  expect_true(deauthed)
+})


### PR DESCRIPTION
## Problem

In a `setupProject()` / `prepInputs()` on a **public** ("Anyone with the link") Google Drive file, with no `googledrive` token loaded, the user gets an interactive prompt:

```
Is it OK to cache OAuth access credentials in the folder ~/.cache/gargle between R sessions?
1: Yes
2: No
```

Traceback:
```
prepInputs() → preProcess() → pp_resolve_files() → .guessAtFile()
  → assessGoogle() → Cache(retry(googledrive::drive_get(as_id(url))))
  → drive_auth() → gargle interactive OAuth prompt
```

The no-auth download support is defeated by the **metadata** read. `assessGoogle()` calls `googledrive::drive_get()` to resolve the file's name/size, and `drive_get()` with no cached token **launches interactive OAuth even for a public file**. That read happens *before* the download path, so the no-auth download logic (and `reproducible.gdriveNoAuth`, which only gated the download) is never reached. The relevant code comment even *assumed* the metadata had "already been read anonymously" — but `assessGoogle()` never deauthorized, so it prompts.

## Fix

`assessGoogle()` now deauthorizes `googledrive` for the `drive_get()`/`drive_ls()` metadata read when:
- no Drive token is loaded (the typical **cloud reader** / public-file case), or
- `reproducible.gdriveNoAuth = TRUE`.

In deauthorized mode googledrive uses an API key, so a public file's metadata resolves **anonymously, with no prompt**. A loaded token (a **cloud writer**, who needs auth to write the shared cloud cache) keeps the existing authenticated behaviour and is **left intact**; in the edge case of `gdriveNoAuth = TRUE` with a token present, the token is restored on exit.

Two small internal helpers: `.gdriveShouldGoAnon()` (decision) and `.gdriveDeauthForPublic()` (scoped deauthorize + token preservation).

## Tests (offline, mocked)

`test-gdrive-noauth-metadata.R`:
- `.gdriveShouldGoAnon`: anonymous when no token or `gdriveNoAuth`; authenticated when a token is present;
- `.gdriveDeauthForPublic`: deauthorizes (no token to restore) when token-less; **no-op** when a token is present without opt-in; preserves+returns the token to restore when `gdriveNoAuth` forces anonymous with a token present.

## Notes

- Independent of the manifest `404` seen in the same session (a dead `urlRemap` CSV URL, correctly ignored with a warning); the `model`/`studyArea` Drive files aren't in that manifest anyway.
- Aligns with the two-user model: cloud **writers** authenticate (token preserved); cloud **readers** access public files (and a public cloud-cache folder) anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)