### PR TITLE
feat(prepInputsCOG): show terra progress bar during windowed remote read

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-09
-Version: 3.1.1.9056
+Date: 2026-06-11
+Version: 3.1.1.9057
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 ## bug fixes
 
+* `prepInputsCOG()` (the COG `/vsicurl/` fast-path) now shows terra's native
+  progress bar during the windowed remote read, which previously ran silently
+  for minutes. The windowed crop is written through terra's block loop so the
+  bar advances as remote tiles are fetched; it is shown only when
+  `verbose > 0`.
+
 * A public Google Drive file could still launch an interactive OAuth prompt when
   a service account was configured via the `GOOGLEDRIVE_AUTH` environment variable
   (or any case where "auth is configured" did not mean "auth will actually

--- a/R/prepInputsCOG.R
+++ b/R/prepInputsCOG.R
@@ -77,9 +77,18 @@ prepInputsCOG <- function(url,
     return("NULL")
 
   # ---- Window-crop: GDAL fetches only tile blocks intersecting to_ext ------
+  # The /vsicurl/ windowed read can take minutes with no feedback. Writing the
+  # crop to a temp file routes it through terra's block loop (one block per
+  # source tile-row), which surfaces terra's native progress bar as the remote
+  # tiles are fetched -- mirroring the download progress users see on the
+  # non-COG path. Enable the bar only when verbose > 0; a very high `progress`
+  # threshold suppresses it otherwise. Save/restore the global terra option.
+  oldProgress <- terra::terraOptions(print = FALSE)$progress
+  on.exit(try(terra::terraOptions(progress = oldProgress), silent = TRUE), add = TRUE)
+  terra::terraOptions(progress = if (isTRUE(verbose > 0)) 1L else .Machine$integer.max)
   r_windowed <- tryCatch({
     terra::window(r_meta) <- to_ext
-    terra::crop(r_meta, to_ext)
+    terra::crop(r_meta, to_ext, filename = tempfile(fileext = ".tif"), overwrite = TRUE)
   }, error = function(e) NULL)
 
   if (is.null(r_windowed) || terra::ncell(r_windowed) == 0L)


### PR DESCRIPTION
## Problem

On the COG `/vsicurl/` fast-path, the windowed remote read (`terra::crop` on a remote raster) is a single **blocking** GDAL call that can run for minutes with **no progress of any kind** — whereas the non-COG download path streams a progress bar. Reported symptom:

```
12:46:39 ... URL remapped via 'reproducible.urlRemap'
12:50:17 ... prepInputsCOG: windowed remote read complete   <- ~3.5 min, silent
```

## Fix

Write the windowed crop to a temp file so terra processes the read through its **block loop** (one block per source tile-row). That surfaces terra's native progress bar as the remote tiles are fetched over HTTP range requests — mirroring the feedback users get on the download path.

- Bar shown only when `verbose > 0`; a very high terra `progress` threshold suppresses it otherwise.
- The global `terra` `progress` option is saved and restored via `on.exit`.

### Why terra's native bar (and not a custom `messagePreProcess` stream)?
`terra::crop` is a single blocking call — R can't interleave its own progress messages during it without restructuring the read or spawning a background process. terra's native bar is the minimal mechanism that reflects the actual block-by-block remote reads. (It is `\r`-based; that renders correctly now that the carriage-return handling was fixed on the SpaDES.core/archive side.)

### Verification
- Confirmed empirically: `crop(..., filename=, progress=1)` emits the advancing bar in a non-interactive session; `progress=.Machine$integer.max` suppresses it.
- Package loads; `prepInputsCOG()` fast-exit paths unchanged; terra option save/restore verified.
- (The real network COG read can't be exercised in CI without a live remote COG + AOI; logic is unchanged apart from routing the same windowed crop through a temp file.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)