### PR TITLE
ci: migrate to PredictiveEcology/actions reusable workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,153 +1,24 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - master
-      - development
+    branches: [master, development]
   pull_request:
-    branches:
-      - master
-      - development
+    branches: [master, development]
 
 name: R-CMD-check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,   nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'devel', http-user-agent: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel-1'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel-2'}
-          - {os: ubuntu-latest,  nosuggests: false,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,  nosuggests: false,   r: 'release'}
-          - {os: ubuntu-latest,  nosuggests: true,   r: 'release'}
-          - {os: ubuntu-latest,  nosuggests: false,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,  nosuggests: false, r: 'oldrel-2'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      _SP_EVOLUTION_STATUS_: 2
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      R_REPRODUCIBLE_RUN_ALL_EXAMPLES: true
-      R_REPRODUCIBLE_RUN_ALL_TESTS: true
-      R_VERSION_LABEL: ${{ matrix.config.r }}
-      # pak respects this for individual download retries on transient errors.
-      R_PKG_INSTALL_RETRIES: 3
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # setup-pandoc occasionally fails with HTTP 5xx (CDN blip).
-      # Three attempts with continue-on-error ride out transient failures.
-      - id: pandoc1
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure'
-        id: pandoc2
-        continue-on-error: true
-        uses: r-lib/actions/setup-pandoc@v2
-      - if: steps.pandoc1.outcome == 'failure' && steps.pandoc2.outcome == 'failure'
-        uses: r-lib/actions/setup-pandoc@v2
-
-      # On Linux we used to install the ubuntugis-unstable PPA via
-      # PredictiveEcology/actions/install-spatial-deps@v0.2. Launchpad's
-      # CDN (ppa.launchpadcontent.net) has been intermittently unreachable
-      # for hours at a time, and even a 3-attempt × 60 s retry can't cover
-      # it. The Ubuntu 24.04 (Noble) GHA runner image already preinstalls
-      # libgdal-dev, libproj-dev, libgeos-dev, libudunits2-dev (GDAL 3.8 /
-      # PROJ 9.4), which is recent enough for everything reproducible needs.
-      # So skip the PPA entirely on Linux and just `apt-get install` the
-      # canonical names from stock Noble — idempotent if already present,
-      # and immune to Launchpad outages.
-      - if: runner.os != 'Linux'
-        uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - if: runner.os == 'Linux'
-        name: Install spatial deps (Linux, stock Noble)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -f -y || true
-          sudo apt-get install -y --fix-missing \
-            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-
-      # On macOS the system GDAL/PROJ install (via Homebrew) does not always
-      # leave `proj.db` on PROJ's default search path. Without that file, every
-      # `terra::project()` / `terra::crs()` call emits
-      #   PROJ: proj_identify: Cannot find proj.db (GDAL error 1)
-      # and reprojections fail outright. Point PROJ at Homebrew's data dir
-      # explicitly so spatial tests can run.
-      - name: Configure PROJ data path (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          PROJ_PREFIX="$(brew --prefix proj 2>/dev/null || true)"
-          PROJ_DATA="$PROJ_PREFIX/share/proj"
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/usr/local/share/proj"; fi
-          if [ ! -d "$PROJ_DATA" ]; then PROJ_DATA="/opt/homebrew/share/proj"; fi
-          echo "PROJ_DATA=$PROJ_DATA" >> "$GITHUB_ENV"
-          echo "PROJ_LIB=$PROJ_DATA"  >> "$GITHUB_ENV"
-          echo "Using PROJ_DATA=$PROJ_DATA"
-          ls -1 "$PROJ_DATA" | head -5 || true
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          # Posit Public Package Manager — pre-built Windows + macOS binaries
-          # served from a CDN. Far more reliable than CRAN mirrors for the
-          # binary-download step that has been failing intermittently on the
-          # Windows runner under `pak`.
-          use-public-rspm: true
-
-      - id: deps
-        continue-on-error: true
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          # Pin pak to its stable channel; the action defaults to devel which
-          # occasionally regresses on Windows.
-          pak-version: stable
-          extra-packages: |
-            any::rcmdcheck
-            rspatial/geodata
-
-      # Fallback: when setup-r-dependencies fails (most often a transient
-      # binary-fetch failure under pak on Windows oldrel), retry the install
-      # via a fresh pak-stable install + pkg_install loop, up to 3 attempts
-      # with 60s backoff. continue-on-error: true on the primary step lets
-      # this step run and decide the job's actual success/failure.
-      - name: Install R deps (retry fallback)
-        if: steps.deps.outcome == 'failure'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          retry_wait_seconds: 60
-          retry_on: error
-          # `nick-fields/retry` validates `shell` against bash|pwsh|sh|python|
-          # cmd|powershell — `Rscript` is rejected even though native GitHub
-          # Actions steps accept it. Use `bash` (available on every runner,
-          # incl. Windows via Git Bash) and invoke Rscript via heredoc.
-          shell: bash
-          command: |
-            Rscript --no-save <<'EOF'
-            install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
-            pak::local_install_dev_deps(ask = FALSE, dependencies = TRUE)
-            pak::pkg_install(c("any::rcmdcheck", "rspatial/geodata"), ask = FALSE)
-            EOF
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--as-cran", "--run-dontrun", "--run-donttest")'
-          upload-snapshots: true
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    secrets: inherit
+    with:
+      extra-packages: |
+        rspatial/geodata
+      # Run \dontrun / \donttest examples the way CRAN's incoming checks do.
+      check-args: 'c("--no-manual", "--as-cran", "--run-dontrun", "--run-donttest")'
+      # Keep the windows oldrel-2 (R 4.4) leg reproducible tested before migrating.
+      extra-config: '[{"config":{"os":"windows-latest","nosuggests":false,"r":"oldrel-2"}}]'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,5 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
     branches: [main, master]
@@ -13,49 +12,8 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_PKG_INSTALL_RETRIES: 3
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # Stock Noble apt; ubuntugis-unstable PPA dropped — see the rationale
-      # in R-CMD-check.yaml.
-      - name: Install spatial deps (Linux, stock Noble)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -f -y || true
-          sudo apt-get install -y --fix-missing \
-            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          Ncpus: 2
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          pak-version: stable
-          extra-packages: |
-            any::pkgdown
-            local::.
-            rspatial/geodata
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: PredictiveEcology/actions/.github/workflows/pkgdown.yaml@main
+    secrets: inherit
+    with:
+      extra-packages: |
+        rspatial/geodata

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,108 +1,23 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
-  # Run coverage only on push to the integration branches (a PR merge IS a push
-  # to `development`), NOT on pull_request. Running it per-PR meant every update
-  # to the busy `development` base recomputed refs/pull/N/merge and, with
-  # `cancel-in-progress: true`, cancelled the in-progress covr run (exit 143),
-  # so coverage showed spurious red on PRs without ever indicating a real failure.
+  # Coverage runs on push to the integration branches only (a PR merge IS a push
+  # to `development`), NOT per-PR: per-PR runs kept recomputing refs/pull/N/merge
+  # on the busy `development` base and cancelling the in-progress covr run.
   push:
-    branches:
-      - master
-      - development
+    branches: [master, development]
 
 name: test-coverage
 
 concurrency:
+  # Do NOT cancel in-progress coverage runs: covr takes ~25 min and merges land
+  # minutes apart; cancelling the previous run surfaced as spurious red.
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Do NOT cancel in-progress coverage runs. test-coverage runs only on pushes to
-  # the integration branches, and merges frequently land minutes apart while a
-  # covr run takes ~25 min. With cancel-in-progress:true, each new merge sent
-  # SIGTERM (exit 143) to the previous, still-running coverage run; combined with
-  # the old `continue-on-error` + re-fail step that surfaced on `development` as a
-  # spurious red "failure" rather than a neutral "cancelled". Queue them instead so
-  # every merge's coverage runs to completion and reports a real pass/fail.
   cancel-in-progress: false
+
 jobs:
   test-coverage:
-    # Mirrors the recipe used by PredictiveEcology/SpaDES.tools, which is
-    # currently green on test-coverage. The previous macOS-latest run was
-    # failing inside covr's R CMD check sub-process with an opaque
-    # "Failure in <path>/test-all.Rout.fail", in a way that R-CMD-check on
-    # the same image does not reproduce.
-    runs-on: ubuntu-latest
-    env:
-      GOOGLEDRIVE_AUTH: ${{ secrets.GOOGLEDRIVE_AUTH }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      NOT_CRAN: true
-      R_PKG_INSTALL_RETRIES: 3
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # Stock Noble apt; ubuntugis-unstable PPA dropped — see the rationale
-      # in R-CMD-check.yaml.
-      - name: Install spatial deps (Linux, stock Noble)
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -f -y || true
-          sudo apt-get install -y --fix-missing \
-            libudunits2-dev libgdal-dev libgeos-dev libproj-dev libsqlite3-dev
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://predictiveecology.r-universe.dev/'
-          Ncpus: 2
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          pak-version: stable
-          extra-packages: |
-            any::covr
-            rspatial/geodata
-
-      - id: covr
-        name: Test coverage
-        # Fail fast on a genuine hang (e.g. a network test that never returns)
-        # instead of waiting for an opaque external SIGTERM at job timeout.
-        timeout-minutes: 45
-        # Wrap covr in tryCatch so the per-session tempdir's
-        # `test-all.Rout.fail` is dumped to the GHA log _before_ R exits and
-        # the tempdir is cleaned up. Without this, a covr failure surfaces
-        # only as an opaque "Failure in <path>/test-all.Rout.fail" with the
-        # actual failing test names and tracebacks lost.
-        #
-        # `covr::codecov()` both runs the test suite (to compute coverage) and
-        # uploads to codecov.io. We must distinguish the two failure modes:
-        #   * a real test/coverage failure leaves a `test-all.Rout.fail` -> RED,
-        #   * a transient codecov.io UPLOAD error (network) leaves none and must
-        #     NOT redden the integration branch, since coverage itself succeeded.
-        run: |
-          res <- tryCatch(
-            covr::codecov(token = Sys.getenv("CODECOV_TOKEN")),
-            error = function(e) e
-          )
-          if (inherits(res, "error")) {
-            files <- list.files(
-              tempdir(), pattern = "test-all\\.Rout\\.fail$",
-              recursive = TRUE, full.names = TRUE
-            )
-            for (f in files) {
-              cat("==========================================\n")
-              cat("=== ", f, " ===\n", sep = "")
-              cat("==========================================\n")
-              cat(readLines(f, warn = FALSE), sep = "\n")
-              cat("\n")
-            }
-            if (length(files)) {
-              stop(res)  # genuine test/coverage failure -> fail the job
-            }
-            message(
-              "covr::codecov() errored with no test-all.Rout.fail present; ",
-              "treating as a transient codecov.io upload failure (non-fatal): ",
-              conditionMessage(res)
-            )
-          }
-        shell: Rscript {0}
+    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
+    secrets: inherit
+    with:
+      extra-packages: |
+        rspatial/geodata


### PR DESCRIPTION
Replaces reproducible's three **standalone** workflows (R-CMD-check, test-coverage,
pkgdown) with **thin callers** of the shared reusable workflows in
`PredictiveEcology/actions` — the pattern SpaDES.project already uses. CI logic
(including `actions/checkout@v5`, spatial deps, retry fallback, the matrix, and the
`GOOGLEDRIVE_AUTH`/`CODECOV_TOKEN` secrets) is now maintained centrally, which also
resolves the Node-20 `checkout@v4` deprecation without a per-package patch.

## reproducible-specific behaviour preserved (via reusable-workflow inputs)
- **`check-args`** → keeps `--run-dontrun --run-donttest` (CRAN-parity example checking).
- **`extra-config`** → keeps the `windows oldrel-2` (R 4.4) leg.
- **`extra-packages: rspatial/geodata`**.
- **test-coverage** stays push-only with `cancel-in-progress: false` (unchanged intent).
- `Depends: R (>= 4.3)` left as-is (declared 4.3, tested down to oldrel-2 = R 4.4).

## Merge order (important)
Depends on **PredictiveEcology/actions#6** (the `extra-config` input) being on
`main` first — the wrappers pin `@main`, and passing an undefined input fails the
run. So: merge actions#6, then this. (`check-args` and the `GOOGLEDRIVE_AUTH`
secret fix from actions#5 are already on `main`.)

## Note
`update-citation-cff.yaml` has no reusable-workflow equivalent, so it keeps its own
`actions/checkout` and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)