### PR TITLE
fix(prepInputs): meaningful error when `fun` cannot be resolved

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-08-20
-Version: 3.1.1.9096
+Date: 2026-08-21
+Version: 3.1.1.9097
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/messages.R
+++ b/R/messages.R
@@ -13,6 +13,20 @@
 .message$stopNeedArchive <- function(archive)
   paste0("Please install.packages('archive') to extract files from \n", archive)
 
+## `fun` may be a function, a quoted call, a symbol, or the name of a function as
+## a string (optionally "pkg::name"). Each form resolves through a different
+## lookup, and each lookup failing on its own reports only what it happened to
+## hit -- "object 'hello' not found", "there is no package called 'nopkg'", or,
+## for an unresolvable symbol, "use of NULL environment is defunct". None name
+## the argument at fault, which is unhelpful for the mistake that actually
+## produces them: passing a *filename* as `fun`.
+.message$stopFunNotResolvedTxt <-
+  "`fun` should be a valid function, the name of that function, or a quoted call"
+
+.message$stopFunNotResolved <- function(fun)
+  paste0(.message$stopFunNotResolvedTxt, "; could not resolve '",
+         paste(format(fun), collapse = " "), "'")
+
 .message$Greps <- list(
   studyArea_Spatial = "The \\'studyArea\\' provided is not a Spatial\\* object.",
   rasterToMatch_Raster = "The \\'rasterToMatch\\' provided is not a Raster\\* object.",

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1212,6 +1212,10 @@ pp_finalize <- function(ctx) {
       possFun <- get0(fun, envir = envir)
       if (is.null(possFun)) {
         env <- .whereInStack(fun)
+        ## .whereInStack returns NULL when the symbol is nowhere on the stack;
+        ## get(envir = NULL) would report the environment, not the argument.
+        if (is.null(env))
+          stop(.message$stopFunNotResolved(fun), call. = FALSE)
         fun <- get(fun, envir = env)
       }
     }
@@ -1223,11 +1227,15 @@ pp_finalize <- function(ctx) {
         if (!is.function(fun)) {
           if (any(grepl("::", fun))) {
             fun2 <- strsplit(fun, "::")[[1]]
-            pkg <- fun2[1]
-            fun <- fun2[2]
-            fun <- getFromNamespace(fun, pkg)
+            ## `fun` itself is left alone so the error can quote what the
+            ## caller actually passed, not just the half after "::".
+            fun <- tryCatch(
+              getFromNamespace(fun2[2], fun2[1]),
+              error = function(e) stop(.message$stopFunNotResolved(fun), call. = FALSE))
           } else {
-            fun <- get(fun, envir)
+            fun <- tryCatch(
+              get(fun, envir),
+              error = function(e) stop(.message$stopFunNotResolved(fun), call. = FALSE))
           }
         }
       }

--- a/tests/testthat/test-argValidation.R
+++ b/tests/testthat/test-argValidation.R
@@ -148,3 +148,48 @@ test_that(".file.move deprecation names the real replacement", {
   expect_false(file.exists(from))
   expect_identical(readLines(to, warn = FALSE), "payload")
 })
+
+test_that(".extractFunction names the offending argument when `fun` cannot be resolved", {
+  testInit()
+
+  ## `fun` is the loader for the target file, so it must be a function, the name
+  ## of one, or a quoted call -- NOT a filename, which is the mistake that
+  ## actually lands here. Each accepted form resolves through a different
+  ## lookup, and each used to surface that lookup's own internal complaint
+  ## ("object 'hello' not found", "there is no package called 'nopkg'", or for a
+  ## symbol "use of NULL environment is defunct"), none of which say which
+  ## argument was wrong.
+  ## Matched against the .message entry rather than a copy of the string, so a
+  ## reword updates the code and the test together (R/messages.R).
+  msg <- .message$stopFunNotResolvedTxt
+
+  ## Plain string naming nothing.
+  expect_error(.extractFunction("hello"), msg, fixed = TRUE)
+  ## The full string is quoted back, so the caller can see what was passed.
+  expect_error(.extractFunction("hello"), "hello", fixed = TRUE)
+
+  ## "pkg::name": missing package, and present package but missing object.
+  expect_error(.extractFunction("nopkg::nofun"), msg, fixed = TRUE)
+  expect_error(.extractFunction("stats::nofun"), msg, fixed = TRUE)
+  ## Quoted whole, not just the half after "::".
+  expect_error(.extractFunction("nopkg::nofun"), "nopkg::nofun", fixed = TRUE)
+
+  ## An unresolvable symbol: .whereInStack() finds nothing and returns NULL.
+  expect_error(.extractFunction(quote(hello), envir = new.env()), msg, fixed = TRUE)
+})
+
+test_that(".extractFunction still resolves every valid form of `fun`", {
+  testInit()
+
+  ## The guard must not have narrowed what is accepted.
+  expect_true(is.function(.extractFunction("readRDS")))
+  expect_true(is.function(.extractFunction("base::readRDS")))
+  expect_true(is.function(.extractFunction(readRDS)))
+
+  ## A quoted call is passed through untouched -- it is evaluated later, not now.
+  expect_true(is.call(.extractFunction(quote(readRDS(x)))))
+
+  ## NA means "do not load"; NULL means "nothing supplied". Neither is a lookup.
+  expect_true(is.na(.extractFunction(NA)))
+  expect_null(.extractFunction(NULL))
+})


### PR DESCRIPTION
## What

`fun` in `prepInputs()`/`preProcess()` is the loader for the target file: a
function, the name of one, or a quoted call. Passing a **filename** instead is
an easy mistake, and every way of getting it wrong reported only whatever the
failing lookup happened to hit:

| passed as `fun` | before |
|---|---|
| `"hello"` | `object 'hello' not found` |
| `"nopkg::nofun"` | `there is no package called 'nopkg'` |
| `"stats::nofun"` | `object 'nofun' not found` |
| `quote(hello)` | `use of NULL environment is defunct` |

None name the argument at fault. The last is the worst: `.whereInStack()`
returns `NULL` when the symbol is nowhere on the stack, so `get(envir = NULL)`
complains about the *environment* rather than about `fun`.

All four now report:

```
`fun` should be a valid function, the name of that function, or a quoted call; could not resolve 'hello'
```

## Notes

- Message lives in `.message` (`R/messages.R`) per that file's own stated
  convention, following the existing `.message$stopNeedArchive` idiom. Split
  into a `Txt` constant plus a generator following the established
  `changingFormatTxt`/`changingFormat` pattern, so the invariant half is
  matchable on its own — which is how the tests match it, per
  `test-cacheHelpers.R`.
- In the `"::"` branch `fun` is no longer overwritten with the half after
  `"::"`, so the error can quote what the caller actually passed. That also
  made the `pkg`/`fun2[2]` temporaries unnecessary.
- `call. = FALSE` because two of the three sites raise from inside a `tryCatch`
  handler, where the call prefix would name the handler frame, not the caller.

## Behaviour unchanged

Every valid form still resolves — function, `"name"`, `"pkg::name"`, quoted
call, `NA`, `NULL` — verified end-to-end through `prepInputs()`.

Local `prepInputs`/`preProcess`/`postProcess` suites: 0 failures.

Tests added to `test-argValidation.R` (both the four failure modes and the
valid forms, so the guard cannot silently narrow what is accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g