### PR TITLE
ci: bump actions/checkout v4 -> v5 in update-citation-cff

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_PKG_INSTALL_RETRIES: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
`update-citation-cff.yaml` has no reusable-workflow equivalent in PredictiveEcology/actions, so its `actions/checkout` is bumped in-repo: `@v4` -> `@v5` (Node 24), clearing the last Node-20 deprecation annotation now that R-CMD-check / pkgdown / test-coverage use the reusable workflows (#530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)