### PR TITLE
fix(Cache): make the DBI backend safe for arbitrary tag values; enable urlLog under it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9073
+Version: 3.1.1.9074
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-08-19
-Version: 3.1.1.9072
+Date: 2026-08-20
+Version: 3.1.1.9073
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/DBI.R
+++ b/R/DBI.R
@@ -526,30 +526,24 @@ dbConnectAll <- function(drv = getDrv(getOption("reproducible.drv", NULL)),
     }
 
     if (useDBI()) {
+      # Cache() passes its whole named list of connections; pick this repo's, as
+      # saveToCache()/searchInRepos() do.
+      if (is.list(conn)) conn <- conn[[cachePath]]
       if (is.null(conn)) {
         conn <- dbConnectAll(drv, cachePath = cachePath, create = FALSE)
         on.exit(DBI::dbDisconnect(conn))
       }
 
-      # This is what the next code pair of lines does
-      # dt <- data.table("cacheId" = cacheId, "tagKey" = "accessed",
-      #                 "tagValue" = as.character(Sys.time()),
-      #                 "createdDate" = as.character(Sys.time()))
-      #
-      # retry(quote(dbAppendTable(conn, CacheDBTableName(cachePath, drv), dt), retries = 15))
-      rs <- retry(retries = 250, exponentialDecayBase = 1.01, quote(
-        DBI::dbSendStatement(
-          conn,
-          paste0(
-            "insert into \"", CacheDBTableName(cachePath, drv), "\"",
-            " (\"cacheId\", \"tagKey\", \"tagValue\", \"createdDate\") values ",
-            "('", cacheId,
-            "', '", tagKey, "', '", tagValue, "', '", curTime, "')"
-          )
-        )
+      # Same insert as saveToCache(): dbAppendTable binds the values rather than
+      # pasting them into the statement. A tagValue is arbitrary user text -- a
+      # file path, a userTag, a url -- and one containing a single quote used to
+      # produce invalid SQL here. Because that failure is deterministic, retry()
+      # then re-ran it 250 times before giving up, turning one apostrophe into a
+      # multi-minute hang.
+      dt <- metadataDT(cacheId, tagKey, tagValue)
+      retry(retries = 250, exponentialDecayBase = 1.01, quote(
+        DBI::dbAppendTable(conn, CacheDBTableName(cachePath, drv), dt)
       ))
-
-      DBI::dbClearResult(rs)
     } else {
       dt <- list(
         "cacheId" = cacheId, "tagKey" = tagKey,
@@ -632,6 +626,9 @@ dbConnectAll <- function(drv = getDrv(getOption("reproducible.drv", NULL)),
     }
     if (length(cacheId) > 1) stop(".updateTagsRepo can only handle updating 1 tag at a time")
     if (useDBI()) {
+      # Cache() passes its whole named list of connections; pick this repo's, as
+      # saveToCache()/searchInRepos() do.
+      if (is.list(conn)) conn <- conn[[cachePath]]
       if (is.null(conn)) {
         conn <- dbConnectAll(drv, cachePath = cachePath, create = FALSE)
         on.exit(DBI::dbDisconnect(conn))
@@ -643,15 +640,20 @@ dbConnectAll <- function(drv = getDrv(getOption("reproducible.drv", NULL)),
       #                 "createdDate" = as.character(Sys.time()))
       #
       # retry(quote(dbAppendTable(conn, CacheDBTableName(cachePath, drv), dt), retries = 15))
+      # glue_sql escapes the values (same idiom as rmFromCache/getHashFromDB);
+      # see the note in .addTagsRepo() -- an unescaped single quote in `tagValue`
+      # would otherwise produce invalid SQL.
+      qry <- glue::glue_sql(
+        "UPDATE {DBI::SQL(glue::double_quote(dbTabName))} SET \"tagValue\" = {tagValue}",
+        " WHERE \"cacheId\" = ({cacheId}) AND \"tagKey\" = ({tagKey})",
+        dbTabName = CacheDBTableName(cachePath, drv),
+        tagValue = as.character(tagValue),
+        cacheId = cacheId,
+        tagKey = tagKey,
+        .con = conn
+      )
       rs <- # retry(retries = 250, exponentialDecayBase = 1.01, quote(
-        DBI::dbSendStatement(
-          conn,
-          paste0(
-            "update \"", CacheDBTableName(cachePath, drv), "\"",
-            " set \"tagValue\" = '", tagValue, "' where ",
-            " \"cacheId\" = '", cacheId, "'", " AND \"tagKey\" = '", tagKey, "'"
-          )
-        )
+        DBI::dbSendStatement(conn, qry)
       # ))
       affectedAnyRows <- DBI::dbGetRowsAffected(rs) > 0
       DBI::dbClearResult(rs)
@@ -882,6 +884,31 @@ CacheDBTableName <- function(cachePath = getOption("reproducible.cachePath"),
 #' - `CacheIsACache()` returns a logical indicating whether the `cachePath` is currently
 #' a `reproducible` cache database;
 #'
+## Is `conn` actually a connection to `cachePath`'s database file?
+##
+## `conn` defaults to the single global `getOption("reproducible.conn")` in most
+## of the DBI helpers, and `Cache()` may work across several `cachePath`s, so a
+## connection belonging to a *different* repo reaches these functions routinely.
+## That matters in CacheIsACache(): there, a table-name mismatch is taken as
+## evidence of a moved repository and triggers movedCache(), i.e. an
+## `ALTER TABLE ... RENAME` -- which, if `conn` simply points somewhere else,
+## silently renames the OTHER repo's table and corrupts it. A mismatch is only
+## meaningful when the connection really is this cachePath's database.
+##
+## Returns FALSE when it cannot tell (no dbname, non-file backend, error), so
+## the destructive branch stays opt-in on positive evidence.
+connIsForCachePath <- function(conn, cachePath,
+                               drv = getDrv(getOption("reproducible.drv", NULL))) {
+  connDBFile <- tryCatch(DBI::dbGetInfo(conn)$dbname, error = function(e) NULL)
+  if (is.null(connDBFile) || !is.character(connDBFile) || !nzchar(connDBFile[1])) {
+    return(FALSE)
+  }
+  expected <- tryCatch(CacheDBFile(cachePath, drv = drv, conn = conn),
+                       error = function(e) NULL)
+  if (is.null(expected)) return(FALSE)
+  isTRUE(normPath(connDBFile[1]) == normPath(expected))
+}
+
 #' @export
 #' @rdname CacheHelpers
 CacheIsACache <- function(cachePath = getOption("reproducible.cachePath"), create = FALSE,
@@ -913,7 +940,8 @@ CacheIsACache <- function(cachePath = getOption("reproducible.cachePath"), creat
       )
       tableShouldBe <- CacheDBTableName(cachePath)
       if (length(tablesInDB) == 1) {
-        if (!any(tablesInDB %in% tableShouldBe) && grepl(type, "SQLite")) {
+        if (!any(tablesInDB %in% tableShouldBe) && grepl(type, "SQLite") &&
+            connIsForCachePath(conn, cachePath, drv)) {
           warning(paste0(
             "The table in the Cache repo does not match the cachePath. ",
             "If this is because of a moved repository (i.e., files ",

--- a/R/cache.R
+++ b/R/cache.R
@@ -1631,8 +1631,14 @@ createConns <- function(cachePath, conns, drv,
     drv <- getDrv(drv)
     if (is.null(conns[[cachePath]])) {
       conns[[cachePath]] <- dbConnectAll(drv, cachePath = cachePath)
-      RSQLite::dbClearResult(RSQLite::dbSendQuery(conns[[cachePath]], "PRAGMA busy_timeout=5000;"))
-      RSQLite::dbClearResult(RSQLite::dbSendQuery(conns[[cachePath]], "PRAGMA journal_mode=WAL;"))
+      # PRAGMA is SQLite-specific syntax. `reproducible.drv`/`reproducible.conn`
+      # accept any DBI backend (RPostgres is the documented other one), and those
+      # error on PRAGMA, so gate on the connection actually being SQLite. Also
+      # skips safely when dbConnectAll() failed and returned NULL.
+      if (is(conns[[cachePath]], "SQLiteConnection")) {
+        RSQLite::dbClearResult(RSQLite::dbSendQuery(conns[[cachePath]], "PRAGMA busy_timeout=5000;"))
+        RSQLite::dbClearResult(RSQLite::dbSendQuery(conns[[cachePath]], "PRAGMA journal_mode=WAL;"))
+      }
     }
   }
 

--- a/R/showCacheEtc.R
+++ b/R/showCacheEtc.R
@@ -984,15 +984,23 @@ showCacheFast <- function(cacheId, cachePath = getOption("reproducible.cachePath
   ## filters in R, on a path that runs on every prepInputs cache hit.
   if (useDBI()) {
     if (is.list(conn)) conn <- conn[[cachePath]]
-    if (is.null(conn)) {
+    tbl <- CacheDBTableName(cachePath, drv = drv)
+    ## The caller's `conn` does not necessarily belong to `cachePath`: with
+    ## several cachePaths, Cache() hands us the connection for whichever repo it
+    ## was working in, while callers such as .maybeRecordUrlForCache() pass
+    ## cachePaths[[1]]. Only use it when it actually holds this repo's table;
+    ## otherwise open (and close) our own for `cachePath`.
+    ## NB: deliberately NOT CacheIsACache() -- that repairs as well as checks,
+    ## and on a table/cachePath mismatch it calls movedCache(), which would
+    ## ALTER TABLE ... RENAME the *other* repo's table.
+    if (is.null(conn) || !isTRUE(tbl %in% DBI::dbListTables(conn))) {
       conn <- dbConnectAll(drv, cachePath = cachePath, create = FALSE)
       if (is.null(conn)) return(.emptyCacheTable)
       on.exit(DBI::dbDisconnect(conn), add = TRUE)
+      if (!isTRUE(tbl %in% DBI::dbListTables(conn))) return(.emptyCacheTable)
     }
-    if (!CacheIsACache(cachePath, drv = drv, conn = conn)) return(.emptyCacheTable)
     sc <- getHashFromDB(tries = 1, conn = conn, drv = drv, repo = cachePath,
-                        dbTabNam = CacheDBTableName(cachePath, drv = drv),
-                        outputHash = cacheId)
+                        dbTabNam = tbl, outputHash = cacheId)
     return(sc[])
   }
 

--- a/R/urlLog.R
+++ b/R/urlLog.R
@@ -351,7 +351,6 @@ clearUrlLog <- function() {
 .maybeRecordUrlForCache <- function(callList, keyFull, cachePaths, drv, conn,
                                     isHit, .callingEnv = parent.frame(),
                                     urlFrameId = NULL) {
-  if (useDBI()) return(invisible())
   if (.urlLogOff()) return(invisible())
 
   cacheId <- keyFull$key

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -41,9 +41,13 @@ if (nzchar(Sys.getenv("R_REPRO_TEST_FULL_MATRIX")) &&
   test_check("reproducible")
 
   ## On CI only (NOT CRAN -- keeps CRAN's check within its time budget), add a
-  ## focused pass of just the Cache() tests (test-cache*.R, via `filter`) under
-  ## the SQLite (useDBI) backend. Only cache storage/retrieval depends on the
-  ## backend, so there is no need to re-run prepInputs()/postProcess()/etc.
+  ## focused pass under the SQLite (useDBI) backend of every test file that
+  ## touches the cache metadata store. This is deliberately wider than
+  ## test-cache*.R: urlLog tags cacheIds, the cloud code round-trips metadata
+  ## between the two backends, and showCache/clearCache read it. Narrowing this
+  ## to "^cache" is what let urlLog sit silently disabled under DBI -- nothing
+  ## in the DBI pass covered it. Anything with a `useDBI()` branch behind it
+  ## belongs here; prepInputs()/postProcess()/gis tests do not.
   ## `CI` is set by GitHub Actions but not by CRAN; RSQLite + DBI are required
   ## for the backend (skipped if a nosuggests run lacks them). The option is set
   ## directly (the R_REPRODUCIBLE_USE_DBI env var is only read at package load).
@@ -52,6 +56,19 @@ if (nzchar(Sys.getenv("R_REPRO_TEST_FULL_MATRIX")) &&
       requireNamespace("DBI", quietly = TRUE)) {
     options(reproducible.useDBI = TRUE)
     Sys.setenv(R_REPRODUCIBLE_USE_DBI = "true")
-    test_check("reproducible", filter = "^cache")
+    dbiBackedTests <- c(
+      "cache",       # cache, cacheGeo, cacheHelpers, cachePath-lazy
+      "cloud",       # cloud, cloud-helpers, cloudFolderID-offline, cloudUploadNonFatal
+      "useCloud",    # useCloudPullPush
+      "showCache",   # showCacheAsyncInstall, showCacheCorruptFile
+      "urlLog",
+      "multipleCacheRepo",
+      "preDigestDump",
+      "lazyAsyncSpawn",
+      "cluster",
+      "misc"
+    )
+    test_check("reproducible",
+               filter = paste(paste0("^", dbiBackedTests), collapse = "|"))
   }
 }

--- a/tests/testthat/test-cacheHelpers.R
+++ b/tests/testthat/test-cacheHelpers.R
@@ -346,3 +346,83 @@ test_that("test miscellaneous unit tests cache-helpers", {
   mess <- capture_messages(clearCache(cachePath = tmpCache))
   expect_true(any(grepl("x not specified, but cachePath is", mess)))
 })
+
+test_that("cache tag values containing quotes round-trip through both backends", {
+  testInit()
+
+  ## Both backends where possible; the DBI one is where the bug lived.
+  backends <- if (.requireNamespace("RSQLite") && .requireNamespace("DBI")) {
+    c(FALSE, TRUE)
+  } else {
+    FALSE
+  }
+
+  for (ud in backends) {
+    withr::local_options(reproducible.useDBI = ud)
+    expect_identical(useDBI(), ud)
+
+    cp <- file.path(tmpdir, paste0("quoteTags", ud))
+    a <- Cache(rnorm, 1, cachePath = cp)
+    cid <- gsub("cacheId:", "", grep("cacheId:", attr(a, "tags"), value = TRUE))
+
+    ## A single quote in a tagValue used to be pasted straight into the SQL,
+    ## making it invalid. Because that failure is deterministic, the retry() in
+    ## .addTagsRepo re-ran it 250 times before erroring -- a multi-minute hang.
+    tricky <- "/home/o'brien/Ian's \"data\".tif"
+    .addTagsRepo(cid, cp, tagKey = "origFilename", tagValue = tricky)
+    sc <- showCacheFast(cid, cp, strict = FALSE)
+    expect_identical(extractFromCache(sc, "origFilename"), tricky)
+
+    ## .updateTagsRepo: both the update-in-place and the add-if-absent branches.
+    tricky2 <- paste0(tricky, "'v2")
+    .updateTagsRepo(cid, cp, tagKey = "origFilename", tagValue = tricky2)
+    .updateTagsRepo(cid, cp, tagKey = "quotedNewKey", tagValue = tricky2, add = TRUE)
+    sc <- showCacheFast(cid, cp, strict = FALSE)
+    expect_identical(extractFromCache(sc, "origFilename"), tricky2)
+    expect_identical(extractFromCache(sc, "quotedNewKey"), tricky2)
+
+    ## showCacheFast returns only the requested cacheId (the DBI branch queries
+    ## for it; the file-backed one reads that cacheId's metadata file).
+    b <- Cache(rnorm, 2, cachePath = cp)
+    expect_identical(unique(showCacheFast(cid, cp, strict = FALSE)[["cacheId"]]), cid)
+  }
+})
+
+test_that("CacheIsACache does not rename another cachePath's table (DBI)", {
+  skip_if_not_installed("RSQLite")
+  skip_if_not_installed("DBI")
+  testInit()
+  withr::local_options(reproducible.useDBI = TRUE)
+  skip_if_not(useDBI())
+
+  drv <- getDrv(NULL)
+  cpA <- file.path(tmpdir, "repoA")
+  cpB <- file.path(tmpdir, "repoB")
+  invisible(Cache(rnorm, 1, cachePath = cpA))
+  invisible(Cache(rnorm, 2, cachePath = cpB))
+
+  connA <- dbConnectAll(drv, cachePath = cpA)
+  on.exit(try(DBI::dbDisconnect(connA), silent = TRUE), add = TRUE)
+  tableA <- DBI::dbListTables(connA)
+
+  ## A connection for repoA paired with repoB's cachePath is a *normal*
+  ## occurrence -- `conn` defaults to the single global reproducible.conn, and
+  ## Cache() may span several cachePaths. The table-name mismatch that follows
+  ## must NOT be read as "this repo moved": movedCache() would ALTER TABLE ...
+  ## RENAME repoA's table to repoB's name, silently corrupting repoA.
+  expect_false(CacheIsACache(cpB, drv = drv, conn = connA))
+  expect_identical(DBI::dbListTables(connA), tableA)
+
+  ## ... but a genuinely moved repo (same database file, stale table name) must
+  ## still self-repair, which is what movedCache() is for.
+  cpMoved <- file.path(tmpdir, "repoMoved")
+  checkPath(file.path(cpMoved, "cacheOutputs"), create = TRUE)
+  froms <- dir(cpA, recursive = TRUE, full.names = TRUE)
+  file.copy(froms, gsub(basename(cpA), basename(cpMoved), froms), overwrite = TRUE)
+
+  connMoved <- dbConnectAll(drv, cachePath = cpMoved)
+  on.exit(try(DBI::dbDisconnect(connMoved), silent = TRUE), add = TRUE)
+  expect_identical(DBI::dbListTables(connMoved), tableA) # stale name, pre-repair
+  suppressWarnings(CacheIsACache(cpMoved, drv = drv, conn = connMoved))
+  expect_identical(DBI::dbListTables(connMoved), CacheDBTableName(cpMoved, drv = drv))
+})


### PR DESCRIPTION
Makes the `useDBI(TRUE)` (SQLite/DBI) backend actually usable. Follow-on to #534, which merged the `NEWS.md` entries and the `showCacheFast()`/`reproducibleOptions()` half of this work ahead of the code — so `development` currently documents these fixes without having them. This closes that gap.

Found while auditing whether `useDBI = FALSE` could be deprecated. It can't (SQLite over NFS relies on `fcntl` locking, and `journal_mode=WAL` is unusable on a network filesystem), so the file-backed default stays — but the DBI path had real defects worth fixing.

## What's fixed

**1. A single quote in a tag value hung `Cache()` — it did not error.**
`.addTagsRepo()`/`.updateTagsRepo()` pasted `tagValue` straight into the SQL, so an apostrophe in any tag value (a file path like `Ian's data.tif`, a `userTag`, a url) produced invalid SQL. That failure is deterministic, so the `retry(retries = 250, exponentialDecayBase = 1.01)` around the insert re-ran it 250 times before giving up. Measured: **>7 minutes**, then `near "brien": syntax error`.

Now uses the idioms already in this package — `DBI::dbAppendTable()` + `metadataDT()` (as `saveToCache()` does) and `glue::glue_sql()` (as `rmFromCache()`/`getHashFromDB()` do). 0.26s, values round-trip byte-exact.

**2. The tag functions ignored `Cache()`'s connection list.**
`saveToCache()`/`searchInRepos()` already select this repo's connection out of the named list; these two didn't, so a list reached DBI unmodified and the write failed — silently, because both call sites wrap it in `try(silent = TRUE)`. This is why `reproducible.urlHitCount` never left 0.

**3. URL logging was disabled outright under DBI.**
`.maybeRecordUrlForCache()` opened with `if (useDBI()) return(invisible())`, because `showCacheFast()` only knew how to read the file-backed per-`cacheId` metadata file. It now answers from a targeted query via `getHashFromDB()`, and its `drv`/`conn` arguments gained the package-standard defaults (the `cacheChaining` callers in `GPT2.R` omit them and would otherwise error under DBI).

**4. `CacheIsACache()` silently corrupted a second cache repo.**
On a table-name mismatch it assumes a *moved repository* and calls `movedCache()` — `ALTER TABLE ... RENAME`. But `conn` does not necessarily belong to `cachePath`: it defaults to the single global `getOption("reproducible.conn")` in `.prepareFileBackedRaster`, `writeFuture`, `clearCache`, `showCache`, and `createCache`, and `Cache()` may span several `cachePath`s. Pairing repo A's connection with repo B's `cachePath` **renamed A's table to B's name**, corrupting A.

Reproduced directly, and reachable independently of anything else in this PR — set `reproducible.conn` (documented as the fast path for remote DB servers), use two `cachePath`s, and it happens.

A moved repo and a foreign connection are indistinguishable by table name alone, so the new `connIsForCachePath()` compares `DBI::dbGetInfo(conn)$dbname` against `CacheDBFile(cachePath)`:

| Scenario | Guard | Outcome |
|---|---|---|
| Genuinely moved repo (stale table name, same `cache.db`) | `TRUE` | Repairs — table renamed, entry recovered |
| Another repo's connection | `FALSE` | Returns `FALSE`, no rename |

**5. Postgres caches could not be opened at all.**
`createConns()` issued SQLite `PRAGMA busy_timeout` / `PRAGMA journal_mode=WAL` on whatever connection it had just opened. `PRAGMA` is SQLite-specific syntax and `RPostgres` — the other backend documented for `reproducible.drv`/`conn` — errors on it. Now gated on the connection actually being SQLite (which also skips safely when `dbConnectAll()` returned `NULL`).

## CI coverage

The `useDBI(TRUE)` CI pass was filtered to `"^cache"`, on the assumption that only cache storage/retrieval depends on the backend. That assumption is what let URL logging sit silently disabled — nothing in the DBI pass touched it. The filter now covers every test file with a `useDBI()` branch behind it.

Checked against a clean worktree at the merge-base: the only failures the wider filter surfaces are `test-cloud.R:82` and `:93`, which fail **identically under both backends** (they need a real Google Drive upload). No added CI risk relative to the file-backed pass that already runs those files.

## Verification

Zero failures on **both** backends across `test-cache` (including the `movedCache` tests), `cacheHelpers`, `cachePath-lazy`, `multipleCacheRepo`, `preDigestDump`, `showCacheAsyncInstall`, `showCacheCorruptFile`, `urlLog`.

New regression tests in `test-cacheHelpers.R`, both exercised across backends: quotes round-tripping through the tag functions (update-in-place and add-if-absent) with `showCacheFast()` returning only the requested `cacheId`; and `CacheIsACache()` leaving a foreign repo's table untouched while a genuinely moved repo still self-repairs.

`NEWS.md` is deliberately untouched — those entries already merged with #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
