### PR TITLE
feat(download): urlRemap can match by Google Drive id (no-auth remap)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9053
+Version: 3.1.1.9054
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 * development version.
 
+## new features
+
+* `reproducible.urlRemap` manifests may now carry an optional **`id` column** (the
+  Google Drive file id; also accepted as `googledriveId`/`googledrive_id`/
+  `driveId`/`gid`). It is used as a *secondary* match, by the id parsed from a
+  Drive `url`, when the resolved filename is unavailable — e.g. an
+  unauthenticated session that cannot read a Drive file's metadata. With it, a
+  Drive URL whose id is in the manifest is redirected to the (public) mirror by
+  `prepInputs()` **before** the Drive metadata lookup, so the download needs no
+  Google authentication at all. Manifests without an `id` column are unchanged.
+
 ## bug fixes
 
 * A **public** Google Drive file no longer triggers an interactive OAuth prompt

--- a/R/download.R
+++ b/R/download.R
@@ -772,6 +772,13 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
 #' supports HTTP Range requests, the parallel download path applies). When there
 #' is no match it returns `NULL`, so the original URL is kept.
 #'
+#' An optional `id` column (also accepted as `googledriveId`, `googledrive_id`,
+#' `driveId` or `gid`) holding the Google Drive file id enables a **secondary**
+#' match by id: when the resolved `filename` is unavailable — e.g. an
+#' unauthenticated session that cannot read a Drive file's metadata — the id is
+#' parsed from the Drive `url` and matched against this column. This lets a
+#' download be redirected to the (public) mirror with no authentication at all.
+#'
 #' The manifest itself — and the responsibility for keeping it current — lives
 #' with the user (for example, a community-maintained mirror manifest);
 #' `reproducible` hard-codes no mirror URLs.
@@ -784,7 +791,9 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
 #'
 #' @param manifest A `data.frame` (or `data.table`) with at least the character
 #'   columns `filename` and `url`. `filename` is matched against the basename of
-#'   the file being downloaded.
+#'   the file being downloaded. An optional `id` column (Google Drive file id) is
+#'   matched secondarily, by the id parsed from the Drive `url`, when no filename
+#'   is available (e.g. an unauthenticated Drive download).
 #'
 #' @return A function of `(url, filename)` returning a replacement URL, or `NULL`
 #'   to keep the original.
@@ -807,20 +816,57 @@ makeUrlRemap <- function(manifest) {
     stop("'manifest' must be a data.frame with columns 'filename' and 'url'")
   }
   urls <- as.character(manifest[["url"]])
-  names(urls) <- basename2(as.character(manifest[["filename"]]))
+  byName <- urls
+  names(byName) <- basename2(as.character(manifest[["filename"]]))
   # Drop rows with empty/NA key or value up front.
-  keep <- nzchar(names(urls)) & !is.na(urls) & nzchar(urls)
-  urls <- urls[keep]
-  function(url, filename) {
-    # Only remap a single file. A length != 1 `filename` (e.g. a Google Drive
-    # directory that resolves to several files) has no single mirror URL, so
-    # keep the original; this also avoids vectorized `is.na()` in `||` below.
-    if (length(filename) != 1L) {
-      return(NULL)
-    }
-    hit <- urls[basename2(filename)]
-    if (length(hit) != 1L || is.na(hit)) NULL else unname(hit)
+  keepN <- nzchar(names(byName)) & !is.na(byName) & nzchar(byName)
+  byName <- byName[keepN]
+
+  # Optional secondary lookup by Google Drive id. When present, a download can be
+  # remapped even if the filename is unknown -- e.g. an unauthenticated session
+  # that cannot resolve a Drive file's name -- by parsing the id out of the url.
+  # Recognise a few likely column names.
+  idCol <- intersect(c("id", "googledriveId", "googledrive_id", "driveId", "gid"),
+                     colnames(manifest))
+  byId <- character(0)
+  if (length(idCol)) {
+    ids <- as.character(manifest[[idCol[[1]]]])
+    byId <- urls
+    names(byId) <- ids
+    keepI <- nzchar(names(byId)) & names(byId) != "NA" & !is.na(byId) & nzchar(byId)
+    byId <- byId[keepI]
   }
+
+  function(url, filename) {
+    # Primary: match on the basename of the resolved filename (a single file). A
+    # length != 1 `filename` (e.g. a Drive directory of several files) has no
+    # single mirror URL, so it is skipped here.
+    if (length(filename) == 1L && !is.na(filename) && nzchar(filename)) {
+      hit <- byName[basename2(filename)]
+      if (length(hit) == 1L && !is.na(hit)) return(unname(hit))
+    }
+    # Secondary: match on the Google Drive id parsed from the url. This lets an
+    # unauthenticated caller (no resolved filename) still redirect to the mirror.
+    if (length(byId) && length(url) == 1L && !is.na(url)) {
+      id <- .extractDriveId(url)
+      if (!is.na(id) && nzchar(id)) {
+        hit <- byId[id]
+        if (length(hit) == 1L && !is.na(hit)) return(unname(hit))
+      }
+    }
+    NULL
+  }
+}
+
+# Extract a Google Drive file/folder id from a Drive URL or a bare id. Returns
+# NA_character_ when none is found. Regex-based, so it needs no googledrive token
+# (the point is to match a manifest by id when the file cannot be authenticated).
+.extractDriveId <- function(url) {
+  u <- tryCatch(as.character(url)[1], error = function(e) NA_character_)
+  if (length(u) != 1L || is.na(u) || !nzchar(u)) return(NA_character_)
+  if (isTRUE(tryCatch(isGoogleID(u), error = function(e) FALSE))) return(u)
+  m <- regmatches(u, regexec("(?:/d/|[?&]id=|/folders/)([A-Za-z0-9_-]{15,})", u, perl = TRUE))[[1]]
+  if (length(m) >= 2L && nzchar(m[[2]])) m[[2]] else NA_character_
 }
 
 #' Resolve and remap a URL early, before the COG fast-path
@@ -851,6 +897,18 @@ makeUrlRemap <- function(manifest) {
 
   isGID <- tryCatch(isGoogleDriveURL(url) || isGoogleID(url), error = function(e) FALSE)
   if (isTRUE(isGID)) {
+    # First try an id-based remap that needs neither authentication nor a
+    # resolved filename: if the manifest lists this Drive id, redirect to the
+    # (public) mirror and skip the Drive metadata lookup -- and its auth --
+    # entirely. Only for single files (a folder has no single mirror URL), and a
+    # no-op (falls through) when there is no id match or no id column.
+    isDir <- tryCatch(isTRUE(isDirectory(url, FALSE)), error = function(e) FALSE)
+    if (!isDir) {
+      early <- .applyUrlRemap(url, filename = NA_character_, verbose = verbose)
+      if (!identical(early, url)) {
+        return(early)
+      }
+    }
     if (!requireNamespace("googledrive", quietly = TRUE)) {
       return(url)
     }

--- a/man/makeUrlRemap.Rd
+++ b/man/makeUrlRemap.Rd
@@ -9,7 +9,9 @@ makeUrlRemap(manifest)
 \arguments{
 \item{manifest}{A \code{data.frame} (or \code{data.table}) with at least the character
 columns \code{filename} and \code{url}. \code{filename} is matched against the basename of
-the file being downloaded.}
+the file being downloaded. An optional \code{id} column (Google Drive file id) is
+matched secondarily, by the id parsed from the Drive \code{url}, when no filename
+is available (e.g. an unauthenticated Drive download).}
 }
 \value{
 A function of \verb{(url, filename)} returning a replacement URL, or \code{NULL}
@@ -26,6 +28,13 @@ supports HTTP Range requests, the parallel download path applies). When there
 is no match it returns \code{NULL}, so the original URL is kept.
 }
 \details{
+An optional \code{id} column (also accepted as \code{googledriveId}, \code{googledrive_id},
+\code{driveId} or \code{gid}) holding the Google Drive file id enables a \strong{secondary}
+match by id: when the resolved \code{filename} is unavailable — e.g. an
+unauthenticated session that cannot read a Drive file's metadata — the id is
+parsed from the Drive \code{url} and matched against this column. This lets a
+download be redirected to the (public) mirror with no authentication at all.
+
 The manifest itself — and the responsibility for keeping it current — lives
 with the user (for example, a community-maintained mirror manifest);
 \code{reproducible} hard-codes no mirror URLs.

--- a/tests/testthat/test-parallel-download-remap.R
+++ b/tests/testthat/test-parallel-download-remap.R
@@ -55,6 +55,68 @@ test_that("makeUrlRemap validates its manifest argument", {
                "filename.*url|columns")
 })
 
+test_that(".extractDriveId parses an id from the various Drive URL forms", {
+  id <- "13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u"
+  expect_identical(reproducible:::.extractDriveId(
+    paste0("https://drive.google.com/file/d/", id, "/view?usp=share_link")), id)
+  expect_identical(reproducible:::.extractDriveId(
+    paste0("https://drive.google.com/open?id=", id)), id)
+  expect_identical(reproducible:::.extractDriveId(
+    paste0("https://drive.google.com/uc?export=download&id=", id)), id)
+  expect_identical(reproducible:::.extractDriveId(
+    "https://drive.google.com/drive/folders/199oEp-TVaCyacwqS4PPf3XWMbhPe4YBN"),
+    "199oEp-TVaCyacwqS4PPf3XWMbhPe4YBN")
+  expect_identical(reproducible:::.extractDriveId(id), id)               # bare id
+  expect_true(is.na(reproducible:::.extractDriveId("https://example.com/a.tif")))
+  expect_true(is.na(reproducible:::.extractDriveId("")))
+})
+
+test_that("makeUrlRemap remaps by Drive id (secondarily) when filename is unknown", {
+  id <- "13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u"
+  manifest <- data.frame(
+    filename = "a.tif",
+    url = "https://mirror/a.tif",
+    id = id,
+    stringsAsFactors = FALSE
+  )
+  remap <- reproducible::makeUrlRemap(manifest)
+
+  # filename match still works (primary)
+  expect_identical(remap("gd://whatever", "a.tif"), "https://mirror/a.tif")
+  # no filename -> match by id parsed from the (Drive) url (secondary)
+  expect_identical(
+    remap(paste0("https://drive.google.com/file/d/", id, "/view"), NA_character_),
+    "https://mirror/a.tif"
+  )
+  expect_identical(remap(id, NA_character_), "https://mirror/a.tif")   # bare id url
+  # an id not in the manifest -> NULL
+  expect_null(remap("https://drive.google.com/file/d/NOPEnopeNOPEnopeNOPEnope12345/view",
+                    NA_character_))
+})
+
+test_that("makeUrlRemap without an id column behaves exactly as before", {
+  manifest <- data.frame(filename = "a.tif", url = "https://mirror/a.tif",
+                         stringsAsFactors = FALSE)
+  remap <- reproducible::makeUrlRemap(manifest)
+  expect_identical(remap("gd://x", "a.tif"), "https://mirror/a.tif")
+  # no id column -> a filename-less call cannot match -> NULL
+  expect_null(remap("https://drive.google.com/file/d/13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u/view",
+                    NA_character_))
+})
+
+test_that(".remapUrlEarly redirects a Drive URL by id WITHOUT calling assessGoogle", {
+  id <- "13-atqi_7ogRPIFxOoJZoUDYdQCJ5-a_u"
+  manifest <- data.frame(filename = "a.tif", url = "https://mirror/a.tif",
+                         id = id, stringsAsFactors = FALSE)
+  withr::local_options(reproducible.urlRemap = manifest)
+  # If the id matches, the Drive metadata lookup (and thus auth) must be skipped.
+  testthat::local_mocked_bindings(
+    assessGoogle = function(...) stop("assessGoogle must not be called when id matches"))
+  out <- reproducible:::.remapUrlEarly(
+    paste0("https://drive.google.com/file/d/", id, "/view"), verbose = 0)
+  expect_identical(out, "https://mirror/a.tif")
+})
+
 test_that(".applyUrlRemap returns the original url when the option is unset", {
   withr::local_options(reproducible.urlRemap = NULL)
   expect_identical(


### PR DESCRIPTION
## Motivation

When a session is **not authenticated**, it can't resolve a Google Drive file's *name*, so a filename-keyed `urlRemap` manifest can't match — and the download falls back to the Drive path (which needs auth). But the Drive **id** is right there in the URL. Carrying the id in the manifest lets us redirect to the public mirror by id, with no auth and no metadata lookup.

## What

- `makeUrlRemap()` manifests may now include an optional **`id` column** (also accepted as `googledriveId`/`googledrive_id`/`driveId`/`gid`). It's a **secondary** match: filename first, then — when no filename is available — the id parsed from the Drive `url`.
- `.remapUrlEarly()` tries the id-based remap **before** `assessGoogle()`, so a Drive URL whose id is in the manifest is redirected to the (public) mirror **before any Drive metadata lookup or authentication**. Gated to single files (a folder has no single mirror URL).
- New helper `.extractDriveId()` (regex; handles `/d/<id>`, `?id=<id>`, `/folders/<id>`, bare id; no googledrive dependency).
- Manifests **without** an `id` column behave exactly as before.

This composes with the data.frame/CSV option form (#510) and the no-auth metadata read (#512): a cloud **reader** with no token, given a Drive `share_link` URL whose id is in the manifest, fetches from the public mirror with zero Google auth.

## Tests (offline)

`test-parallel-download-remap.R`:
- `.extractDriveId` across the Drive URL forms + bare id + non-Drive;
- `makeUrlRemap` secondary id match (filename-less) and no-id-column unchanged;
- `.remapUrlEarly` redirects a Drive URL by id **without calling `assessGoogle`** (mocked to fail if called).

## Note

The manifest's `id` column is produced by whoever builds the manifest (e.g. `googledrive::drive_ls()` gives `name` + `id`); `reproducible` stays a pure consumer and hard-codes no mirror URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)