### PR TITLE
fix(nextNumericName): match only exact stem with optional _N suffix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-06-17
-Version: 3.1.1.9062
+Date: 2026-06-21
+Version: 3.1.1.9063
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/cache-helpers.R
+++ b/R/cache-helpers.R
@@ -420,7 +420,10 @@ nextNumericName <- function(string) {
   theExt <- fileExt(string)
   saveFilenameSansExt <- filePathSansExt(string)
   finalNumericPattern <- "_[[:digit:]]+$"
-  allSimilarFilesInDir <- dir(dirname(saveFilenameSansExt), pattern = basename(saveFilenameSansExt))
+
+  fns <- dir(dirname(saveFilenameSansExt), pattern = basename(saveFilenameSansExt))
+  allSimilarFilesInDir <- fns[grepl(paste0("^", basename(saveFilenameSansExt), "(_[0-9]+)?$"),
+                                    sub("\\..*$", "", fns))]
   allSimilarFilesInDirSansExt <- if (length(allSimilarFilesInDir) == 0) {
     unique(saveFilenameSansExt)
   } else {


### PR DESCRIPTION
## Summary
`nextNumericName()` used `dir(pattern = basename(...))`, which does a substring match. For a stem like `rstLCC2000_Global2ELFs` this wrongly captured unrelated siblings such as `rstLCC2000_Global2ELFs_propFlam*`.

This anchors the match to the exact stem followed by an optional `_<digits>`, comparing against the filename with all extensions stripped (`sub("\\..*$", "", fns)`) so legitimate siblings like `.tif` and `.tif.aux.xml` are still retained.

## Changes
- `R/cache-helpers.R`: anchored, suffix-aware match in `nextNumericName()`
- `DESCRIPTION`: version bump to 3.1.1.9063, date to 2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)