### PR TITLE
test(gdrive): fail loudly when a configured Drive credential does not work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9075
+Version: 3.1.1.9076
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -54,13 +54,31 @@ opts <- options(
 # Whatever files are on googledrive must be shared with this google service account
 if (isNamespaceLoaded("googledrive"))
   if ((!googledrive::drive_has_token())) {
+    ## Prefer a user OAuth token, as testInit() does -- a service account
+    ## authenticates but has no Drive quota on user-owned folders, so it cannot
+    ## complete an upload round-trip. GDRIVE_OAUTH_TOKEN is a path to a
+    ## serialized token, set by the reusable workflow when the GOOGLEDRIVE_AUTH
+    ## secret holds one. See helper-allEqual.R.
+    oauthTokenFile <- Sys.getenv("GDRIVE_OAUTH_TOKEN")
+    if (nzchar(oauthTokenFile) && file.exists(oauthTokenFile)) {
+      tok <- tryCatch(readRDS(oauthTokenFile), error = function(e) {
+        message("GDRIVE_OAUTH_TOKEN could not be read: ", conditionMessage(e)); NULL
+      })
+      if (!is.null(tok))
+        tryCatch(googledrive::drive_auth(token = tok),
+                 error = function(e)
+                   message("GDRIVE_OAUTH_TOKEN was not usable: ", conditionMessage(e)))
+    }
     gauthEnv <- Sys.getenv("GOOGLEDRIVE_AUTH")
-    if (nzchar(gauthEnv)) {
+    if (!googledrive::drive_has_token() && nzchar(gauthEnv)) {
       ## drive_auth(path =) accepts a JSON file path OR the JSON contents
       ## directly. On GHA the secret holds JSON; locally it's a path.
       ## see helper-allEqual.R: tolerate revoked / rotated service-account keys
+      ## Report the reason rather than discarding it: a revoked credential is
+      ## otherwise indistinguishable from no credential at all.
       tryCatch(googledrive::drive_auth(path = gauthEnv),
-               error = function(e) invisible(NULL))
+               error = function(e)
+                 message("GOOGLEDRIVE_AUTH was not usable: ", conditionMessage(e)))
     }
   }
 

--- a/tests/testthat/test-gdriveAuthDiagnostic.R
+++ b/tests/testthat/test-gdriveAuthDiagnostic.R
@@ -1,0 +1,62 @@
+## A configured Google Drive credential must actually work.
+##
+## Every other Drive test is written to skip() when authentication is
+## unavailable -- correct behaviour for CRAN, forks and contributors, but it
+## means a *broken* credential is indistinguishable from *no* credential: both
+## just skip. Under covr it is worse, because covr neither fails on test errors
+## nor prints a skip summary, so the run goes green and the only symptom is a
+## coverage number that quietly stays flat.
+##
+## That is not hypothetical. A service-account key authenticated fine for months
+## while being unable to complete any upload (service accounts have no Drive
+## quota on user-owned folders), which left CacheGeo() at 0/176 lines and the
+## cloud.R round-trip functions at 0, with nothing anywhere saying why.
+##
+## So: skip when nothing is configured, but FAIL -- loudly, with the reason --
+## when something is configured and does not work.
+
+test_that("a configured Google Drive credential is usable", {
+  skip_on_cran()
+  skip_if_not_installed("googledrive")
+
+  tokenFile <- Sys.getenv("GDRIVE_OAUTH_TOKEN")
+  saCred    <- Sys.getenv("GOOGLEDRIVE_AUTH")
+  if (!nzchar(tokenFile) && !nzchar(saCred)) {
+    skip("No Drive credential configured (GDRIVE_OAUTH_TOKEN / GOOGLEDRIVE_AUTH unset)")
+  }
+
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  ## testInit() skips above if it cannot authenticate at all. Reaching here means
+  ## a token is loaded, so anything below is a genuine defect worth failing on.
+  expect_true(googledrive::drive_has_token())
+
+  ## drive_has_token() only reports that a token *object* exists. It is TRUE for
+  ## a scope-limited token that 403s on first use, and for one whose refresh is
+  ## broken -- both of which look like success right up until the tests silently
+  ## produce nothing. Make one real API call.
+  who <- tryCatch(googledrive::drive_user()$emailAddress,
+                  error = function(e) paste("ERROR:", conditionMessage(e)))
+  expect_false(startsWith(who, "ERROR:"),
+               label = paste("drive_user() failed --", who))
+  expect_true(nzchar(who))
+
+  ## Report what is actually in use. These land in the test log and are the
+  ## difference between "Drive tests skipped" and knowing *which* identity,
+  ## client and scopes were in play.
+  info <- c(
+    paste("credential:", if (nzchar(tokenFile)) "user OAuth token" else "service account"),
+    paste("identity:  ", who),
+    paste("is service account:", grepl("gserviceaccount", who))
+  )
+  message(paste(info, collapse = "\n"))
+
+  ## A service account can authenticate but cannot upload to a user-owned
+  ## folder, so it can never exercise the cloud round-trip. Not a failure --
+  ## some setups legitimately only read -- but it must be visible.
+  if (grepl("gserviceaccount", who)) {
+    message("NOTE: authenticated as a service account. It has no Drive quota on ",
+            "user-owned folders, so upload/round-trip tests cannot pass and the ",
+            "cloud code paths will report zero coverage.")
+  }
+})


### PR DESCRIPTION
Makes a broken Google Drive credential **fail loudly** instead of skipping in silence.

## Why

Every Drive test skips when auth is unavailable — correct for CRAN, forks and contributors. But it means a **broken** credential is indistinguishable from **no** credential: both just skip.

Under `covr` it's worse. It neither fails on test errors nor prints a skip summary, so the run goes green and the only symptom is a coverage number that quietly stays flat.

That's not hypothetical. A service-account key authenticated fine for months while being unable to complete any upload — service accounts have no Drive quota on user-owned folders — leaving:

| function | hit / measured |
|---|---|
| `CacheGeo` | 0 / 176 |
| `cloudDownload` | 0 / 36 |
| `showCacheCloud` | 0 / 32 |
| `cloudDownloadRasterBackend` | 0 / 32 |

Diagnosing it meant inferring from coverage percentages across repeated CI round-trips, because nothing in any log — workflow or R — said anything at all.

## What this adds

`test-gdriveAuthDiagnostic.R`: skip when nothing is configured, **fail with the reason** when something is configured and doesn't work.

It deliberately makes one real API call rather than trusting `drive_has_token()`, which only reports that a token *object* exists. That's `TRUE` for a scope-limited token that 403s on first use, and for one whose refresh is broken — both look like success right up until the tests silently produce nothing.

It also logs which identity is in use, and notes explicitly when that identity is a service account, since that alone caps what the cloud tests can reach.

Verified across all three states:

| state | result |
|---|---|
| no credential configured | clean skip |
| working user token | pass |
| scope-limited token | **failure carrying `Client error: (403) Forbidden`** |

## Also

`setup.R` has its own auth block — a second copy of the logic in `helper-allEqual.R` — that knew only about service accounts. Inert today (it runs before `googledrive` is loaded, and `GOOGLEDRIVE_AUTH` is empty when a token is staged), but it would drift. It now understands `GDRIVE_OAUTH_TOKEN` too.

Both copies now report *why* auth failed rather than discarding it:

```r
tryCatch(googledrive::drive_auth(path = gauthEnv),
         error = function(e) invisible(NULL))    # was
```

## Context

Follows PredictiveEcology/actions#12 and #536. The credential chain is confirmed working end to end — the workflow stages the token at the exact expected byte count and exports it to R — yet `cacheGeo` coverage on CI stays at 16.6% while identical local `covr` runs, with CI's env vars, reach 69–75%. This PR is what will make the next run say *why* instead of leaving us to infer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
