### PR TITLE
fix(prepInputs): try Drive auth non-interactively, fall back to public (no prompt)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9054
+Version: 3.1.1.9055
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,24 @@
 
 * development version.
 
+## bug fixes
+
+* A public Google Drive file could still launch an interactive OAuth prompt when
+  a service account was configured via the `GOOGLEDRIVE_AUTH` environment variable
+  (or any case where "auth is configured" did not mean "auth will actually
+  succeed silently"). The previous logic *guessed* from gargle options/env whether
+  authentication was possible, then let `drive_get()` attempt it — but plain
+  `drive_auth()` does not consult `GOOGLEDRIVE_AUTH`, so the guess was a false
+  positive that fell through to the prompt. `assessGoogle()` now *attempts*
+  authentication non-interactively instead of guessing: it tries the
+  `GOOGLEDRIVE_AUTH`/`GARGLE_SERVICE_ACCOUNT` service-account JSON, then a cached
+  user token, with `rlang_interactive` forced `FALSE` so a missing token errors
+  *quietly* rather than prompting; only if nothing usable loads does it
+  deauthorize and read the public file anonymously. Net: a loaded or
+  silently-loadable token (incl. a service account) is used; a public file always
+  resolves with no prompt; `reproducible.gdriveNoAuth = TRUE` still forces the
+  public path.
+
 ## new features
 
 * `reproducible.urlRemap` manifests may now carry an optional **`id` column** (the

--- a/R/download.R
+++ b/R/download.R
@@ -618,59 +618,48 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   isTRUE(tryCatch(googledrive::drive_has_token(), error = function(e) FALSE))
 }
 
-# Can googledrive authenticate WITHOUT an interactive prompt? TRUE when the user
-# has configured gargle for non-interactive auth: a specific OAuth email (so a
-# cached token at `gargle_oauth_cache` is loaded silently) or a service-account
-# JSON. Used to decide whether a token-less session should still attempt auth
-# (and silently load a cached token) rather than fall back to anonymous access.
-.gdriveCanAuthNonInteractively <- function() {
-  email <- tryCatch(getOption("gargle_oauth_email"), error = function(e) NULL)
-  wantsEmail <- (is.character(email) && length(email) == 1L && !is.na(email) && nzchar(email)) ||
-    isTRUE(email)
-  hasServiceAccount <- nzchar(Sys.getenv("GOOGLEDRIVE_AUTH", "")) ||
-    nzchar(Sys.getenv("GARGLE_SERVICE_ACCOUNT", ""))
-  isTRUE(wantsEmail) || isTRUE(hasServiceAccount)
+# Attempt googledrive authentication WITHOUT ever prompting. In order:
+#   1. a service-account JSON in `GOOGLEDRIVE_AUTH` (reproducible's convention) or
+#      `GARGLE_SERVICE_ACCOUNT` -- `drive_auth(path = ...)`, fully non-interactive;
+#   2. otherwise a cached user token -- `drive_auth()` with `rlang_interactive`
+#      forced FALSE, so a missing token ERRORS quietly instead of launching OAuth.
+# If nothing usable is available the attempt fails quietly (returns FALSE). Plain
+# `drive_auth()` does NOT itself consult `GOOGLEDRIVE_AUTH` (that is reproducible's
+# own env var), so step 1 is what actually honours a configured service account.
+# Returns TRUE iff a token is loaded afterwards.
+.gdriveTryAuthQuietly <- function() {
+  if (!requireNamespace("googledrive", quietly = TRUE)) return(FALSE)
+  op <- options(rlang_interactive = FALSE)
+  on.exit(options(op), add = TRUE)
+  saPath <- Sys.getenv("GOOGLEDRIVE_AUTH", Sys.getenv("GARGLE_SERVICE_ACCOUNT", ""))
+  isTRUE(tryCatch({
+    if (nzchar(saPath) && file.exists(path.expand(saPath))) {
+      suppressMessages(googledrive::drive_auth(path = path.expand(saPath)))
+    } else {
+      suppressMessages(googledrive::drive_auth())
+    }
+    isTRUE(googledrive::drive_has_token())
+  }, error = function(e) FALSE))
 }
 
-# Should a Google Drive *metadata* read (drive_get/drive_ls in assessGoogle) be
-# done anonymously, i.e. without triggering interactive OAuth?
-#   * `reproducible.gdriveNoAuth = TRUE`  -> always anonymous (explicit opt-in);
-#   * a token is already loaded           -> no (use it -- the "cloud writer" case);
-#   * no token loaded, but gargle is configured to authenticate non-interactively
-#     (an OAuth email or a service account) -> no: let drive_auth() silently load
-#     the cached token. Going anonymous here was a regression that prevented a
-#     configured user from ever authenticating.
-#   * otherwise (no token, no usable auth config) -> yes: the typical "cloud
-#     reader" / public-file case, where authenticating would only mean an
-#     interactive prompt that we want to avoid.
-.gdriveShouldGoAnon <- function(hadToken = .gdriveHasToken()) {
-  if (isTRUE(getOption("reproducible.gdriveNoAuth", FALSE))) return(TRUE)
-  if (isTRUE(hadToken)) return(FALSE)
-  !.gdriveCanAuthNonInteractively()
-}
-
-# Put googledrive into anonymous (deauthorized) mode so a metadata read of a
-# public ("Anyone with the link") file resolves via an API key instead of
-# launching an interactive OAuth flow. Without this, `googledrive::drive_get()`
-# with no cached token PROMPTS ("Is it OK to cache OAuth credentials ...") even
-# for a public file. Returns a small list the caller uses to restore state:
-#   - deauthed: did we deauthorize?
-#   - token:    the previously-loaded token (or NULL) to restore on.exit, used
-#               only in the edge case of `gdriveNoAuth = TRUE` *with* a token
-#               present (so a cloud writer's token is never clobbered).
-# A no-token deauthorization is left in place (there was nothing to restore, and
-# the session was already token-less). No-op when googledrive is unavailable.
-.gdriveDeauthForPublic <- function() {
-  if (!requireNamespace("googledrive", quietly = TRUE)) return(list(deauthed = FALSE))
-  hadToken <- .gdriveHasToken()
-  if (!.gdriveShouldGoAnon(hadToken)) return(list(deauthed = FALSE))
-  tok <- if (isTRUE(hadToken)) {
-    tryCatch(googledrive::drive_token(), error = function(e) NULL)
-  } else {
-    NULL
+# Establish the googledrive auth state for a metadata/download operation, NEVER
+# prompting, and report which path to take ("token" or "anon"):
+#   * a token is already loaded            -> "token" (works public + private);
+#   * `reproducible.gdriveNoAuth = TRUE`    -> deauthorize, "anon" (public only);
+#   * otherwise *try* to authenticate quietly (a cached token / service account
+#     loads silently). If that succeeds -> "token"; if it fails (nothing usable,
+#     and we never prompt) -> deauthorize and "anon" (read the PUBLIC file).
+# This replaces guessing from gargle options ("is an email set?") with an actual,
+# non-prompting attempt -- so a public file always resolves with no prompt, while
+# a configured user's cached token is still used for private files.
+.gdrivePrepareAuth <- function() {
+  if (!requireNamespace("googledrive", quietly = TRUE)) return("anon")
+  if (.gdriveHasToken()) return("token")
+  if (!isTRUE(getOption("reproducible.gdriveNoAuth", FALSE)) && isTRUE(.gdriveTryAuthQuietly())) {
+    return("token")
   }
   try(googledrive::drive_deauth(), silent = TRUE)
-  list(deauthed = TRUE, token = tok)
+  "anon"
 }
 
 # A browser-pasteable URL for a Google Drive resource, for use in error messages.
@@ -1910,17 +1899,13 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
     on.exit(options(opts), add = TRUE)
   }
 
-  # Resolve a PUBLIC file's metadata without launching interactive OAuth. With no
-  # cached token, `drive_get()`/`drive_ls()` below would otherwise prompt ("Is it
-  # OK to cache OAuth credentials ...") even for an "Anyone with the link" file --
-  # the metadata read happens before (and so defeats) the no-auth download path.
-  # Deauthorizing makes googledrive use an API key, so a public file resolves
-  # anonymously. A loaded token (cloud writer) is preserved; in the edge case of
-  # `gdriveNoAuth = TRUE` with a token present, it is restored on exit.
-  .anonRead <- .gdriveDeauthForPublic()
-  if (isTRUE(.anonRead$deauthed) && !is.null(.anonRead$token)) {
-    on.exit(try(googledrive::drive_auth(token = .anonRead$token), silent = TRUE), add = TRUE)
-  }
+  # Establish auth state without ever prompting: use a loaded token, else try to
+  # authenticate quietly (cached token / service account, no prompt), else
+  # deauthorize and read the PUBLIC file's metadata anonymously. Without this,
+  # `drive_get()`/`drive_ls()` below would launch the OAuth prompt ("Is it OK to
+  # cache OAuth credentials ...") even for an "Anyone with the link" file -- and
+  # the metadata read happens before (so defeats) the no-auth download path.
+  .gdrivePrepareAuth()
 
   # Cache the drive_get / drive_ls result indefinitely. The Cache key
   # includes the URL/ID, so each distinct file pays one API hit ever per

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -2,103 +2,90 @@
 # interactive OAuth. The decision + deauthorize helpers are tested offline by
 # mocking the token check and googledrive's auth functions.
 
-test_that(".gdriveCanAuthNonInteractively detects a configured email / service account", {
-  withr::local_options(gargle_oauth_email = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
-  expect_false(reproducible:::.gdriveCanAuthNonInteractively())
-
-  withr::local_options(gargle_oauth_email = "someone@example.com")
-  expect_true(reproducible:::.gdriveCanAuthNonInteractively())
-
-  withr::local_options(gargle_oauth_email = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "/path/to/sa.json")
-  expect_true(reproducible:::.gdriveCanAuthNonInteractively())
-})
-
-test_that(".gdriveShouldGoAnon: anonymous only when token-less AND no usable auth config", {
-  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
-
-  # token-less, no gargle config -> anonymous (cloud-reader / public-file case)
-  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
-  # token present -> keep existing (authenticated) behaviour
-  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
-
-  # explicit opt-in forces anonymous even when a token is present
-  withr::local_options(reproducible.gdriveNoAuth = TRUE)
-  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = TRUE))
-})
-
-test_that(".gdriveShouldGoAnon does NOT go anonymous when gargle can auth (regression)", {
-  withr::local_options(reproducible.gdriveNoAuth = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
-
-  # a configured OAuth email -> authenticate (load cached token), not anonymous
-  withr::local_options(gargle_oauth_email = "someone@example.com")
-  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
-
-  # a service-account JSON -> authenticate
-  withr::local_options(gargle_oauth_email = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "/path/to/sa.json")
-  expect_false(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
-
-  # ...but an explicit gdriveNoAuth still forces anonymous
-  withr::local_options(gargle_oauth_email = "someone@example.com",
-                       reproducible.gdriveNoAuth = TRUE)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "")
-  expect_true(reproducible:::.gdriveShouldGoAnon(hadToken = FALSE))
-})
-
-test_that(".gdriveDeauthForPublic deauthorizes when there is no token (and no auth config)", {
+test_that(".gdriveTryAuthQuietly authenticates via a service-account JSON when present", {
   skip_if_not_installed("googledrive")
-  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = NULL)
-  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  withr::local_options(gargle_oauth_email = NULL)
+  sa <- withr::local_tempfile(fileext = ".json")
+  writeLines("{}", sa)                        # a file that exists
+  withr::local_envvar(GOOGLEDRIVE_AUTH = sa, GARGLE_SERVICE_ACCOUNT = "")
 
-  deauthed <- FALSE
-  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  authPath <- NULL
   testthat::local_mocked_bindings(
-    drive_deauth = function(...) deauthed <<- TRUE,
-    drive_token = function(...) stop("must not fetch a token"),
+    drive_auth = function(...) { authPath <<- list(...)$path; invisible() },
+    drive_has_token = function(...) TRUE,
     .package = "googledrive"
   )
-
-  res <- reproducible:::.gdriveDeauthForPublic()
-  expect_true(res$deauthed)
-  expect_null(res$token)        # nothing to restore (there was no token)
-  expect_true(deauthed)         # googledrive::drive_deauth() was called
+  expect_true(reproducible:::.gdriveTryAuthQuietly())
+  # it honoured GOOGLEDRIVE_AUTH by passing path = the service-account JSON
+  expect_identical(normalizePath(authPath, mustWork = FALSE),
+                   normalizePath(sa, mustWork = FALSE))
 })
 
-test_that(".gdriveDeauthForPublic is a no-op when a token is present (no opt-in)", {
+test_that(".gdriveTryAuthQuietly fails QUIETLY (no prompt) when no token is available", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  # gargle errors (rather than prompting) under forced non-interactive when it has
+  # no token; emulate that here.
+  testthat::local_mocked_bindings(
+    drive_auth = function(...) stop("Can't get Google credentials"),
+    drive_has_token = function(...) FALSE,
+    .package = "googledrive"
+  )
+  expect_false(reproducible:::.gdriveTryAuthQuietly())
+})
+
+test_that(".gdrivePrepareAuth: a loaded token -> 'token' (no auth attempt, no deauth)", {
   skip_if_not_installed("googledrive")
   withr::local_options(reproducible.gdriveNoAuth = NULL)
-
-  deauthed <- FALSE
-  testthat::local_mocked_bindings(.gdriveHasToken = function() TRUE)
+  deauthed <- FALSE; tried <- FALSE
   testthat::local_mocked_bindings(
-    drive_deauth = function(...) deauthed <<- TRUE,
-    .package = "googledrive"
-  )
-
-  res <- reproducible:::.gdriveDeauthForPublic()
-  expect_false(res$deauthed)
-  expect_false(deauthed)        # a cloud writer's token is left untouched
+    .gdriveHasToken = function() TRUE,
+    .gdriveTryAuthQuietly = function() { tried <<- TRUE; FALSE })
+  testthat::local_mocked_bindings(drive_deauth = function(...) deauthed <<- TRUE,
+                                  .package = "googledrive")
+  expect_identical(reproducible:::.gdrivePrepareAuth(), "token")
+  expect_false(tried)        # already authenticated; no need to try
+  expect_false(deauthed)     # token left intact
 })
 
-test_that(".gdriveDeauthForPublic preserves a token to restore when gdriveNoAuth forces anon", {
+test_that(".gdrivePrepareAuth: no token + quiet auth succeeds -> 'token'", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(
+    .gdriveHasToken = function() FALSE,
+    .gdriveTryAuthQuietly = function() TRUE)
+  testthat::local_mocked_bindings(drive_deauth = function(...) deauthed <<- TRUE,
+                                  .package = "googledrive")
+  expect_identical(reproducible:::.gdrivePrepareAuth(), "token")
+  expect_false(deauthed)
+})
+
+test_that(".gdrivePrepareAuth: no token + quiet auth fails -> deauthorize, 'anon'", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(
+    .gdriveHasToken = function() FALSE,
+    .gdriveTryAuthQuietly = function() FALSE)
+  testthat::local_mocked_bindings(drive_deauth = function(...) deauthed <<- TRUE,
+                                  .package = "googledrive")
+  expect_identical(reproducible:::.gdrivePrepareAuth(), "anon")
+  expect_true(deauthed)      # fell back to anonymous/public
+})
+
+test_that(".gdrivePrepareAuth: gdriveNoAuth=TRUE + no token -> 'anon' without trying auth", {
   skip_if_not_installed("googledrive")
   withr::local_options(reproducible.gdriveNoAuth = TRUE)
-
-  deauthed <- FALSE
-  testthat::local_mocked_bindings(.gdriveHasToken = function() TRUE)
+  deauthed <- FALSE; tried <- FALSE
   testthat::local_mocked_bindings(
-    drive_deauth = function(...) deauthed <<- TRUE,
-    drive_token = function(...) "TOKEN",
-    .package = "googledrive"
-  )
-
-  res <- reproducible:::.gdriveDeauthForPublic()
-  expect_true(res$deauthed)
-  expect_identical(res$token, "TOKEN")  # caller restores this on.exit
+    .gdriveHasToken = function() FALSE,
+    .gdriveTryAuthQuietly = function() { tried <<- TRUE; TRUE })
+  testthat::local_mocked_bindings(drive_deauth = function(...) deauthed <<- TRUE,
+                                  .package = "googledrive")
+  expect_identical(reproducible:::.gdrivePrepareAuth(), "anon")
+  expect_false(tried)        # forced anon never attempts auth
   expect_true(deauthed)
 })
 


### PR DESCRIPTION
## Problem

A **public** Drive file still launched the OAuth prompt when a **service account** was configured via `GOOGLEDRIVE_AUTH`:

```r
Sys.getenv("GOOGLEDRIVE_AUTH")
#> "~/genial-cycling-408722-788552a3ecac.json"
reproducible::prepInputs(url = "https://drive.google.com/file/d/1ILE0.../view?usp=share_link")
#> Is it OK to cache OAuth access credentials in the folder ~/.cache/gargle ...?
```

The previous logic **guessed** from gargle options/env whether auth was possible (`GOOGLEDRIVE_AUTH` set ⇒ "can auth"), then let `drive_get()` attempt it. But plain `drive_auth()` does **not** consult `GOOGLEDRIVE_AUTH` (only reproducible's test helper passes `path=`), so the guess was a false positive that fell straight through to the interactive prompt.

## Fix: attempt, don't guess

Replace `.gdriveShouldGoAnon` / `.gdriveCanAuthNonInteractively` / `.gdriveDeauthForPublic` with an actual **non-prompting attempt**:

- **`.gdriveTryAuthQuietly()`** — tries the `GOOGLEDRIVE_AUTH`/`GARGLE_SERVICE_ACCOUNT` service-account JSON (`drive_auth(path=)`), then a cached user token, with `rlang_interactive` forced `FALSE` so a missing token **errors quietly instead of prompting**. Returns whether a token loaded.
- **`.gdrivePrepareAuth()`** — token already loaded → use it; else (unless `gdriveNoAuth=TRUE`) try quiet auth → use it on success; else **deauthorize and read the public file anonymously**.

So: a loaded or silently-loadable token (incl. a service account) authenticates; a public file **always** resolves with no prompt; `reproducible.gdriveNoAuth = TRUE` still forces the public path. This is the "try auth, fail silently, then public" sequence requested.

## Verified end-to-end

On the real public URL, against this branch:
- `GOOGLEDRIVE_AUTH` = SA JSON (exists) → **authenticates via the SA** (`token=TRUE`), resolves the file, **no prompt**.
- `GOOGLEDRIVE_AUTH` unset → **anonymous** (`token=FALSE`), resolves the file, **no prompt**.

## Tests

`test-gdrive-noauth-metadata.R` rewritten: `.gdriveTryAuthQuietly` honours the SA JSON path / fails quietly with no token; `.gdrivePrepareAuth` returns token vs anon across loaded-token / quiet-auth-success / quiet-auth-fail / `gdriveNoAuth=TRUE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)