### PR TITLE
fix(prepInputs): show full pasteable URL when a Google Drive access fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9053
+Version: 3.1.1.9054
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@
 
 ## bug fixes
 
+* A failed Google Drive access during `prepInputs()` / `preProcess()` now reports
+  the full, browser-pasteable URL instead of only the bare `fileId`. Previously a
+  `googledrive::drive_get()` failure surfaced e.g. `File not found:
+  13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u.`, which cannot be opened in a browser to
+  check the file exists / is shared. `assessGoogle()` now wraps the metadata read
+  and re-raises with `https://drive.google.com/file/d/<id>` (or the original Drive
+  URL), keeping the underlying error detail (e.g. the 404 reason).
+
 * A **public** Google Drive file no longer triggers an interactive OAuth prompt
   ("Is it OK to cache OAuth access credentials ...") during `prepInputs()` /
   `preProcess()` when no `googledrive` token is loaded. The no-auth download path

--- a/R/download.R
+++ b/R/download.R
@@ -651,6 +651,30 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   list(deauthed = TRUE, token = tok)
 }
 
+# A browser-pasteable URL for a Google Drive resource, for use in error messages.
+# googledrive's own errors report only the bare fileId (e.g. "File not found:
+# 13-atqi_..."), which the user cannot paste into a browser to check. If the
+# input is already a Drive URL, echo it; if it is a bare ID, build the viewer
+# URL; otherwise return it unchanged.
+.gdriveBrowserUrl <- function(url) {
+  u <- tryCatch(as.character(url)[1], error = function(e) NA_character_)
+  if (length(u) != 1L || is.na(u) || !nzchar(u)) return(NA_character_)
+  if (isTRUE(tryCatch(isGoogleDriveURL(u), error = function(e) FALSE))) return(u)
+  if (isTRUE(tryCatch(isGoogleID(u), error = function(e) FALSE))) return(googledriveIDtoHumanURL(u))
+  u
+}
+
+# Re-raise a googledrive metadata-access error with the full (pasteable) URL up
+# front, preserving the original error detail (404 reason/location etc.).
+.stopGoogleDriveAccess <- function(url, e) {
+  browserUrl <- .gdriveBrowserUrl(url)
+  stop("Could not access the Google Drive resource:\n  ",
+       if (!is.na(browserUrl)) browserUrl else url,
+       "\n  (open it in a browser to confirm it exists and is shared ",
+       "'Anyone with the link')\n  ",
+       conditionMessage(e), call. = FALSE)
+}
+
 # Does the downloaded file look like Google's HTML interstitial (sign-in page or
 # virus-scan-warning download form) rather than the requested bytes?
 .looksLikeGoogleInterstitial <- function(file) {
@@ -1833,27 +1857,29 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
   # URL. retry() captures its `expr` argument with substitute() and works
   # the same way whether or not it's wrapped in quote().
   # if (is.null(archive) || is.na(archive)) {
-  if (isTRUE(isDirectory(url, FALSE))) {
-    fileAttr <- Cache(
-      retry(retries = 1, googledrive::drive_ls(googledrive::as_id(url),
-                                               shared_drive = team_drive)),
-      verbose = FALSE
-    )
-  } else {
-    if (packageVersion("googledrive") < "2.0.0") {
-      fileAttr <- Cache(
-        retry(retries = 1, googledrive::drive_get(googledrive::as_id(url),
-                                                  team_drive = team_drive)),
+  fileAttr <- tryCatch({
+    if (isTRUE(isDirectory(url, FALSE))) {
+      Cache(
+        retry(retries = 1, googledrive::drive_ls(googledrive::as_id(url),
+                                                 shared_drive = team_drive)),
         verbose = FALSE
       )
     } else {
-      fileAttr <- Cache(
-        retry(retries = 1, googledrive::drive_get(googledrive::as_id(url),
-                                                  shared_drive = team_drive)),
-        verbose = FALSE
-      )
+      if (packageVersion("googledrive") < "2.0.0") {
+        Cache(
+          retry(retries = 1, googledrive::drive_get(googledrive::as_id(url),
+                                                    team_drive = team_drive)),
+          verbose = FALSE
+        )
+      } else {
+        Cache(
+          retry(retries = 1, googledrive::drive_get(googledrive::as_id(url),
+                                                    shared_drive = team_drive)),
+          verbose = FALSE
+        )
+      }
     }
-  }
+  }, error = function(e) .stopGoogleDriveAccess(url, e))
 
   fileSize <- sapply(fileAttr$drive_resource, function(x) x$size)
   if (!is.null(unlist(fileSize))) {

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -66,3 +66,28 @@ test_that(".gdriveDeauthForPublic preserves a token to restore when gdriveNoAuth
   expect_identical(res$token, "TOKEN")  # caller restores this on.exit
   expect_true(deauthed)
 })
+
+# --- error messages carry the full, pasteable URL (not just the bare fileId) ---
+
+test_that(".gdriveBrowserUrl returns a pasteable URL for URLs and bare IDs", {
+  fileUrl <- "https://drive.google.com/file/d/13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u/view?usp=share_link"
+  expect_identical(reproducible:::.gdriveBrowserUrl(fileUrl), fileUrl)         # full URL echoed
+  folderUrl <- "https://drive.google.com/drive/folders/199oEp-TVaCyacwqS4PPf3XWMbhPe4YBN"
+  expect_identical(reproducible:::.gdriveBrowserUrl(folderUrl), folderUrl)
+  # a bare 33-char Drive ID -> the file viewer URL
+  id <- "13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u"
+  expect_identical(reproducible:::.gdriveBrowserUrl(id),
+                   "https://drive.google.com/file/d/13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u")
+  expect_true(is.na(reproducible:::.gdriveBrowserUrl(NA_character_)))
+  expect_true(is.na(reproducible:::.gdriveBrowserUrl("")))
+})
+
+test_that(".stopGoogleDriveAccess surfaces the full URL and the original error", {
+  id <- "13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u"
+  err <- simpleError("Client error: (404) Not Found\nFile not found: 13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u.")
+  # a bare ID becomes a pasteable viewer URL in the message
+  expect_error(reproducible:::.stopGoogleDriveAccess(id, err),
+               "drive\\.google\\.com/file/d/13-atqi")
+  # ...and the original googledrive detail is preserved
+  expect_error(reproducible:::.stopGoogleDriveAccess(id, err), "File not found")
+})


### PR DESCRIPTION
## Problem

When a Google Drive file/folder can't be accessed, the error reports only the bare `fileId`, which you can't paste into a browser to check:

```
Error in retry(retries = 1, googledrive::drive_get(googledrive::as_id(url), ...
  Caused by error in `.f()`:
  ! Client error: (404) Not Found
  File not found: 13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u.
```

## Fix

`assessGoogle()` now wraps the `drive_get()`/`drive_ls()` metadata read and re-raises with the full, browser-pasteable URL up front — the original Drive URL when one was supplied, otherwise `https://drive.google.com/file/d/<id>` built from the id — while preserving the underlying googledrive error detail:

```
Error: Could not access the Google Drive resource:
  https://drive.google.com/file/d/13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u
  (open it in a browser to confirm it exists and is shared 'Anyone with the link')
  Client error: (404) Not Found
File not found: 13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u.
```

## Implementation

- `.gdriveBrowserUrl(url)` — echoes a full Drive URL, builds the viewer URL from a bare 33-char ID (reusing `googledriveIDtoHumanURL()`/`isGoogle*`), returns `NA` for empty input.
- `.stopGoogleDriveAccess(url, e)` — re-raises with the pasteable URL + the original error message.

## Tests (offline)

`test-gdrive-noauth-metadata.R`: `.gdriveBrowserUrl` for file URLs / folder URLs / bare IDs / empty; `.stopGoogleDriveAccess` surfaces both the pasteable URL and the original 404 detail.

Builds on #512 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)