### PR TITLE
fix(prepInputs): respect configured gargle auth before going anonymous on Drive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9053
+Version: 3.1.1.9054
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,15 @@
 
 ## bug fixes
 
+* The public-Drive no-auth metadata read no longer prevents a *configured* user
+  from authenticating. The previous change deauthorized `googledrive` whenever no
+  token was currently *loaded*, but "no token loaded" is not the same as "cannot
+  authenticate": a user with `gargle_oauth_email` (+ `gargle_oauth_cache`) set, or
+  a service-account JSON, can load a cached token silently. `assessGoogle()` now
+  only falls back to anonymous access when token-less **and** gargle has no usable
+  non-interactive auth configured (so `drive_auth()` can silently load the cached
+  token); `reproducible.gdriveNoAuth = TRUE` still forces anonymous.
+
 * A **public** Google Drive file no longer triggers an interactive OAuth prompt
   ("Is it OK to cache OAuth access credentials ...") during `prepInputs()` /
   `preProcess()` when no `googledrive` token is loaded. The no-auth download path

--- a/R/download.R
+++ b/R/download.R
@@ -618,13 +618,35 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   isTRUE(tryCatch(googledrive::drive_has_token(), error = function(e) FALSE))
 }
 
+# Can googledrive authenticate WITHOUT an interactive prompt? TRUE when the user
+# has configured gargle for non-interactive auth: a specific OAuth email (so a
+# cached token at `gargle_oauth_cache` is loaded silently) or a service-account
+# JSON. Used to decide whether a token-less session should still attempt auth
+# (and silently load a cached token) rather than fall back to anonymous access.
+.gdriveCanAuthNonInteractively <- function() {
+  email <- tryCatch(getOption("gargle_oauth_email"), error = function(e) NULL)
+  wantsEmail <- (is.character(email) && length(email) == 1L && !is.na(email) && nzchar(email)) ||
+    isTRUE(email)
+  hasServiceAccount <- nzchar(Sys.getenv("GOOGLEDRIVE_AUTH", "")) ||
+    nzchar(Sys.getenv("GARGLE_SERVICE_ACCOUNT", ""))
+  isTRUE(wantsEmail) || isTRUE(hasServiceAccount)
+}
+
 # Should a Google Drive *metadata* read (drive_get/drive_ls in assessGoogle) be
-# done anonymously, i.e. without triggering interactive OAuth? TRUE when no token
-# is loaded -- the typical "cloud reader" / public-file case -- or when the user
-# opted in via `reproducible.gdriveNoAuth`. A loaded token (a "cloud writer", who
-# needs auth to write the shared cache) otherwise keeps the existing behaviour.
+# done anonymously, i.e. without triggering interactive OAuth?
+#   * `reproducible.gdriveNoAuth = TRUE`  -> always anonymous (explicit opt-in);
+#   * a token is already loaded           -> no (use it -- the "cloud writer" case);
+#   * no token loaded, but gargle is configured to authenticate non-interactively
+#     (an OAuth email or a service account) -> no: let drive_auth() silently load
+#     the cached token. Going anonymous here was a regression that prevented a
+#     configured user from ever authenticating.
+#   * otherwise (no token, no usable auth config) -> yes: the typical "cloud
+#     reader" / public-file case, where authenticating would only mean an
+#     interactive prompt that we want to avoid.
 .gdriveShouldGoAnon <- function(hadToken = .gdriveHasToken()) {
-  isTRUE(getOption("reproducible.gdriveNoAuth", FALSE)) || !isTRUE(hadToken)
+  if (isTRUE(getOption("reproducible.gdriveNoAuth", FALSE))) return(TRUE)
+  if (isTRUE(hadToken)) return(FALSE)
+  !.gdriveCanAuthNonInteractively()
 }
 
 # Put googledrive into anonymous (deauthorized) mode so a metadata read of a

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -2,9 +2,24 @@
 # interactive OAuth. The decision + deauthorize helpers are tested offline by
 # mocking the token check and googledrive's auth functions.
 
-test_that(".gdriveShouldGoAnon: anonymous when no token or when gdriveNoAuth", {
-  withr::local_options(reproducible.gdriveNoAuth = NULL)
-  # no token -> anonymous (the typical cloud-reader / public-file case)
+test_that(".gdriveCanAuthNonInteractively detects a configured email / service account", {
+  withr::local_options(gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  expect_false(reproducible:::.gdriveCanAuthNonInteractively())
+
+  withr::local_options(gargle_oauth_email = "someone@example.com")
+  expect_true(reproducible:::.gdriveCanAuthNonInteractively())
+
+  withr::local_options(gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "/path/to/sa.json")
+  expect_true(reproducible:::.gdriveCanAuthNonInteractively())
+})
+
+test_that(".gdriveShouldGoAnon: anonymous only when token-less AND no usable auth config", {
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+
+  # token-less, no gargle config -> anonymous (cloud-reader / public-file case)
   expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
   # token present -> keep existing (authenticated) behaviour
   expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
@@ -12,12 +27,32 @@ test_that(".gdriveShouldGoAnon: anonymous when no token or when gdriveNoAuth", {
   # explicit opt-in forces anonymous even when a token is present
   withr::local_options(reproducible.gdriveNoAuth = TRUE)
   expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
+})
+
+test_that(".gdriveShouldGoAnon does NOT go anonymous when gargle can auth (regression)", {
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+
+  # a configured OAuth email -> authenticate (load cached token), not anonymous
+  withr::local_options(gargle_oauth_email = "someone@example.com")
+  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
+
+  # a service-account JSON -> authenticate
+  withr::local_options(gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "/path/to/sa.json")
+  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
+
+  # ...but an explicit gdriveNoAuth still forces anonymous
+  withr::local_options(gargle_oauth_email = "someone@example.com",
+                       reproducible.gdriveNoAuth = TRUE)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "")
   expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
 })
 
-test_that(".gdriveDeauthForPublic deauthorizes when there is no token", {
+test_that(".gdriveDeauthForPublic deauthorizes when there is no token (and no auth config)", {
   skip_if_not_installed("googledrive")
-  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
 
   deauthed <- FALSE
   testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)


### PR DESCRIPTION
## Regression

The public-Drive no-auth metadata read (#512) deauthorized `googledrive` whenever no token was currently **loaded**. But "no token loaded" ≠ "cannot authenticate": a user who has configured non-interactive auth —

```r
options(gargle_oauth_email = "me@example.com", gargle_oauth_cache = "~/.secret")
```

— or a service-account JSON, can load a cached token **silently**. The deauth short-circuited that, so a configured user could never authenticate (their cached token was never loaded), even though no prompt would have occurred.

## Fix

`.gdriveShouldGoAnon()` now goes anonymous only when **token-less AND** gargle cannot authenticate non-interactively:

- `reproducible.gdriveNoAuth = TRUE` → anonymous (explicit opt-in);
- a token already loaded → use it;
- no token, but `gargle_oauth_email` (or `GOOGLEDRIVE_AUTH` / `GARGLE_SERVICE_ACCOUNT`) is set → **authenticate** (let `drive_auth()` load the cached token silently);
- no token, no usable auth config → anonymous (the cloud-reader / public-file case).

New helper `.gdriveCanAuthNonInteractively()`.

## Tests

`test-gdrive-noauth-metadata.R`: `.gdriveCanAuthNonInteractively` detection; `.gdriveShouldGoAnon` goes anonymous only when token-less with no auth config, and does **not** when an email / service account is configured (with `gdriveNoAuth` still overriding). Tests control the gargle option and env vars (CI sets `GOOGLEDRIVE_AUTH`).

Builds on #512 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)