### PR TITLE
test(download): cover the network-free helpers in download.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9076
+Version: 3.1.1.9077
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -1,0 +1,137 @@
+## Unit tests for helpers in R/download.R that need no network.
+##
+## download.R is 53.9% covered and holds the largest block of uncovered lines in
+## the package. Most of that is genuinely network-bound (dlGoogle, assessGoogle,
+## download_resumable_httr2), but a handful of helpers are ordinary functions --
+## duration formatting, HTML form parsing, interstitial detection, checksum-file
+## editing -- that were untested only because they live in a file whose main
+## paths need the internet.
+
+test_that(".formatDuration renders h/m/s and rejects bad input", {
+  testInit()
+
+  expect_identical(.formatDuration(0), "0s")
+  expect_identical(.formatDuration(45), "45s")
+  ## Minutes and seconds are zero-padded so successive readings line up.
+  expect_identical(.formatDuration(61), "1m01s")
+  expect_identical(.formatDuration(599), "9m59s")
+  expect_identical(.formatDuration(3661), "1h01m01s")
+  expect_identical(.formatDuration(36000), "10h00m00s")
+  ## Fractional seconds round rather than truncate.
+  expect_identical(.formatDuration(59.6), "1m00s")
+
+  ## Anything not a single finite non-negative number is "--" rather than an error,
+  ## because this only ever decorates a progress message.
+  expect_identical(.formatDuration(-1), "--")
+  expect_identical(.formatDuration(NA_real_), "--")
+  expect_identical(.formatDuration(Inf), "--")
+  expect_identical(.formatDuration(numeric(0)), "--")
+  expect_identical(.formatDuration(c(1, 2)), "--")
+})
+
+test_that(".parseGoogleConfirm extracts hidden form inputs", {
+  testInit()
+
+  f <- file.path(tmpdir, "interstitial.html")
+  writeLines(c(
+    '<html><body><form action="https://drive.usercontent.google.com/download">',
+    '<input type="hidden" name="id" value="1AbC-dEf">',
+    '<input type="hidden" name="export" value="download">',
+    '<input type="hidden" name="confirm" value="t">',
+    '<input type="hidden" name="uuid" value="abcd-1234">',
+    '<input type="submit" value="Download anyway">',
+    '</form></body></html>'
+  ), f)
+
+  out <- .parseGoogleConfirm(f)
+  expect_type(out, "list")
+  ## These four are what the download has to resubmit.
+  expect_identical(out$id, "1AbC-dEf")
+  expect_identical(out$export, "download")
+  expect_identical(out$confirm, "t")
+  expect_identical(out$uuid, "abcd-1234")
+  ## An input with a value but no name contributes nothing.
+  expect_false("" %in% names(out))
+
+  ## No inputs -> empty list, not an error.
+  f2 <- file.path(tmpdir, "plain.html")
+  writeLines("<html><body>nothing here</body></html>", f2)
+  expect_length(.parseGoogleConfirm(f2), 0L)
+
+  ## Unreadable file is caught and treated as "no inputs".
+  expect_length(suppressWarnings(.parseGoogleConfirm(file.path(tmpdir, "missing.html"))), 0L)
+})
+
+test_that(".looksLikeGoogleInterstitial distinguishes the HTML gate from a real payload", {
+  testInit()
+
+  gate <- file.path(tmpdir, "gate.html")
+  writeLines(paste('<!DOCTYPE html><html><body>',
+                   '<form action="https://drive.usercontent.google.com/download">',
+                   'Google Drive can\'t perform a virus scan.</form></body></html>'), gate)
+  expect_true(.looksLikeGoogleInterstitial(gate))
+
+  ## HTML, but not Drive's gate -- must not be mistaken for one.
+  other <- file.path(tmpdir, "other.html")
+  writeLines("<html><body>some unrelated page</body></html>", other)
+  expect_false(.looksLikeGoogleInterstitial(other))
+
+  ## A real (binary) payload. Embedded NUL bytes are why the function reads raw
+  ## and matches useBytes -- a plain grepl() here can trip locale translation.
+  bin <- file.path(tmpdir, "payload.zip")
+  writeBin(as.raw(c(0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0xff, 0xfe, 0x00, 0x01)), bin)
+  expect_false(.looksLikeGoogleInterstitial(bin))
+
+  ## Absent and empty files are both "not an interstitial".
+  expect_false(.looksLikeGoogleInterstitial(file.path(tmpdir, "nope.html")))
+  empty <- file.path(tmpdir, "empty.html")
+  file.create(empty)
+  expect_false(.looksLikeGoogleInterstitial(empty))
+})
+
+test_that("purgeChecksums removes only the named files", {
+  skip_if_not_installed("data.table")
+  testInit()
+
+  cf <- file.path(tmpdir, "CHECKSUMS.txt")
+  data.table::fwrite(data.table::data.table(
+    file     = c("a.tif", "b.tif", "c.tif"),
+    checksum = c("aaa", "bbb", "ccc")
+  ), cf)
+
+  purgeChecksums(cf, "b.tif")
+
+  out <- data.table::fread(cf)
+  expect_identical(sort(out$file), c("a.tif", "c.tif"))
+  expect_false("bbb" %in% out$checksum)
+
+  ## Purging something absent leaves the file untouched rather than erroring.
+  purgeChecksums(cf, "not-there.tif")
+  expect_identical(nrow(data.table::fread(cf)), 2L)
+})
+
+test_that(".gdriveHasToken reports token state without erroring", {
+  testInit()
+
+  res <- .gdriveHasToken()
+  expect_type(res, "logical")
+  expect_length(res, 1L)
+  expect_false(is.na(res))
+
+  ## After an explicit deauth it must be FALSE -- this is the predicate the
+  ## download path uses to decide between authenticated and anonymous access.
+  if (requireNamespace("googledrive", quietly = TRUE)) {
+    withr::defer(try(googledrive::drive_deauth(), silent = TRUE))
+    try(googledrive::drive_deauth(), silent = TRUE)
+    expect_false(.gdriveHasToken())
+  }
+})
+
+test_that(".isRstudioServer is FALSE outside RStudio Server", {
+  testInit()
+  skip_if("tools:rstudio" %in% search(), "running inside RStudio")
+
+  ## Plain R session (which is what CI and R CMD check are): no rstudio on the
+  ## search path, so the answer is FALSE without consulting the API.
+  expect_false(.isRstudioServer())
+})


### PR DESCRIPTION
Tests for the six helpers in `R/download.R` that need no network.

## Context

`download.R` holds the largest block of uncovered lines in the package — **552 uncovered at 53.9%**. Most of that is genuinely network-bound and can only be reached with working Drive credentials:

| function | uncovered |
|---|---|
| `dlGoogle` | 126 |
| `download_resumable_httr2` | 65 |
| `assessGoogle` | 37 |
| `.dlGooglePublic` | 21 |

(Incidentally: `download_resumable_httr2` is **not** stale — it has six call sites across `download.R` and `downloadTileAndUpload.R`. It has zero *test* references, which is why it reads as dead in the coverage report. Live code, never exercised.)

## What this covers

Six helpers in the same file need no network, and were untested only because the file around them does — ~39 measurable lines, all previously at zero:

`.formatDuration`, `.parseGoogleConfirm`, `.looksLikeGoogleInterstitial`, `purgeChecksums`, `.gdriveHasToken`, `.isRstudioServer`.

Tests target behaviour at the call site rather than restating the implementation:

- **`.formatDuration`** returns `"--"` for anything that isn't a single finite non-negative number — it only decorates a progress message and must never raise. Zero-padding is asserted (`1m01s`, not `1m1s`) so successive readings align.
- **`.parseGoogleConfirm`** recovers the `id`/`export`/`confirm`/`uuid` the download must resubmit, and yields an empty list — not an error — for a page with no inputs or a file it can't read.
- **`.looksLikeGoogleInterstitial`** separates Drive's HTML gate from a real payload, including a binary fixture with embedded NUL bytes. That's the specific case the function reads raw and matches `useBytes` to survive, so it's worth pinning.
- **`purgeChecksums`** removes only the named entries and tolerates purging an absent one.
- **`.gdriveHasToken`** is `FALSE` after an explicit deauth — the predicate the download path uses to choose authenticated vs anonymous access.

33 assertions, no new dependencies, no network.

## On the expected delta

Modest — roughly **+0.35 pp**.

Worth stating plainly because I got this wrong on #537: I predicted +2.6 pp there and it delivered +0.64. The error was counting *source lines* as covr's denominator. covr counts **measurable expressions**; multi-line signatures, braces, comments and blanks all collapse. For `downloadTileAndUpload.R` that's a ~2:1 ratio (558 countable lines in a ~1100-line file), and for the functions in question closer to 4:1.

These six span ~110 source lines but only ~39 countable ones. Estimated accordingly this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
