### PR TITLE
fix(gdrive): nest per-session cloud folders under a stable testsForPkgs parent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9079
+Version: 3.1.1.9080
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9080
+Version: 3.1.1.9081
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9081
+Version: 3.1.1.9082
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/helper-allEqual.R
+++ b/tests/testthat/helper-allEqual.R
@@ -604,48 +604,77 @@ expect_match_noSlashN <- function(object, regexp, ...) {
 
 }
 
-## Root Drive folder for THIS test session, created once and reused.
+## Drive layout for the test suite:
 ##
-## The suite previously used a fixed folder literally named "testsForPkgs", and
-## every job deleted it wholesale on teardown. Local cachePaths are random, and
-## so are the working subfolders -- but their shared *parent* was not, so the
-## first job to finish destroyed every concurrent job's working folder mid-run.
-## With 8 R-CMD-check matrix legs plus the coverage job all starting together,
-## that surfaced as `drive_rm()` 404s ("File not found") and as uploads being
-## skipped because another job had already put the object there.
+##   testsForPkgs/                        <- stable parent, NEVER deleted
+##     run-<GHA run>-<job>-<rnd>/         <- one per test SESSION, removed on teardown
+##       <per-test working folders>
 ##
-## The name carries the GHA run and job when available, so a folder left behind
-## by a cancelled run can be traced back to it; a random suffix keeps concurrent
-## local runs apart too.
+## The suite originally used "testsForPkgs" itself as the working root and
+## deleted it wholesale on teardown. Local cachePaths are random, and so are the
+## per-test working folders -- but their shared *parent* was not, so the first
+## job to finish destroyed every concurrent job's workspace mid-run. With 8
+## R-CMD-check matrix legs plus the coverage job all starting together, that
+## surfaced as drive_rm() 404s ("File not found") and as uploads being skipped
+## because another job had already put the object there.
+##
+## Session folders are nested rather than sitting at the Drive root, so the root
+## does not accumulate one folder per run. Their names carry the GHA run and job
+## when available, so anything left behind by a cancelled run (which cannot run
+## its own teardown) is traceable; the random suffix keeps concurrent local runs
+## apart too.
+
+## The stable parent. Fetched if it exists, created once if not, and never
+## removed -- deleting it is precisely the bug described above.
+.cloudTestParent <- local({
+  dir <- NULL
+  function() {
+    stillThere <- !is.null(dir) && isTRUE(tryCatch({
+      googledrive::drive_get(id = dir$id); TRUE
+    }, error = function(e) FALSE))
+    if (!stillThere) {
+      found <- tryCatch(googledrive::drive_get(path = "testsForPkgs/"),
+                        error = function(e) NULL)
+      dir <<- if (!is.null(found) && NROW(found) > 0) {
+        ## Concurrent jobs can each create one before either sees the other;
+        ## settling on the first keeps every job in the same place.
+        found[1, ]
+      } else {
+        retry(quote(googledrive::drive_mkdir(name = "testsForPkgs")))
+      }
+    }
+    dir
+  }
+})
+
 .cloudTestRootName <- local({
   nm <- NULL
   function() {
     if (is.null(nm)) {
       tag <- paste(Filter(nzchar, c(Sys.getenv("GITHUB_RUN_ID"), Sys.getenv("GITHUB_JOB"))),
                    collapse = "-")
-      nm <<- paste0("testsForPkgs-", if (nzchar(tag)) paste0(tag, "-") else "", rndstr(1, 6))
+      nm <<- paste0("run-", if (nzchar(tag)) paste0(tag, "-") else "", rndstr(1, 6))
     }
     nm
   }
 })
 
-## The dribble for this session's root folder, creating it on first use.
+## This session's working folder, inside the stable parent.
 ##
-## Self-healing on purpose: googleSetupForUseCloud() removes this root in its
-## teardown, so a later test_that() in the same session finds it gone. Without
-## the existence check, drive_mkdir(path = <deleted folder>) fails, retries five
+## Self-healing on purpose: googleSetupForUseCloud() removes it in its teardown,
+## so a later test_that() in the same session finds it gone. Without the
+## existence check, drive_mkdir(path = <deleted folder>) fails, retries five
 ## times and reports "Failed after 5 attempts". (The old fixed-name code got
 ## this right by accident, re-creating "testsForPkgs" whenever it was missing.)
 .cloudTestRoot <- local({
   dir <- NULL
   function() {
-    stillThere <- !is.null(dir) &&
-      isTRUE(tryCatch({
-        googledrive::drive_get(id = dir$id)
-        TRUE
-      }, error = function(e) FALSE))
+    stillThere <- !is.null(dir) && isTRUE(tryCatch({
+      googledrive::drive_get(id = dir$id); TRUE
+    }, error = function(e) FALSE))
     if (!stillThere) {
-      dir <<- retry(quote(googledrive::drive_mkdir(name = .cloudTestRootName())))
+      dir <<- retry(quote(googledrive::drive_mkdir(name = .cloudTestRootName(),
+                                                   path = .cloudTestParent())))
     }
     dir
   }

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -205,6 +205,18 @@ test_that("test miscellaneous fns (part 2)", {
     add = TRUE
   )
 
+  ## Give this test its own derived cloud folder name.
+  ##
+  ## cloudFolderFromCacheRepo() is basename(dirname(x))_basename(x), so for the
+  ## default session cache (<tempdir>/reproducible/cache) it strips the random
+  ## tempdir and yields the CONSTANT "reproducible_cache" -- identical on every
+  ## machine and every CI job. With 9 jobs running concurrently against one
+  ## Drive account they each create a folder of that name at the Drive root, and
+  ## the drive_ls() below then fails with "Doesn't uniquely identify exactly one
+  ## folder or shared drive". Pointing cachePath at this test's own random
+  ## directory makes the derived name unique per job.
+  withr::local_options(reproducible.cachePath = tmpCache)
+
   ras <- terra::rast(terra::ext(0, 1, 0, 1), resolution = 1, vals = 1)
   ras <- terra::writeRaster(ras, filename = tmpfile[1], overwrite = TRUE)
 

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -217,6 +217,11 @@ test_that("test miscellaneous fns (part 2)", {
   ## directory makes the derived name unique per job.
   withr::local_options(reproducible.cachePath = tmpCache)
 
+  ## Likewise unique per run. "testy" was a fixed folder name created at the
+  ## Drive ROOT by every concurrent job, so resolving it by name could find
+  ## zero, one or several folders depending on who else was mid-run.
+  testyName <- paste0("testy", rndstr(1, 6))
+
   ras <- terra::rast(terra::ext(0, 1, 0, 1), resolution = 1, vals = 1)
   ras <- terra::writeRaster(ras, filename = tmpfile[1], overwrite = TRUE)
 
@@ -226,9 +231,9 @@ test_that("test miscellaneous fns (part 2)", {
   tmpCloudFolderID <- checkAndMakeCloudFolderID(create = TRUE)
   gdriveLs <- driveLs(cloudFolderID = NULL, "sdfsdf")
   expect_true(NROW(gdriveLs) == 0)
-  expect_true(is(checkAndMakeCloudFolderID("testy"), "dribble") ||
-    is(checkAndMakeCloudFolderID("testy"), "character"))
-  cloudFolderID <- checkAndMakeCloudFolderID("testy", create = TRUE)
+  expect_true(is(checkAndMakeCloudFolderID(testyName), "dribble") ||
+    is(checkAndMakeCloudFolderID(testyName), "character"))
+  cloudFolderID <- checkAndMakeCloudFolderID(testyName, create = TRUE)
   testthat::with_mocked_bindings(
     retry = function(..., retries = 1) TRUE,
     {
@@ -254,7 +259,7 @@ test_that("test miscellaneous fns (part 2)", {
   mess1 <- capture_messages(expect_error(expect_warning({
     a <- cloudDownload(
       outputHash = "sdfsd", newFileName = "test.tif",
-      gdriveLs = gdriveLs1, cloudFolderID = "testy", cachePath = tmpCache
+      gdriveLs = gdriveLs1, cloudFolderID = testyName, cachePath = tmpCache
     )
   })))
   expect_true(sum(grepl("Downloading cloud copy of test\\.tif", mess1)) == 1)


### PR DESCRIPTION
Follow-up to #540, which merged one commit before this one and so did not include it.

## The problem

#540 gave each test session its own cloud root folder, fixing jobs deleting each other's workspaces. But it put those folders at the **Drive root**, one per run — so the account fills up with `testsForPkgs-<run>-<job>-<rnd>` entries.

## The layout now

```
testsForPkgs/                     <- stable parent, NEVER deleted
  run-<GHA run>-<job>-<rnd>/      <- one per session, removed on teardown
    <per-test working folders>
```

The parent is fetched when it exists and created once when it does not, and is **never removed** — deleting it is exactly the original bug, where whichever job finished first destroyed every concurrent job's workspace mid-run. Only this session's subtree is torn down, so the isolation property from #540 is unchanged while the Drive root stays clean.

If two jobs both create a parent before either sees the other, the first is used, keeping every job in the same place.

## Verified

Against a real Drive account:

- session folder created inside the existing `testsForPkgs` (found, not re-created)
- `r$drive_resource[[1]]$parents[[1]] == parent$id` — genuinely nested
- teardown removes only the session folder; parent intact
- Drive suite clean: `test-cacheGeo` 20, `test-cloud` 81, `test-gdriveAuthDiagnostic` 3, zero failures

Re-verified after the Drive root was manually cleaned: `testsForPkgs` resolves to exactly one folder, contents 0, and a fresh session nests correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
