### PR TITLE
perf(cache): memoise cloud showSimilar metadata downloads via Cache()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-09
-Version: 3.1.1.9056
+Date: 2026-06-11
+Version: 3.1.1.9057
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-06-11
-Version: 3.1.1.9057
+Version: 3.1.1.9058
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -150,7 +150,12 @@
   It now downloads the small per-`cacheId` metadata files (`.dbFile.*`) from the
   cloud folder, folds them into the local cache listing, and follows the normal
   `showSimilar` path. Only metadata files are fetched (not the cached objects),
-  and `cacheId`s already present locally are skipped.
+  `cacheId`s already present locally are skipped, and each remote metadata file
+  is itself wrapped in `Cache()` (keyed by its `cacheId`) so the many `Cache()`
+  calls in a single run (e.g. a module's `.inputObjects`) do not re-download the
+  same `.dbFile` repeatedly across calls or sessions. That memo lives in a
+  dedicated `cloudMeta` sub-cache, so it does not bloat the main cache's
+  `showCache()` scans.
 
 * New option `reproducible.digestVersion` — a single integer that selects the
   `cacheId` (digest) algorithm, replacing the per-version booleans

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -268,6 +268,29 @@ cloudDownload <- function(outputHash, newFileName, gdriveLs, cachePath, cloudFol
   inReposPoss
 }
 
+# Download + load a single cloud metadata (`.dbFile`) file. Deliberately errors
+# (rather than returning NULL) on failure so that a transient download error is
+# NOT memoised by the Cache() wrapper in showCacheCloud() -- only successful
+# loads are cached. The tmp download is removed once loaded; the returned
+# data.table is what Cache() keeps.
+# NOTE: the content key is named `hash`, NOT `cacheId`, on purpose -- `cacheId`
+# is in `.defaultCacheOmitArgs`, so a Cache() wrapper keyed on an arg named
+# `cacheId` would drop it from the digest and collapse every file onto one
+# cache entry. `hash` is not reserved, so each file keys distinctly.
+.downloadCloudDBFile <- function(id, name, hash, cachePath,
+                                 drv = getDrv(getOption("reproducible.drv", NULL)),
+                                 conn = getOption("reproducible.conn", NULL),
+                                 verbose = getOption("reproducible.verbose")) {
+  localFile <- file.path(tempdir2(), basename2(name))
+  on.exit(unlink(localFile), add = TRUE)
+  retry(quote(googledrive::drive_download(
+    file = googledrive::as_id(id), path = localFile, overwrite = TRUE
+  )))
+  loadFile(localFile, cacheSaveFormat = fileExt(localFile),
+           cacheId = hash, cachePath = cachePath,
+           drv = drv, conn = conn, verbose = verbose - 2)
+}
+
 #' List and read all cloud cache metadata (dbFile) files
 #'
 #' Downloads every per-`cacheId` metadata file (the small `.dbFile.*` files) from
@@ -310,21 +333,31 @@ showCacheCloud <- function(cloudFolderID, cachePath, existingCacheIds = characte
   if (NROW(gdriveLs) == 0)
     return(.emptyCacheTable)
 
-  messageCache("Retrieving ", NROW(gdriveLs),
-               " cloud cache metadata file(s) for showSimilar", verbose = verbose)
-
+  # Each metadata file is content-addressed by its cacheId, so wrap the
+  # download in Cache() keyed on cacheId (everything else -- the volatile
+  # gdrive id, the connection objects, etc. -- is omitted from the digest).
+  # The many Cache() calls in a single run (e.g. a module's `.inputObjects`)
+  # then resolve from the cache instead of re-downloading the same `.dbFile`
+  # over and over. useCloud/showSimilar are off on the inner call so it cannot
+  # recurse back into cloud listing or showSimilar.
+  #
+  # These memo entries live in a dedicated sub-cache ("cloudMeta") so they do
+  # NOT land in the main cache's `cacheOutputs/` dir -- showCache()/showSimilar
+  # scan only the main dir, so the metadata memo never bloats those scans (and
+  # is not touched by clearCache() on the main repo). conn = NULL lets the inner
+  # Cache manage the sub-cache's own connection when useDBI is TRUE.
+  cloudMetaPath <- checkPath(file.path(cachePath, "cloudMeta"), create = TRUE)
   dts <- lapply(seq_len(NROW(gdriveLs)), function(ind) {
-    localFile <- file.path(tempdir2(), basename2(gdriveLs[["name"]][ind]))
-    dl <- try(retry(quote(googledrive::drive_download(
-      file = googledrive::as_id(gdriveLs[["id"]][ind]),
-      path = localFile, overwrite = TRUE
-    ))), silent = TRUE)
-    if (is(dl, "try-error"))
-      return(NULL)
-    out <- try(loadFile(localFile, cacheSaveFormat = fileExt(localFile),
-                        cacheId = cacheIds[ind], cachePath = cachePath,
-                        drv = drv, conn = conn, verbose = verbose - 2),
-               silent = TRUE)
+    out <- try(
+      .downloadCloudDBFile(id = gdriveLs[["id"]][ind], name = gdriveLs[["name"]][ind],
+                           hash = cacheIds[ind], cachePath = cloudMetaPath,
+                           drv = drv, conn = conn, verbose = verbose) |>
+        Cache(useCloud = FALSE, showSimilar = FALSE, cachePath = cloudMetaPath,
+              omitArgs = c("id", "name", "cachePath", "drv", "conn", "verbose"),
+              userTags = paste0("cloudCacheId:", cacheIds[ind]),
+              .functionName = "cloudDBFileMeta",
+              drv = drv, conn = NULL, verbose = verbose - 2),
+      silent = TRUE)
     if (is(out, "try-error")) NULL else out
   })
   dts <- Filter(Negate(is.null), dts)

--- a/tests/testthat/test-cloud-helpers.R
+++ b/tests/testthat/test-cloud-helpers.R
@@ -35,6 +35,35 @@ test_that("isOrHasRaster recurses into lists and environments", {
   expect_true(any(unlist(outE)))
 })
 
+test_that(".downloadCloudDBFile keys on a non-reserved arg (not cacheId)", {
+  # showCacheCloud() wraps .downloadCloudDBFile() in Cache() to memoise each
+  # remote .dbFile by its content hash. If the keying arg were named `cacheId`
+  # (which is in .defaultCacheOmitArgs) Cache() would drop it from the digest
+  # and collapse every file onto one entry -- listing only one similar item.
+  fmls <- names(formals(reproducible:::.downloadCloudDBFile))
+  expect_true("hash" %in% fmls)
+  expect_false("cacheId" %in% fmls)
+  expect_false("hash" %in% reproducible:::.defaultCacheOmitArgs)
+})
+
+test_that("Cache() keyed on a non-reserved arg yields distinct entries", {
+  # Guards the assumption behind showCacheCloud's memo: varying the (non-reserved)
+  # key arg must produce distinct cache entries. (A regression here is what made
+  # showSimilar list only one cloud item.)
+  skip_on_cran()
+  tmp <- file.path(tempdir(), paste0("ccloud-key-", Sys.getpid()))
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  dir.create(tmp, recursive = TRUE, showWarnings = FALSE)
+  withr::local_options(reproducible.cachePath = tmp, reproducible.useDBI = FALSE,
+                       reproducible.showSimilar = FALSE, reproducible.verbose = -1)
+  f <- function(id, hash) data.table::data.table(v = hash)
+  got <- vapply(c("h1", "h2", "h3"), function(h)
+    (f(id = "same", hash = h) |>
+       Cache(cachePath = tmp, omitArgs = "id", .functionName = "m", verbose = -1))$v,
+    character(1))
+  expect_identical(unname(got), c("h1", "h2", "h3"))
+})
+
 test_that("mergeShownCacheCloud is a no-op when there is no cloud metadata", {
   local <- data.table::data.table(
     cacheId = "aaa", tagKey = c("function", "x"),

--- a/tests/testthat/test-cloud-helpers.R
+++ b/tests/testthat/test-cloud-helpers.R
@@ -51,11 +51,12 @@ test_that("Cache() keyed on a non-reserved arg yields distinct entries", {
   # key arg must produce distinct cache entries. (A regression here is what made
   # showSimilar list only one cloud item.)
   skip_on_cran()
+  skip_if_not_installed("terra") # Cache()'s .wrap path needs terra even for a data.table
   tmp <- file.path(tempdir(), paste0("ccloud-key-", Sys.getpid()))
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  oldOpts <- options(reproducible.cachePath = tmp, reproducible.useDBI = FALSE,
+                     reproducible.showSimilar = FALSE, reproducible.verbose = -1)
+  on.exit({options(oldOpts); unlink(tmp, recursive = TRUE)}, add = TRUE)
   dir.create(tmp, recursive = TRUE, showWarnings = FALSE)
-  withr::local_options(reproducible.cachePath = tmp, reproducible.useDBI = FALSE,
-                       reproducible.showSimilar = FALSE, reproducible.verbose = -1)
   f <- function(id, hash) data.table::data.table(v = hash)
   got <- vapply(c("h1", "h2", "h3"), function(h)
     (f(id = "same", hash = h) |>


### PR DESCRIPTION
## Problem

In the `useCloud` `showSimilar` path, `showCacheCloud()` re-downloaded **every** per-`cacheId` `.dbFile.*` metadata file from the cloud folder on **every** call. Because `Cache()` runs many times in a single run (e.g. a module's `.inputObjects`), the whole set of cloud metadata files was re-fetched repeatedly — slow, and visible as a flood of `drive_download` messages.

The caching for this was built earlier but stranded on the unmerged `feat-showSimilar-useCloud` branch and never reached `development`, so `development` still runs the un-cached loop.

## Fix

Surgical, reusing the existing `Cache()` tool:

1. Extract the inline download/load loop body into a named helper `.downloadCloudDBFile()`.
2. Wrap it in `Cache()`, keyed per `cacheId`, in a dedicated **`cloudMeta` sub-cache** (`<cachePath>/cloudMeta`).

Repeat calls within a run **and across sessions** now resolve from the local memo instead of re-downloading. Only genuinely-new cloud `cacheId`s ever download.

### Notes
- The key arg is named `hash`, not `cacheId` — `cacheId` is in `.defaultCacheOmitArgs` and would collapse every file onto one entry. A guard test enforces this.
- The memo is a **distinct sub-repository** under the main cache path, with its own DB (`cloudMeta/cache.db`) and `cloudMeta/cacheOutputs/`. The main repo's `showCache()`/`showSimilar()`/`clearCache()` scope to `<cachePath>` and glob `cacheOutputs/` non-recursively, so the memo never bloats normal cache views.
- The unrelated `showSimilar` diagnostic-message addition from the original branch is intentionally **left out** — this PR is just the perf fix.

## Tests
- 2 guard tests added in `test-cloud-helpers.R` (helper keys on a non-reserved arg; `Cache()` keyed on a non-reserved arg yields distinct entries).
- Full `test-cloud-helpers.R` passes locally (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)