### PR TITLE
test(exportedMethods): cover the untested wrap/filename/memoise methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-20
-Version: 3.1.1.9079
+Version: 3.1.1.9080
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/test-exportedMethodsHelpers.R
+++ b/tests/testthat/test-exportedMethodsHelpers.R
@@ -1,0 +1,148 @@
+## Tests for methods in R/exportedMethods.R that had no coverage.
+##
+## These are the S3 methods Cache() dispatches on when preparing an object for
+## storage (.wrap/.unwrap), when repointing a file-backed object at new files
+## (updateFilenameSlots), and when memoising (makeMemoisable/unmakeMemoisable).
+## Several are raster-specific; `raster` is in Suggests, so those construct a
+## small dummy RasterLayer rather than relying on a fixture, and skip when the
+## package is absent.
+
+test_that(".wrap/.unwrap round-trip an environment", {
+  testInit()
+  cp <- checkPath(file.path(tmpdir, "cache"), create = TRUE)
+
+  e <- new.env(parent = emptyenv())
+  e$a <- 1:3
+  e$b <- "x"
+
+  w <- .wrap(e, cachePath = cp, preDigest = list(), cacheId = "wrapEnvId")
+  expect_true(is.environment(w))
+
+  u <- .unwrap(w, cachePath = cp, cacheId = "wrapEnvId")
+  expect_true(is.environment(u))
+  ## Contents survive the round trip unchanged -- this is what Cache() relies on
+  ## when an environment is cached and later restored.
+  expect_identical(u$a, 1:3)
+  expect_identical(u$b, "x")
+})
+
+test_that(".wrap.environment drops everything outside outputObjects", {
+  testInit()
+  cp <- checkPath(file.path(tmpdir, "cache"), create = TRUE)
+
+  e <- new.env(parent = emptyenv())
+  e$keep <- 1
+  e$drop <- 2
+
+  ## NOTE: this mutates `e` in place (rm(list = ..., envir = obj)), it does not
+  ## work on a copy. Asserted here because a caller passing a live environment
+  ## will see its contents removed.
+  .wrap(e, cachePath = cp, preDigest = list(), cacheId = "outputObjId",
+        outputObjects = "keep")
+
+  expect_identical(ls(e), "keep")
+  expect_identical(e$keep, 1)
+})
+
+test_that("makeMemoisable.data.table returns an independent copy", {
+  skip_if_not_installed("data.table")
+  testInit()
+
+  dt <- data.table::data.table(a = 1:3, b = letters[1:3])
+  mm <- makeMemoisable(dt)
+
+  expect_s3_class(mm, "data.table")
+  expect_equal(mm$a, 1:3)
+
+  ## The point of the method: data.table modifies by reference, so a memoised
+  ## copy must not track later edits to the original.
+  dt[, a := 99L]
+  expect_equal(mm$a, 1:3)
+  expect_false(identical(mm$a, dt$a))
+})
+
+test_that("unmakeMemoisable returns its input unchanged by default", {
+  testInit()
+
+  expect_identical(unmakeMemoisable(1:3), 1:3)
+  expect_identical(unmakeMemoisable("a"), "a")
+
+  l <- list(a = 1, b = "two")
+  expect_identical(unmakeMemoisable(l), l)
+
+  ## The default method is an identity, so a round trip through both is a no-op
+  ## for anything without a specialised method.
+  expect_identical(unmakeMemoisable(makeMemoisable(l)), l)
+})
+
+test_that("updateFilenameSlots repoints a file-backed RasterLayer", {
+  skip_if_not_installed("raster")
+  testInit("raster")
+
+  r <- raster::raster(raster::extent(0, 10, 0, 10), resolution = 1, vals = 1)
+  r <- raster::writeRaster(r, filename = file.path(tmpdir, "r1.grd"), overwrite = TRUE)
+  expect_identical(Filenames(r, allowMultiple = FALSE), normPath(file.path(tmpdir, "r1.grd")))
+
+  newf <- file.path(tmpdir, "moved.grd")
+  r2 <- updateFilenameSlots(r, newFilenames = newf)
+
+  ## Only the recorded filename changes; this is a slot edit, not a file move.
+  expect_identical(Filenames(r2, allowMultiple = FALSE), normPath(newf))
+  expect_true(file.exists(file.path(tmpdir, "r1.grd")))
+
+  ## newFilenames is required -- omitting it must be an error, not a silent no-op.
+  expect_error(updateFilenameSlots(r), "newFilenames")
+})
+
+test_that("updateFilenameSlots accepts a directory instead of filenames", {
+  skip_if_not_installed("raster")
+  testInit("raster")
+
+  r <- raster::raster(raster::extent(0, 10, 0, 10), resolution = 1, vals = 1)
+  r <- raster::writeRaster(r, filename = file.path(tmpdir, "dir1.grd"), overwrite = TRUE)
+
+  newDir <- checkPath(file.path(tmpdir, "elsewhere"), create = TRUE)
+  r2 <- updateFilenameSlots(r, newFilenames = newDir)
+
+  ## A single existing directory means "keep the basename, change the folder".
+  expect_identical(basename(Filenames(r2, allowMultiple = FALSE)), "dir1.grd")
+  expect_identical(dirname(Filenames(r2, allowMultiple = FALSE)), normPath(newDir))
+})
+
+test_that("updateFilenameSlots.list handles a list of RasterLayers", {
+  skip_if_not_installed("raster")
+  testInit("raster")
+
+  mk <- function(nm) {
+    rr <- raster::raster(raster::extent(0, 10, 0, 10), resolution = 1, vals = 1)
+    raster::writeRaster(rr, filename = file.path(tmpdir, nm), overwrite = TRUE)
+  }
+  rl <- list(mk("l1.grd"), mk("l2.grd"))
+
+  newf <- c(file.path(tmpdir, "n1.grd"), file.path(tmpdir, "n2.grd"))
+  out <- updateFilenameSlots(rl, newFilenames = newf)
+
+  ## The list method routes through raster::stack()/unstack(), so the result
+  ## comes back as a list of the same length, one filename updated per element.
+  expect_type(out, "list")
+  expect_length(out, 2L)
+  expect_true(all(vapply(out, inherits, logical(1), "RasterLayer")))
+})
+
+test_that("updateFilenameSlots.environment maps over the environment", {
+  skip_if_not_installed("raster")
+  testInit("raster")
+
+  r <- raster::raster(raster::extent(0, 10, 0, 10), resolution = 1, vals = 1)
+  r <- raster::writeRaster(r, filename = file.path(tmpdir, "e1.grd"), overwrite = TRUE)
+
+  ee <- new.env()
+  ee$r1 <- r
+
+  out <- updateFilenameSlots(ee, newFilenames = file.path(tmpdir, "eNew.grd"))
+
+  ## The environment method lapply()s and therefore returns a list, not an
+  ## environment -- asserted so a change in that shape is caught.
+  expect_type(out, "list")
+  expect_length(out, 1L)
+})


### PR DESCRIPTION
`R/exportedMethods.R` is at 67.4% with 145 uncovered lines. It holds the S3 methods `Cache()` dispatches on — preparing an object for storage (`.wrap`/`.unwrap`), repointing a file-backed object at new files (`updateFilenameSlots`), and memoising.

Several had **zero** coverage:

| method | lines |
|---|---|
| `.wrap.environment` | 11 |
| `updateFilenameSlots.list` | 8 |
| `.unwrap.environment` | 7 |
| `updateFilenameSlots.environment` | 4 |
| `makeMemoisable.data.table` | 1 |
| `unmakeMemoisable` / `.default` | 2 |

The raster-specific ones build a small dummy `RasterLayer` rather than depending on a fixture, and skip when `raster` (Suggests) is absent.

## What the assertions pin down

Behaviour a caller would actually notice, not the implementation:

- an environment round-trips through `.wrap`/`.unwrap` with contents intact — what `Cache()` relies on when caching and restoring one;
- **`.wrap.environment` with `outputObjects` mutates the caller's environment in place** (`rm(list = ..., envir = obj)`), it does not work on a copy. Surprising enough to be worth a test;
- `makeMemoisable.data.table` returns an independent copy, so later modify-by-reference edits to the original don't leak into the memoised value — the entire reason the method exists;
- `updateFilenameSlots` edits the recorded filename **without moving any file**, and treats a single existing directory as "keep the basename, change the folder";
- omitting `newFilenames` errors rather than silently no-op'ing;
- the list and environment methods return a list — the shapes their callers depend on.

25 assertions, no new dependencies, no network.

## One CI detail

Uses `resolution =` rather than `res =`. The suite sets `warnPartialMatchArgs = TRUE` and R-CMD-check runs with `error-on: "warning"`, so a partial argument match would fail the check rather than just warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g
