### PR TITLE
Remove live browser() calls and dead debugging sentinel

### DIFF
--- a/R/GPT2.R
+++ b/R/GPT2.R
@@ -2181,7 +2181,11 @@ cacheChainingStep <- function(keyFull, callList, .cacheChaining, cacheChainDetai
             cidToCheck <- names(lll2)[hasAll]
             # cidToCheck <- lll$cacheId2[hasAll]
             if (NROW(cidToCheck) > 1) {
-              browser() # these are now wrong -- should be unnecessary -- there should not ever be >1 of these; so don't need to !keep
+              stop(
+                "Internal error: cache chaining resolved more than one candidate ",
+                "cacheId (", paste(cidToCheck, collapse = ", "), "). Please report ",
+                "this at https://github.com/PredictiveEcology/reproducible/issues"
+              )
             }
             if (NROW(cidToCheck)) {
               if (!keyFull$key %in% cidToCheck) { # no override needed
@@ -2236,7 +2240,10 @@ dealWithCacheRecoveryErrors <- function(memoiseFail, outputTestIntegrity, fns, c
       hardLinkOrCopy(fnsInCache, fns, overwrite = TRUE, verbose = FALSE)
       fnsExistAfter <- file.exists(fns)
       if (any(fnsExistAfter %in% FALSE) && isTRUE(any(fnsExistBefore != fnsExistAfter))) # this means that hardLinkOrCopy failed
-        browser()
+        stop(
+          "Failed to restore file-backed cache object(s) from the cache: ",
+          paste(fns[fnsExistAfter %in% FALSE], collapse = ", ")
+        )
     }
   }
   memoiseFail

--- a/R/cache.R
+++ b/R/cache.R
@@ -1442,7 +1442,11 @@ searchInRepos <- function(cachePaths, outputHash, drv, conn, verbose = getOption
             unlink(csf)
             dtFile <- NULL
           } else if (length(fe) > 1) { # has both the qs2 and rds dbFile
-            browser()
+            stop(
+              "Internal error: found both a qs2 and rds cache database file for ",
+              outputHash, " in ", repo, ". Please report this at ",
+              "https://github.com/PredictiveEcology/reproducible/issues"
+            )
           }
         }
 

--- a/R/checksums.R
+++ b/R/checksums.R
@@ -427,7 +427,6 @@ setMethod(
         # BUT don't use `try` for all/any digests as it is too slow to run all/any time
         fss2 <- try(eval(evalThis), silent = TRUE)
         if (is(fss2, "try-error")) {
-          browser()
           fss2 <- character(length(file))
           file <- file[nonZeroSize]
           fss2[nonZeroSize] <- eval(evalThis)

--- a/R/convertPaths.R
+++ b/R/convertPaths.R
@@ -110,7 +110,6 @@ setMethod(
       }
     } else if (inherits(obj, "RasterLayer")) {
       fns <- raster::filename(obj)
-      if (exists("._Filenames_1")) browser()
       if (length(fns) == 0 || all(nchar(fns) == 0)) {
         fns <- NULL
       }

--- a/R/exportedMethods.R
+++ b/R/exportedMethods.R
@@ -69,7 +69,10 @@ absoluteBase <- function(relToWhere, cachePath = getOption("reproducible.cachePa
     } else {
       ab <- try(possRelPaths[[1]])
     }
-    if (is(ab, "try-error")) browser()
+    if (is(ab, "try-error")) {
+      stop("Could not resolve a relative path from cachePath = ", cachePath,
+           " (relToWhere = ", relToWhere, "): ", attr(ab, "condition")$message)
+    }
   }
 
   ab

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1754,7 +1754,10 @@ linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
           toMess <- c(head(toCollapsed[!result], 24), "... (omitting many)", tail(toCollapsed[!result], 24))
         }
         result2 <- try(file.copy(from[!result], to[!result], overwrite = overwrite))
-        if (is(result2, "try-error")) browser()
+        if (is(result2, "try-error")) {
+          stop("Failed to copy file(s) to destination: ",
+               attr(result2, "condition")$message)
+        }
 
         toMessCollapsed <- paste(toMess, collapse = "\n")
         fromMessCollapsed <- paste(fromMess, collapse = "\n")

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1652,7 +1652,10 @@ process <- function(out, funCaptured,
         ## Don't cache the reading of a raster
         ## -- normal reading of raster on disk is fast b/c only reads metadata
         outProcess <- try(do.call(theFun, append(list(asPath(out$targetFilePath)), args)))
-        if (is(outProcess, "try-error")) browser()
+        if (is(outProcess, "try-error")) {
+          stop("Failed to read ", out$targetFilePath, " with the supplied function: ",
+               attr(outProcess, "condition")$message)
+        }
       } else {
         if (identical(theFun, base::load)) {
           if (is.null(args$envir)) {


### PR DESCRIPTION
## Summary

Eight `browser()` calls were reachable in production (non-test) code, plus one
leftover debugging sentinel. In a non-interactive session (`R CMD check`, CRAN's
check farm, or a user's batch job) a `browser()` either hangs waiting on stdin
or errors obscurely when its branch executes. This also violates CRAN policy
against `browser()` in shipped code, so it is a blocker for the upcoming
resubmission.

This PR removes all eight and replaces them with appropriate handling. No
behavior change on the happy path; the only observable difference is that
previously-debugger-trapped states now raise informative errors.

## Changes (+26/-8 across 7 files)

- **Error-path `try-error` traps** now `stop()` with the captured condition
  message instead of dropping into the debugger:
  - `R/exportedMethods.R` (`absoluteBase`, relative-path resolution)
  - `R/prepInputs.R` (reading a target file with the supplied function)
  - `R/preProcess.R` (`linkOrCopy`, `file.copy` failure)
- **`R/checksums.R`** drops the `browser()` but keeps its existing fallback path.
- **"Cannot happen" invariants** now `stop()` with an internal-error message
  pointing at the issue tracker:
  - `R/cache.R` (both a qs2 and rds cache DB file present)
  - `R/GPT2.R` (cache chaining resolving >1 candidate cacheId; failed
    file-backed cache recovery)
- **`R/convertPaths.R`** removes the `exists("._Filenames_1")` debugging sentinel.

## Verification

- `grep -rn "browser()" R/` shows no remaining live calls (only commented-out ones).
- Edited files parse cleanly.

`R CMD check --as-cran` has not yet been run on this branch.


🤖 Generated with Posit Assistant (Claude Opus 4.8)
