### PR TITLE
test(gdrive): authenticate with a user OAuth token when one is staged

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9074
+Version: 3.1.1.9075
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/helper-allEqual.R
+++ b/tests/testthat/helper-allEqual.R
@@ -187,6 +187,35 @@ testInit <- function(libraries = character(), ask = FALSE, verbose, tmpFileExt =
       skip("SKIP_GAUTH=true; skipping Google Drive tests")
     if (isNamespaceLoaded("googledrive"))
       if ((!googledrive::drive_has_token())) {
+        ## Prefer a real user OAuth token when one is available.
+        ##
+        ## A service account has no Drive quota on user-owned folders: it
+        ## authenticates fine but cannot complete an upload round-trip, so the
+        ## Drive tests start and then stop part-way. Nothing fails loudly --
+        ## covr does not fail on test errors and prints no skip summary -- so
+        ## those code paths just silently show 0 coverage (CacheGeo() sat at
+        ## 0/176 lines this way). A user token carries the user's own quota.
+        ##
+        ## GDRIVE_OAUTH_TOKEN is a path to a serialized token, set by the
+        ## reusable workflow when the GOOGLEDRIVE_AUTH secret holds one (see
+        ## PredictiveEcology/actions); locally, point it at your own saveRDS'd
+        ## token. Falls through to the service-account path below when unset or
+        ## unreadable, so this is a no-op until the secret is switched over.
+        oauthTokenFile <- Sys.getenv("GDRIVE_OAUTH_TOKEN")
+        if (nzchar(oauthTokenFile) && file.exists(oauthTokenFile)) {
+          tok <- tryCatch(readRDS(oauthTokenFile), error = function(e) {
+            message("GDRIVE_OAUTH_TOKEN could not be read: ", conditionMessage(e))
+            NULL
+          })
+          if (!is.null(tok)) {
+            tryCatch(googledrive::drive_auth(token = tok),
+                     error = function(e)
+                       message("GDRIVE_OAUTH_TOKEN was not usable: ", conditionMessage(e)))
+          }
+        }
+      }
+    if (isNamespaceLoaded("googledrive"))
+      if ((!googledrive::drive_has_token())) {
         if (!nzchar(Sys.getenv("GOOGLEDRIVE_AUTH"))) {
           Sys.setenv("GOOGLEDRIVE_AUTH" = "~/genial-cycling-408722-788552a3ecac.json")
         }
@@ -204,8 +233,12 @@ testInit <- function(libraries = character(), ask = FALSE, verbose, tmpFileExt =
           ## Google credentials" abort, which turns every Drive-using test
           ## into an ERROR instead of a SKIP. Swallow it so the
           ## skip_if_no_token() below cleanly skips instead.
+          ## Report the reason rather than discarding it: a revoked or
+          ## malformed credential is otherwise indistinguishable from "no
+          ## credential configured", and the tests just skip in silence.
           tryCatch(googledrive::drive_auth(path = gauthEnv),
-                   error = function(e) invisible(NULL))
+                   error = function(e)
+                     message("GOOGLEDRIVE_AUTH was not usable: ", conditionMessage(e)))
         }
       }
 


### PR DESCRIPTION
Consuming side of PredictiveEcology/actions#12 — makes `testInit()` authenticate with a real user OAuth token when one is staged.

## Why

A service account has **no Drive quota on user-owned folders**. It authenticates fine, so `drive_has_token()` is `TRUE` and the Drive tests *start* — then stop part-way at the first upload.

Nothing fails loudly. `covr` doesn't fail on test errors and prints no skip summary, so the run goes green while those paths show zero coverage. On `development`:

| function | hit / measured |
|---|---|
| `CacheGeo` | **0** / 176 |
| `cloudDownload` | **0** / 36 |
| `showCacheCloud` | **0** / 32 |
| `cloudDownloadRasterBackend` | **0** / 32 |

…while the non-Drive helpers beside them are covered (`checkAndMakeCloudFolderID` 46/67, `driveLs` 13/24, `extractPolygonIfWithin` 27/32). That contrast is the tell.

Worth being precise about what was *not* wrong: the secret was staged correctly the whole time (`Staged service-account JSON (2409 bytes)` in the job log), and `GOOGLEDRIVE_AUTH` was set on the covr step. The credential simply cannot upload.

## What changed

`testInit()` tries `GDRIVE_OAUTH_TOKEN` — a path to a serialized token — via `drive_auth(token = ...)` before the existing service-account path. The reusable workflow sets it when the `GOOGLEDRIVE_AUTH` secret holds a token rather than a key.

Ordering is deliberate: token first, and anything missing, unreadable or unusable **falls through** to today's behaviour. So this is inert until the secret is switched over, and degrades rather than erroring.

Verified against four states — unset variable, nonexistent path, non-RDS file, and a valid RDS that isn't a token. None error; the two failure modes each emit their own message:

```
MSG: GDRIVE_OAUTH_TOKEN could not be read: unknown input format
MSG: GDRIVE_OAUTH_TOKEN was not usable: Can't get Google credentials.
```

## Also: stop swallowing the auth failure reason

```r
tryCatch(googledrive::drive_auth(path = gauthEnv),
         error = function(e) invisible(NULL))     # <- discarded
```

This made a revoked or malformed credential indistinguishable from no credential: both skipped, silently. It's a large part of why the zero coverage above went unexplained for so long. It now `message()`s the condition so it appears in the CI log.

## Sequencing

1. actions#12 merges (teaches the workflow to recognise a token) ← **must be first**
2. `GOOGLEDRIVE_AUTH` org secret swapped to the base64 token ← *already done*
3. This PR

Between 2 and 1, the workflow warns `did not decode to service-account JSON` and Drive tests skip — no failures, and no worse than the status quo, since they were producing no coverage anyway.

Once all three land, `CacheGeo` and the `cloud.R` round-trip functions should move off zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
