### PR TITLE
test: skip terra postProcess test when qs2 is not installed

### DIFF
--- a/tests/testthat/test-postProcessTerra.R
+++ b/tests/testthat/test-postProcessTerra.R
@@ -11,6 +11,10 @@ test_that("testing terra", {
   withr::local_options(reproducible.cachePath = tmpCache)
 
   skip_if_not_installed("terra")
+  # This test opts into the qs2 cache save format (reproducible.cacheSaveFormat
+  # above); skip where qs2 is unavailable (e.g. the macOS runner) rather than
+  # erroring in Cache() -> .requireNamespace(.qs2Format, stopOnFALSE = TRUE).
+  skip_if_not_installed("qs2")
   f <- system.file("ex/elev.tif", package = "terra")
   tf <- tempfile(fileext = ".tif")
   tf1 <- tempfile(fileext = ".tif")


### PR DESCRIPTION
`tests/testthat/test-postProcessTerra.R` opts into the qs2 cache save format
(`reproducible.cacheSaveFormat = .qs2Format`). On runners where `qs2` isn't
installed (e.g. macOS-latest), `Cache()` reaches
`.requireNamespace(.qs2Format, stopOnFALSE = TRUE)` and **errors** at
`test-postProcessTerra.R:43` (`external`… `qs2 is required but not yet installed`).

Add `skip_if_not_installed("qs2")` so the test skips gracefully there instead of
failing the check.

Pre-existing (independent of #527); split out as its own small PR and also merged
into #527 so that branch's macOS job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)