### PR TITLE
fix(Cache): scope cloud-cache Drive listing to the cacheId, not the whole folder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-14
-Version: 3.1.1.9059
+Date: 2026-06-16
+Version: 3.1.1.9060
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@
 
 ## bug fixes
 
+* `Cache(useCloud = TRUE)` no longer pages the **entire** cloud-cache Google Drive
+  folder on every call. `driveLs()` filtered file names *locally*, so each lookup
+  asked the API for the whole folder (for an accumulated cache that is thousands
+  of files — "Files retrieved so far: 3500 ...") just to keep the handful sharing
+  one `cacheId`. Because cache files are named `<cacheId>...`, the per-`cacheId`
+  lookup now pushes a server-side `name contains '<cacheId>'` query to
+  `googledrive::drive_ls()`, so Drive returns only the relevant files. Listings
+  whose filter is not a plain name prefix (e.g. the `.dbFile.` metadata sweep used
+  by `showSimilar` across machines) fall back to the previous full listing.
+
 * `prepInputsCOG()` (the COG `/vsicurl/` fast-path) now shows terra's native
   progress bar during the windowed remote read, which previously ran silently
   for minutes. The windowed crop is written through terra's block loop so the

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -156,6 +156,25 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption("reproducible.cl
   return(cloudFolderID)
 }
 
+# Build a server-side Google Drive query (`q`) that narrows a `drive_ls()` to the
+# files we actually want, instead of paging the ENTIRE folder and filtering names
+# locally. An accumulated cloud cache folder can hold thousands of files, so
+# without this every Cache() call pages the whole folder ("Files retrieved so
+# far: 3500 ...") just to keep the handful that share one cacheId.
+#
+# Cache files are all named `<cacheId>...` (the cacheId is a name PREFIX -- see
+# keyInGdriveLs(), which anchors on `^<cacheId>`), and Drive's `name contains`
+# does prefix matching, so a single-token cacheId `pattern` can be pushed to the
+# server. A `pattern` that is a regex (alternation, a suffix such as the dbFile
+# listing, etc.) is NOT a plain prefix -> return NULL and fall back to the full
+# listing + local filter.
+.cloudNamePrefixQuery <- function(pattern) {
+  if (length(pattern) != 1L) return(NULL)
+  if (is.na(pattern) || !nzchar(pattern)) return(NULL)
+  if (!grepl("^[[:alnum:]]+$", pattern)) return(NULL) # regex metachars -> not a plain name prefix
+  sprintf("name contains '%s'", pattern)
+}
+
 driveLs <- function(cloudFolderID = NULL, pattern = NULL, cachePath = getOption("reproducible.cachePath"),
                     verbose = getOption("reproducible.verbose", 1),
                     team_drive = NULL) {
@@ -171,11 +190,16 @@ driveLs <- function(cloudFolderID = NULL, pattern = NULL, cachePath = getOption(
     ) # only deals with NULL case
   }
 
+  # `q` is appended to (ANDed with) the parent-folder clause drive_ls() builds, so
+  # the API returns only this cacheId's files rather than the entire folder. NULL
+  # when `pattern` is not a plain prefix (drive_ls(q = NULL) keeps prior behaviour).
+  nameQuery <- .cloudNamePrefixQuery(pattern)
   messageCache("Retrieving file list in cloud folder", verbose = verbose)
   gdriveLs <- retry(quote({
     googledrive::drive_ls(
       path = cloudFolderID, ## TODO: team drives needs a dribble
-      pattern = paste0(collapse = "|", c(pattern))
+      pattern = paste0(collapse = "|", c(pattern)),
+      q = nameQuery
     )
   }))
   if (is(gdriveLs, "try-error")) {

--- a/tests/testthat/test-cloud-helpers.R
+++ b/tests/testthat/test-cloud-helpers.R
@@ -9,6 +9,42 @@ test_that("isID rejects strings outside the 32-33 length window", {
   expect_false(reproducible:::isID(""))
 })
 
+test_that(".cloudNamePrefixQuery pushes a single cacheId to the server, NULL otherwise", {
+  # A plain cacheId (the per-Cache lookup) is a name PREFIX -> a `name contains`
+  # query so Drive returns only that cacheId's files, not the whole folder.
+  expect_identical(reproducible:::.cloudNamePrefixQuery("bedb839348d3b36e"),
+                   "name contains 'bedb839348d3b36e'")
+  # Not prefix-safe -> NULL (fall back to full listing + local filter):
+  expect_null(reproducible:::.cloudNamePrefixQuery(".dbFile."))          # a suffix / has metachars
+  expect_null(reproducible:::.cloudNamePrefixQuery("tagA|tagB"))         # regex alternation
+  expect_null(reproducible:::.cloudNamePrefixQuery(c("a", "b")))         # more than one token
+  expect_null(reproducible:::.cloudNamePrefixQuery(NULL))
+  expect_null(reproducible:::.cloudNamePrefixQuery(NA_character_))
+  expect_null(reproducible:::.cloudNamePrefixQuery(""))
+})
+
+test_that("driveLs scopes a cacheId lookup server-side (q), and not a regex pattern", {
+  skip_if_not_installed("googledrive")
+  # Capture the args drive_ls() is called with, without hitting the network.
+  seenQ <- new.env()
+  fakeLs <- function(path, pattern, q, ...) {
+    seenQ$q <- q
+    seenQ$pattern <- pattern
+    googledrive::as_dribble()        # empty dribble (0 rows)
+  }
+  testthat::local_mocked_bindings(drive_ls = fakeLs, .package = "googledrive")
+
+  folder <- googledrive::as_dribble() # an (empty) tbl, so checkAndMakeCloudFolderID is skipped
+
+  # cacheId lookup -> server-side `name contains` query
+  reproducible:::driveLs(folder, pattern = "bedb839348d3b36e", verbose = -1)
+  expect_identical(seenQ$q, "name contains 'bedb839348d3b36e'")
+
+  # dbFile-suffix listing -> no server query (NULL); full listing + local filter
+  reproducible:::driveLs(folder, pattern = reproducible:::suffixMultipleDBFiles(), verbose = -1)
+  expect_null(seenQ$q)
+})
+
 test_that("isOrHasRaster identifies a SpatRaster", {
   skip_if_not_installed("terra")
   r <- terra::rast(terra::ext(0, 1, 0, 1), vals = 1)


### PR DESCRIPTION
## Problem

With `Cache(useCloud = TRUE)` (e.g. SpaDES.core's module-level `.useCloud`), each cached step bogs down listing the Google Drive cache folder — googledrive prints `Files retrieved so far: 3500 ...` and climbs, even though only a few files belong to the `cacheId` being looked up.

Root cause: `Cache()` (`R/GPT2.R:120`, `:181`) calls `driveLs(cloudFolderID, cacheId)` on every cloud read/write. `driveLs()` passed the cacheId to `googledrive::drive_ls()` as **`pattern`**, which is filtered **client-side**. So the API returned the **entire** folder and reproducible grepped names locally. For an accumulated cloud cache (thousands of files), every call paged the whole folder just to keep the ~4 files for one cacheId.

## Fix

Cache files are named `<cacheId>...` (the cacheId is a name prefix — see `keyInGdriveLs()`, anchored on `^<cacheId>`), and Drive's `name contains` does prefix matching, so the filter can be pushed to the **server**:

- New `.cloudNamePrefixQuery()` builds `name contains '<cacheId>'` for a single plain (alphanumeric) token.
- `driveLs()` passes it as `q`, which `drive_ls()` ANDs with its parent-folder clause. The API now returns only that cacheId's files instead of the whole folder.

A `pattern` that is **not** a plain prefix — regex alternation (userTag searches) or a suffix (the `.dbFile.` metadata sweep behind cross-machine `showSimilar`) — yields `NULL` and falls back to the previous full listing + local filter, so behaviour there is unchanged.

## Tests

Offline (`test-cloud-helpers.R`), no network:
- `.cloudNamePrefixQuery()`: a plain cacheId → `name contains '...'`; suffix / alternation / multi-token / empty / `NA` → `NULL`.
- `driveLs()` (mocked `drive_ls`): a cacheId lookup is scoped server-side via `q`; a `.dbFile.` suffix pattern passes `q = NULL` (full listing).

All offline cloud test files pass (`test-cloud-helpers`, `test-cloudFolderID-offline`, `test-cloudUploadNonFatal`).

> Note: verified by logic + offline mocks; worth a sanity check against a real large cloud-cache folder, where the `Files retrieved so far: ...` enumeration should disappear for per-cacheId lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)