### PR TITLE
test(ci): run Cache() tests under useDBI=TRUE on CI + fix backend file-count assertion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-08-17
-Version: 3.1.1.9065
+Date: 2026-08-18
+Version: 3.1.1.9066
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -39,4 +39,19 @@ if (nzchar(Sys.getenv("R_REPRO_TEST_FULL_MATRIX")) &&
   ## Covers ~95% of the test surface; alternate raster/DBI paths are
   ## still exercised by individual test files that explicitly opt in.
   test_check("reproducible")
+
+  ## On CI only (NOT CRAN -- keeps CRAN's check within its time budget), add a
+  ## focused pass of just the Cache() tests (test-cache*.R, via `filter`) under
+  ## the SQLite (useDBI) backend. Only cache storage/retrieval depends on the
+  ## backend, so there is no need to re-run prepInputs()/postProcess()/etc.
+  ## `CI` is set by GitHub Actions but not by CRAN; RSQLite + DBI are required
+  ## for the backend (skipped if a nosuggests run lacks them). The option is set
+  ## directly (the R_REPRODUCIBLE_USE_DBI env var is only read at package load).
+  if (isTRUE(as.logical(Sys.getenv("CI", "false"))) &&
+      requireNamespace("RSQLite", quietly = TRUE) &&
+      requireNamespace("DBI", quietly = TRUE)) {
+    options(reproducible.useDBI = TRUE)
+    Sys.setenv(R_REPRODUCIBLE_USE_DBI = "true")
+    test_check("reproducible", filter = "^cache")
+  }
 }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -233,8 +233,14 @@ test_that("test file-backed raster caching", {
       sc <- showCache(tmpCache)
       origFile <- sc[tagKey == "origFilename"]$cacheId
       hasFilenameInCache <- NROW(sc[tagKey %in% tagFilenamesInCache])
+      ## On-disk file count is backend-dependent. Both backends write the object
+      ## .rds and the file-backed .tif (2 files). The flat-file backend ALSO
+      ## writes the tag store and the filename-tag file to disk, whereas useDBI()
+      ## keeps those in the SQLite DB -- so gate both flat-file-only files on
+      ## !useDBI(). (Previously `hasFilenameInCache` was added unconditionally,
+      ## over-counting by one under useDBI = TRUE.)
       expect_true(length(dir(CacheStorageDir(tmpCache), pattern = origFile)) ==
-                    (1 + hasFilenameInCache + as.integer(!useDBI()) + 2 * savePreDigest + 1L))
+                    (2L + as.integer(!useDBI()) * (hasFilenameInCache + 1L) + 2L * savePreDigest))
       # expect_true(length(dir(CacheStorageDir(tmpCache), pattern = origFile)) == 1 + !useDBI())
     }
 


### PR DESCRIPTION
## Why
Only `Cache()` storage/retrieval depends on the cache backend, yet CI and CRAN only ever exercise the **flat-file** backend (`useDBI=FALSE`). The `useDBI=TRUE` (SQLite) passes in `test-all.R` are gated behind `R_REPRO_TEST_FULL_MATRIX`, which **no workflow sets** — so the SQLite backend is currently validated only by a handful of opt-in tests, not the full Cache() suite.

## What
- **`tests/test-all.R`**: after the default single pass, add a focused pass of just the `test-cache*.R` files (testthat `filter = "^cache"`) under `options(reproducible.useDBI = TRUE)`, gated on **`CI`** (set by GitHub Actions, not CRAN) + RSQLite/DBI available. No `prepInputs`/`postProcess`/etc. re-run; CRAN stays single-pass and within its time budget; no reusable-workflow plumbing.
- **`tests/testthat/test-cache.R`**: fix the "test file-backed raster caching" file-count assertion, which over-counted by one under `useDBI=TRUE`. Both backends write the object `.rds` + file-backed `.tif`; the flat-file backend *also* writes the tag store **and** the filename-tag file to disk, whereas `useDBI` keeps both in the SQLite DB. Only the tag store was gated on `!useDBI()` before; now both flat-file-only files are.

## Verified locally
- The 5 `test-cache*.R` files under `useDBI=TRUE`: **359 pass** (the lone failure was this over-count, now fixed).
- `test-cache.R` passes under **both** backends after the fix: `useDBI=FALSE` 303/0, `useDBI=TRUE` 293/0.

Note: version bumped to 3.1.1.9066; if merged after #532 (also 9066/9067) there may be a trivial DESCRIPTION Version conflict to resolve (take the higher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)