### PR TITLE
fix(messages): cliCol tolerates a colour-function option value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-16
-Version: 3.1.1.9060
+Date: 2026-06-17
+Version: 3.1.1.9061
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 ## bug fixes
 
+* `cliCol()` (used by `messageColoured()` / `messagePreProcess()`) no longer errors with
+  "non-character object(s)" when a `reproducible.messageColour*` option holds a colour
+  *function* (e.g. `cli::col_red`) rather than a colour-name string; such functions now
+  pass through unchanged.
 * `Cache(useCloud = TRUE)` no longer pages the **entire** cloud-cache Google Drive
   folder on every call. `driveLs()` filtered file names *locally*, so each lookup
   asked the API for the whole folder (for an accumulated cache that is thousands

--- a/R/messages.R
+++ b/R/messages.R
@@ -508,6 +508,8 @@ messageStripColor <- function(o)
 .txtUnableToAccessIndex <- "unable to access index"
 
 cliCol <- function(col) {
+  if (is.function(col)) # `messageColour*` options may hold a colour function directly
+    return(col)
   if (!startsWith(col, "col_"))
     col <- paste0("col_", col)
   getFromNamespace(col, asNamespace("cli"))

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,3 +1,11 @@
+test_that("cliCol accepts colour names and colour functions", {
+  ## colour-name string (the default `messageColour*` option form)
+  expect_identical(cliCol("red"), cliCol("col_red"))
+  ## a colour function held directly in the option must pass through untouched,
+  ## not be fed to startsWith() (which errors with "non-character object(s)")
+  expect_identical(cliCol(cli::col_red), cli::col_red)
+})
+
 test_that("test miscellaneous fns (part 1)", {
   # ONLY RELEVANT FOR RASTERS
   testInit("raster", tmpFileExt = c(".tif", ".grd"))


### PR DESCRIPTION
## Problem
`cliCol()` assumes `getOption("reproducible.messageColour*")` is a colour-name **string**:

```r
cliCol <- function(col) {
  if (!startsWith(col, "col_"))
    col <- paste0("col_", col)
  getFromNamespace(col, asNamespace("cli"))
}
```

When the option instead holds a colour **function** (e.g. `cli::col_red`) — which the option's name (`messageColourFunction`) permits, and which the previous (now commented-out) implementation explicitly supported — `startsWith()` throws:

```
Error in startsWith(col, "col_") : non-character object(s)
```

This crashes the whole message path, so any `messagePreProcess()` / `prepInputs()` call dies. It surfaced as intermittent macOS R-CMD-check failures in downstream `SpaDES.project` (`setupProject()` studyArea tests) — failing on one run and passing on a re-run depending on whether the option happened to hold a string or a function in that session.

## Fix
Guard for a function value and pass it through unchanged before the string-only logic:

```r
cliCol <- function(col) {
  if (is.function(col)) # `messageColour*` options may hold a colour function directly
    return(col)
  ...
}
```

## Test
Adds a focused test in `test-misc.R`:
- `cliCol("red")` == `cliCol("col_red")` (string form unchanged)
- `cliCol(cli::col_red)` returns the function untouched (previously errored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)