### PR TITLE
fix(prepInputs): don't deauthorize a configured Google Drive user on a failed quiet auth

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-14
-Version: 3.1.1.9059
+Date: 2026-06-16
+Version: 3.1.1.9060
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,18 @@
   is respected, so a missing token loads from cache or completes OAuth — no manual
   `drive_auth()` step needed.
 
+* A further case of that same regression: when a *configured* user's quiet auth
+  attempt could not silently load a token — e.g. the cached token was minted with
+  an OAuth client googledrive has since changed (`tidyverse-erato` → `tidyverse-clio`),
+  or the session is non-interactive — `assessGoogle()` still called
+  `drive_deauth()` and read anonymously, 404ing their private file ("File not
+  found") and poisoning later `googledrive` calls. `.gdrivePrepareAuth()` now
+  deauthorizes **only** when auth is *not* configured (the public-file reader) or
+  `reproducible.gdriveNoAuth = TRUE`. A configured user whose quiet attempt fails
+  is left untouched, so the real `drive_get()`/`drive_download()` runs its normal
+  auth — completing OAuth in an interactive session, or raising gargle's clear
+  "non-interactive auth" error instead of a misleading 404.
+
 ## new features
 
 * `reproducible.urlRemap` manifests may now carry an optional **`id` column** (the

--- a/R/download.R
+++ b/R/download.R
@@ -618,6 +618,21 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   isTRUE(tryCatch(googledrive::drive_has_token(), error = function(e) FALSE))
 }
 
+# Has the user CONFIGURED googledrive auth, i.e. does the session signal an
+# intent to authenticate (as opposed to a pure public-file reader)? TRUE when
+# either a service-account JSON is named (reproducible's `GOOGLEDRIVE_AUTH` or
+# `GARGLE_SERVICE_ACCOUNT`) or a gargle OAuth email (`gargle_oauth_email`) is set.
+# Used to decide (a) whether a missing-token auth attempt may run interactively,
+# and (b) whether a FAILED attempt falls back to anonymous/public access or holds
+# out for real authentication -- a configured user must never be silently
+# downgraded to an anonymous 404 on their private files.
+.gdriveAuthConfigured <- function() {
+  saPath <- Sys.getenv("GOOGLEDRIVE_AUTH", Sys.getenv("GARGLE_SERVICE_ACCOUNT", ""))
+  hasSA <- nzchar(saPath) && file.exists(path.expand(saPath))
+  email <- getOption("gargle_oauth_email")
+  hasSA || (!is.null(email) && !isFALSE(email))
+}
+
 # Attempt googledrive authentication on the user's behalf (no manual
 # `drive_auth()` step required). In order:
 #   1. a service-account JSON in `GOOGLEDRIVE_AUTH` (reproducible's convention) or
@@ -639,9 +654,7 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   if (!requireNamespace("googledrive", quietly = TRUE)) return(FALSE)
   saPath <- Sys.getenv("GOOGLEDRIVE_AUTH", Sys.getenv("GARGLE_SERVICE_ACCOUNT", ""))
   hasSA <- nzchar(saPath) && file.exists(path.expand(saPath))
-  email <- getOption("gargle_oauth_email")
-  authConfigured <- hasSA || (!is.null(email) && !isFALSE(email))
-  if (!authConfigured) {
+  if (!.gdriveAuthConfigured()) {
     op <- options(rlang_interactive = FALSE)
     on.exit(options(op), add = TRUE)
   }
@@ -656,23 +669,37 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
 }
 
 # Establish the googledrive auth state for a metadata/download operation, NEVER
-# prompting, and report which path to take ("token" or "anon"):
+# prompting unprompted, and report which path the metadata read should take
+# ("token" or "anon"):
 #   * a token is already loaded            -> "token" (works public + private);
 #   * `reproducible.gdriveNoAuth = TRUE`    -> deauthorize, "anon" (public only);
-#   * otherwise *try* to authenticate (a cached token / service account loads
-#     silently; a configured-but-uncached user completes OAuth -- see
-#     `.gdriveTryAuthQuietly()`). If that succeeds -> "token"; if it fails (nothing
-#     usable, and an unconfigured session never prompts) -> deauthorize and "anon"
-#     (read the PUBLIC file).
+#   * otherwise *try* to authenticate quietly (a cached token / service account
+#     loads silently; a configured + interactive session completes OAuth -- see
+#     `.gdriveTryAuthQuietly()`). If that succeeds -> "token".
+#   * if the quiet attempt FAILS, the fallback depends on whether auth is
+#     CONFIGURED (`.gdriveAuthConfigured()`):
+#       - configured (email / service account): the user intends to authenticate,
+#         so do NOT deauthorize -> "token". Deauthorizing would force the metadata
+#         read anonymous, turning a private file into a misleading 404 ("File not
+#         found") and poisoning later googledrive calls in the session. Leaving
+#         googledrive untouched lets the subsequent `drive_get()`/`drive_download()`
+#         run its normal auth: load a cached token, complete OAuth interactively,
+#         or raise gargle's own clear "non-interactive auth" error -- not a 404.
+#       - not configured (the typical public-file reader): deauthorize -> "anon",
+#         so the read uses an API key and never prompts.
 # This replaces guessing from gargle options ("is an email set?") with an actual
-# attempt -- so a public file always resolves with no prompt, while a configured
-# user authenticates for their private files instead of silently going anonymous.
+# attempt -- so a public file resolves with no prompt, while a configured user
+# authenticates for their private files instead of silently going anonymous.
 .gdrivePrepareAuth <- function() {
   if (!requireNamespace("googledrive", quietly = TRUE)) return("anon")
   if (.gdriveHasToken()) return("token")
-  if (!isTRUE(getOption("reproducible.gdriveNoAuth", FALSE)) && isTRUE(.gdriveTryAuthQuietly())) {
-    return("token")
+  if (isTRUE(getOption("reproducible.gdriveNoAuth", FALSE))) {
+    try(googledrive::drive_deauth(), silent = TRUE)
+    return("anon")
   }
+  if (isTRUE(.gdriveTryAuthQuietly())) return("token")
+  # Quiet attempt did not load a token.
+  if (isTRUE(.gdriveAuthConfigured())) return("token")
   try(googledrive::drive_deauth(), silent = TRUE)
   "anon"
 }

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -93,9 +93,11 @@ test_that(".gdrivePrepareAuth: no token + quiet auth succeeds -> 'token'", {
   expect_false(deauthed)
 })
 
-test_that(".gdrivePrepareAuth: no token + quiet auth fails -> deauthorize, 'anon'", {
+test_that(".gdrivePrepareAuth: no token + quiet fails + NOT configured -> deauthorize, 'anon'", {
   skip_if_not_installed("googledrive")
-  withr::local_options(reproducible.gdriveNoAuth = NULL)
+  # No auth configured (no email, no service account): the public-file reader.
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = NULL)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
   deauthed <- FALSE
   testthat::local_mocked_bindings(
     .gdriveHasToken = function() FALSE,
@@ -104,6 +106,26 @@ test_that(".gdrivePrepareAuth: no token + quiet auth fails -> deauthorize, 'anon
                                   .package = "googledrive")
   expect_identical(reproducible:::.gdrivePrepareAuth(), "anon")
   expect_true(deauthed)      # fell back to anonymous/public
+})
+
+test_that(".gdrivePrepareAuth: no token + quiet fails + CONFIGURED -> 'token', NO deauthorize", {
+  skip_if_not_installed("googledrive")
+  # The user has configured auth (gargle email) but the quiet attempt could not
+  # silently load a token (e.g. cached token minted with a now-changed OAuth
+  # client, or a non-interactive session). We must NOT deauthorize: that would
+  # force the metadata read anonymous and 404 the user's private file. Leave
+  # googledrive untouched so the real drive_get()/drive_download() authenticates.
+  withr::local_options(reproducible.gdriveNoAuth = NULL,
+                       gargle_oauth_email = "someone@example.com")
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  deauthed <- FALSE
+  testthat::local_mocked_bindings(
+    .gdriveHasToken = function() FALSE,
+    .gdriveTryAuthQuietly = function() FALSE)
+  testthat::local_mocked_bindings(drive_deauth = function(...) deauthed <<- TRUE,
+                                  .package = "googledrive")
+  expect_identical(reproducible:::.gdrivePrepareAuth(), "token")
+  expect_false(deauthed)     # configured user is NOT downgraded to anonymous
 })
 
 test_that(".gdrivePrepareAuth: gdriveNoAuth=TRUE + no token -> 'anon' without trying auth", {


### PR DESCRIPTION
## Problem

A regression in the Google Drive no-prompt auth path. `assessGoogle()` calls `.gdrivePrepareAuth()` before any metadata read; when the quiet auth attempt failed it **always** called `drive_deauth()` and read anonymously.

For a user who has **configured** auth (`gargle_oauth_email` / service account) but whose cached token cannot load silently, this silently downgraded them to anonymous access:

- The metadata `drive_get()` then 404'd their **private** file — reported as a misleading `Error: ... File not found` rather than an auth problem.
- Because `drive_deauth()` is global state, it also poisoned later direct `googledrive` calls in the same session.

This bites when the cached token was minted with an OAuth client googledrive has since changed (`tidyverse-erato` → `tidyverse-clio`), or in a non-interactive session — exactly the "options are set, `drive_auth()` would work, but prepInputs goes anonymous" case.

## Fix

`.gdrivePrepareAuth()` now calls `drive_deauth()` **only** when auth is *not* configured (the public-file reader) or `reproducible.gdriveNoAuth = TRUE`. A configured user whose quiet attempt fails is left untouched, so the real `drive_get()` / `drive_download()` runs its normal auth — completing OAuth in an interactive session, or raising gargle's clear "non-interactive auth" error instead of a 404.

The intended sequence of efforts is restored:
**remap → no auth** · **configured-but-unauthenticated → authenticate** · **public → anonymous**.

Factored the "is auth configured?" check into `.gdriveAuthConfigured()`, shared by `.gdriveTryAuthQuietly()` and `.gdrivePrepareAuth()`.

## Tests

Split the prior `quiet auth fails -> deauthorize, 'anon'` test into the two cases that now diverge:

- **configured** (`gargle_oauth_email` set) + quiet fails → `'token'`, **no** `drive_deauth()`
- **not configured** + quiet fails → `'anon'`, `drive_deauth()` called

All offline helper tests in `test-gdrive-noauth-metadata.R` pass. Verified end-to-end with the reporter's config (email set, stale `tidyverse-erato` tokens, no remap): `.gdrivePrepareAuth()` returns `token` without deauthorizing, and `drive_get()` surfaces gargle's actionable auth error instead of `404 File not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)