### PR TITLE
ci: bump actions/checkout v4 -> v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,7 @@ jobs:
       R_PKG_INSTALL_RETRIES: 3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
       # Three attempts with continue-on-error ride out transient failures.

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_PKG_INSTALL_RETRIES: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -37,7 +37,7 @@ jobs:
       R_PKG_INSTALL_RETRIES: 3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-downstream.yaml
+++ b/.github/workflows/test-downstream.yaml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout reproducible
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: reproducible
 
       - name: Checkout SpaDES.core
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: PredictiveEcology/SpaDES.core
           ref: development
           path: SpaDES.core
 
       - name: Checkout SpaDES.project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: PredictiveEcology/SpaDES.project
           ref: development

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_PKG_INSTALL_RETRIES: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
GitHub deprecated Node.js 20 and is force-running `actions/checkout@v4` on Node 24,
producing a deprecation annotation on every CI job
(https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-run).

Bump `actions/checkout@v4` → `@v5` (Node 24) across all 5 workflows that use it.
`r-hub/actions/checkout@v1` and other actions are left untouched.

Split out as its own small PR and also cherry-picked into #527 so that branch's runs
stop showing the annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)