### PR TITLE
ci(test-coverage): stop spurious red from cancelled coverage runs

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,7 +13,14 @@ name: test-coverage
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Do NOT cancel in-progress coverage runs. test-coverage runs only on pushes to
+  # the integration branches, and merges frequently land minutes apart while a
+  # covr run takes ~25 min. With cancel-in-progress:true, each new merge sent
+  # SIGTERM (exit 143) to the previous, still-running coverage run; combined with
+  # the old `continue-on-error` + re-fail step that surfaced on `development` as a
+  # spurious red "failure" rather than a neutral "cancelled". Queue them instead so
+  # every merge's coverage runs to completion and reports a real pass/fail.
+  cancel-in-progress: false
 jobs:
   test-coverage:
     # Mirrors the recipe used by PredictiveEcology/SpaDES.tools, which is
@@ -58,12 +65,20 @@ jobs:
 
       - id: covr
         name: Test coverage
-        continue-on-error: true
+        # Fail fast on a genuine hang (e.g. a network test that never returns)
+        # instead of waiting for an opaque external SIGTERM at job timeout.
+        timeout-minutes: 45
         # Wrap covr in tryCatch so the per-session tempdir's
         # `test-all.Rout.fail` is dumped to the GHA log _before_ R exits and
         # the tempdir is cleaned up. Without this, a covr failure surfaces
         # only as an opaque "Failure in <path>/test-all.Rout.fail" with the
         # actual failing test names and tracebacks lost.
+        #
+        # `covr::codecov()` both runs the test suite (to compute coverage) and
+        # uploads to codecov.io. We must distinguish the two failure modes:
+        #   * a real test/coverage failure leaves a `test-all.Rout.fail` -> RED,
+        #   * a transient codecov.io UPLOAD error (network) leaves none and must
+        #     NOT redden the integration branch, since coverage itself succeeded.
         run: |
           res <- tryCatch(
             covr::codecov(token = Sys.getenv("CODECOV_TOKEN")),
@@ -81,10 +96,13 @@ jobs:
               cat(readLines(f, warn = FALSE), sep = "\n")
               cat("\n")
             }
-            stop(res)
+            if (length(files)) {
+              stop(res)  # genuine test/coverage failure -> fail the job
+            }
+            message(
+              "covr::codecov() errored with no test-all.Rout.fail present; ",
+              "treating as a transient codecov.io upload failure (non-fatal): ",
+              conditionMessage(res)
+            )
           }
         shell: Rscript {0}
-
-      - if: steps.covr.outcome == 'failure'
-        name: Re-fail the job
-        run: exit 1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-09
-Version: 3.1.1.9055
+Version: 3.1.1.9056
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",


### PR DESCRIPTION
## Problem

`test-coverage` on `development` is almost always red, failing with **exit 143 (SIGTERM)** — not a test assertion. It flaps independently of code changes (e.g. #506 ✅, #507 ❌, #508 ❌, #509 ❌, #515 ❌).

## Root cause

Exit 143 = SIGTERM = GitHub's **cancellation** signal. The workflow had `concurrency.cancel-in-progress: true` on group `test-coverage-${ref}`. Since `test-coverage` runs on every push to `development` and merges land minutes apart while a covr run takes ~25 min, **each new merge cancelled the previous still-running coverage run**.

That cancellation should have surfaced as a neutral `cancelled`, but the `continue-on-error: true` covr step + the separate "Re-fail the job" `exit 1` step converted it into a **red `failure`**. Evidence: on the `failure` runs, all real steps are green and the post-cleanup steps are `skipped` — the signature of a run cancellation, not a covr crash.

## Fix

1. **`cancel-in-progress: false`** — queue coverage runs so each merge's coverage runs to completion instead of being SIGTERM-killed by the next merge.
2. **`timeout-minutes: 45`** on the covr step — a genuine hang (e.g. a network test that never returns) now fails fast with a clear signal instead of an opaque external kill.
3. **Distinguish failure modes** — `covr::codecov()` both runs the suite and uploads. A real test/coverage failure leaves a `test-all.Rout.fail` → job **RED**; a transient `codecov.io` **upload** error leaves none and is now **non-fatal** (coverage itself succeeded). This replaces the `continue-on-error` + re-fail dance, which is removed.

Coverage computation semantics are unchanged (same `covr::codecov()` call). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)