### PR TITLE
test: cover local-archive shortcut, link fallback, geodata outage, savePreDigest (78.41 -> 79.00)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9103
+Version: 3.1.1.9104
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9102
+Version: 3.1.1.9103
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9100
+Version: 3.1.1.9101
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9101
+Version: 3.1.1.9102
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/tests/testthat/test-downloadLocalArchive.R
+++ b/tests/testthat/test-downloadLocalArchive.R
@@ -1,0 +1,116 @@
+## Coverage for downloadFile()'s "we already have the archive" shortcut
+## (R/download.R, inside `if (missingNeededFiles)` -> `if (!is.null(archive))`).
+##
+## The point of that block is to NOT hit the network: when a local copy of the
+## archive is on disk and holds everything asked for, the download is skipped
+## and the files come out of the local archive instead. Every test here passes a
+## deliberately unresolvable url, so if the shortcut stopped working these would
+## fail by attempting a real download rather than silently passing. `.invalid`
+## is IANA-reserved, so it cannot resolve even behind wildcard DNS.
+##
+## NOTE ON ENTRY POINT: these drive the exported downloadFile() directly rather
+## than prepInputs(). Going through prepInputs does NOT reach this block --
+## preProcess runs pp_resolve_needed_files() (which extracts from a local
+## archive via .tryExtractFromArchive) a full phase before pp_download(), so by
+## the time downloadFile() is called nothing is missing and the shortcut is
+## skipped. Verified by tracing .listFilesInArchive: 0 calls via prepInputs,
+## 2 via downloadFile(). downloadFile() is exported, so this is public API.
+##
+## No network, no Drive.
+
+## A two-file zip; returns its path.
+mkZip <- function(dir, files = c("a.txt", "b.txt")) {
+  checkPath(dir, create = TRUE)
+  owd <- setwd(dir); on.exit(setwd(owd), add = TRUE)
+  for (f in files) writeLines(f, f)
+  suppressWarnings(utils::zip("t.zip", files, flags = "-q"))
+  normalizePath(file.path(dir, "t.zip"))
+}
+
+## dest holding a valid CHECKSUMS.txt for `files`, but not the files themselves
+## -- i.e. "we have been here before, the payload is gone, the archive remains".
+seedChecksums <- function(dest, srcDir, files) {
+  checkPath(dest, create = TRUE)
+  file.copy(file.path(srcDir, files), dest)
+  Checksums(path = dest, write = TRUE,
+            files = file.path(dest, files), verbose = 0)
+  unlink(file.path(dest, files))
+}
+
+badUrl <- "https://example.invalid/does-not-exist.zip"
+
+test_that("downloadFile extracts from a local archive instead of downloading", {
+  testInit()
+
+  src <- file.path(tmpdir, "src")
+  arch <- mkZip(src)
+  dest <- file.path(tmpdir, "dest")
+  seedChecksums(dest, src, c("a.txt", "b.txt"))
+  needed <- file.path(dest, c("a.txt", "b.txt"))
+
+  out <- downloadFile(
+    archive = arch, targetFile = "a.txt", neededFiles = needed,
+    destinationPath = dest, quick = FALSE,
+    checksumFile = file.path(dest, "CHECKSUMS.txt"),
+    checkSums = Checksums(path = dest, write = FALSE, files = needed, verbose = 0),
+    url = badUrl, needChecksums = 0, preDigest = NULL,
+    .tempPath = tempdir2(rndstr(1, 6))
+  )
+
+  ## No download was attempted -- an unresolvable url would have errored.
+  expect_type(out, "list")
+  ## The files came out of the local archive.
+  expect_true(all(file.exists(needed)))
+  expect_identical(readLines(needed[1], warn = FALSE), "a.txt")
+  ## The success path narrows `archive` to the copies that existed locally.
+  expect_identical(basename(unlist(out$archive)), "t.zip")
+})
+
+test_that("downloadFile reports the archive it used and leaves checksums intact", {
+  testInit()
+
+  src <- file.path(tmpdir, "src2")
+  arch <- mkZip(src)
+  dest <- file.path(tmpdir, "dest2")
+  seedChecksums(dest, src, c("a.txt", "b.txt"))
+  needed <- file.path(dest, c("a.txt", "b.txt"))
+
+  out <- downloadFile(
+    archive = arch, targetFile = "a.txt", neededFiles = needed,
+    destinationPath = dest, quick = FALSE,
+    checksumFile = file.path(dest, "CHECKSUMS.txt"),
+    checkSums = Checksums(path = dest, write = FALSE, files = needed, verbose = 0),
+    url = badUrl, needChecksums = 0, preDigest = NULL,
+    .tempPath = tempdir2(rndstr(1, 6))
+  )
+
+  ## The returned contract other preProcess phases rely on.
+  expect_true(all(c("needChecksums", "archive", "neededFiles",
+                    "downloaded", "checkSums") %in% names(out)))
+  ## CHECKSUMS.txt survives -- it is what made the shortcut usable.
+  expect_true(file.exists(file.path(dest, "CHECKSUMS.txt")))
+})
+
+test_that("downloadFile falls through to the url when the archive lacks the files", {
+  testInit()
+
+  ## haveAll is FALSE: the archive exists but does not contain what was asked
+  ## for, so the shortcut must NOT be taken. It has to fall through and try the
+  ## url, which fails because the url is unresolvable -- that error IS the
+  ## assertion, proving it did not wrongly satisfy the request from the archive.
+  src <- file.path(tmpdir, "src3")
+  arch <- mkZip(src)
+  dest <- checkPath(file.path(tmpdir, "dest3"), create = TRUE)
+  needed <- file.path(dest, "not-in-there.txt")
+
+  expect_error(
+    suppressWarnings(suppressMessages(downloadFile(
+      archive = arch, targetFile = "not-in-there.txt", neededFiles = needed,
+      destinationPath = dest, quick = FALSE,
+      checksumFile = file.path(dest, "CHECKSUMS.txt"),
+      checkSums = .emptyChecksumsResult,
+      url = badUrl, needChecksums = 1, preDigest = NULL,
+      .tempPath = tempdir2(rndstr(1, 6))
+    )))
+  )
+})

--- a/tests/testthat/test-googleInterstitial.R
+++ b/tests/testthat/test-googleInterstitial.R
@@ -1,0 +1,100 @@
+## Coverage for the Google Drive "confirm download" interstitial handling in
+## R/download.R: .looksLikeGoogleInterstitial() and .parseGoogleConfirm().
+##
+## When a public Drive file is too big for a virus scan, Drive serves an HTML
+## confirmation page INSTEAD of the file, with HTTP 200. Nothing errors -- the
+## download "succeeds" and writes a small HTML file where a dataset was
+## expected. These two functions are what notice that and re-issue the request
+## with the form's parameters, so their failure mode is silent corruption of a
+## downloaded input.
+##
+## Both are pure functions over a local file, so this needs no network and no
+## Drive credentials, and runs on CRAN.
+
+## A stand-in for Drive's interstitial page.
+interstitialHtml <- paste0(
+  '<!DOCTYPE html><html><head><title>Google Drive - Virus scan warning</title>',
+  '</head><body><form id="download-form" action="https://drive.usercontent.google.com/download">',
+  '<input type="hidden" name="id" value="ABC123">',
+  '<input type="hidden" name="export" value="download">',
+  '<input type="hidden" name="confirm" value="t">',
+  '<input type="hidden" name="uuid" value="dead-beef">',
+  '</form></body></html>')
+
+test_that(".looksLikeGoogleInterstitial spots an HTML page served instead of a file", {
+  testInit()
+
+  f <- file.path(tmpdir, "page.html")
+  writeLines(interstitialHtml, f)
+  expect_true(.looksLikeGoogleInterstitial(f))
+
+  ## Needs BOTH signals: html-ish AND a Drive marker. Ordinary HTML is not an
+  ## interstitial -- a caller may legitimately be downloading an HTML file.
+  plain <- file.path(tmpdir, "plain.html")
+  writeLines("<html><body>an ordinary page</body></html>", plain)
+  expect_false(.looksLikeGoogleInterstitial(plain))
+})
+
+test_that(".looksLikeGoogleInterstitial is FALSE for real payloads and missing files", {
+  testInit()
+
+  ## A real (binary) download must never be mistaken for the interstitial.
+  z <- file.path(tmpdir, "real.zip")
+  owd <- setwd(tmpdir); writeLines("payload", "p.txt")
+  suppressWarnings(utils::zip(z, "p.txt", flags = "-q")); setwd(owd)
+  expect_false(.looksLikeGoogleInterstitial(z))
+
+  ## Absent and empty files are "not an interstitial", not an error: this is
+  ## called on whatever the download left behind, including nothing.
+  expect_false(.looksLikeGoogleInterstitial(file.path(tmpdir, "nope.bin")))
+  empty <- file.path(tmpdir, "empty.bin"); file.create(empty)
+  expect_false(.looksLikeGoogleInterstitial(empty))
+})
+
+test_that(".looksLikeGoogleInterstitial handles non-UTF-8 bytes without erroring", {
+  testInit()
+
+  ## The check reads raw bytes precisely so a binary payload cannot trip
+  ## locale translation inside grepl(). Bytes that are invalid UTF-8 are the
+  ## case that used to be able to error rather than return FALSE.
+  f <- file.path(tmpdir, "binary.bin")
+  writeBin(as.raw(c(0xff, 0xfe, 0x00, 0x01, 0x80, 0x90, 0xa0)), f)
+  expect_false(.looksLikeGoogleInterstitial(f))
+})
+
+test_that(".parseGoogleConfirm extracts the form parameters", {
+  testInit()
+
+  f <- file.path(tmpdir, "page.html")
+  writeLines(interstitialHtml, f)
+
+  params <- .parseGoogleConfirm(f)
+
+  ## These are exactly what gets pasted into the retry URL, so both names and
+  ## values matter.
+  expect_type(params, "list")
+  expect_identical(params$id, "ABC123")
+  expect_identical(params$confirm, "t")
+  expect_identical(params$uuid, "dead-beef")
+  expect_true(all(c("id", "export", "confirm", "uuid") %in% names(params)))
+})
+
+test_that(".parseGoogleConfirm returns empty for pages with no usable inputs", {
+  testInit()
+
+  ## No <input> at all -> nothing to retry with; the caller checks
+  ## length(params) before building a second URL.
+  none <- file.path(tmpdir, "none.html")
+  writeLines("<html><body>no form here</body></html>", none)
+  expect_length(.parseGoogleConfirm(none), 0)
+
+  ## Inputs missing a name or a value are skipped rather than producing
+  ## malformed query parameters.
+  partial <- file.path(tmpdir, "partial.html")
+  writeLines(paste0('<html><input type="hidden" value="novalue">',
+                    '<input type="hidden" name="">',
+                    '<input type="hidden" name="ok" value="yes"></html>'), partial)
+  p <- .parseGoogleConfirm(partial)
+  expect_identical(names(p), "ok")
+  expect_identical(p$ok, "yes")
+})

--- a/tests/testthat/test-linkOrCopy.R
+++ b/tests/testthat/test-linkOrCopy.R
@@ -89,3 +89,65 @@ test_that("linkOrCopy handles several files at once", {
   expect_identical(readLines(tos[1], warn = FALSE), "payload1")
   expect_identical(readLines(tos[2], warn = FALSE), "payload2")
 })
+
+test_that("linkOrCopy falls back to copying when hard-linking fails", {
+  testInit()
+
+  ## The fallback normally only fires across filesystems, which a test cannot
+  ## arrange portably. Mocking file.link to fail reaches it deterministically --
+  ## and that IS the real-world case: a destination on another mount.
+  src <- file.path(tmpdir, "src.txt")
+  writeLines("payload", src)
+  to <- file.path(tmpdir, "copied.txt")
+
+  suppressMessages(
+    testthat::with_mocked_bindings(
+      linkOrCopy(src, to, symlink = FALSE, verbose = 0),
+      file.link = function(...) FALSE, .package = "base")
+  )
+
+  ## What a caller depends on: the bytes arrive regardless of the mechanism.
+  expect_true(file.exists(to))
+  expect_identical(readLines(to, warn = FALSE), "payload")
+})
+
+test_that("linkOrCopy copies every file when hard-linking fails for a vector", {
+  testInit()
+
+  ## The fallback path indexes with `from[!result]`, so a partial/whole vector
+  ## failure must still deliver all of them -- an off-by-one here would silently
+  ## drop inputs.
+  srcs <- file.path(tmpdir, c("m1.txt", "m2.txt", "m3.txt"))
+  for (i in seq_along(srcs)) writeLines(paste0("payload", i), srcs[i])
+  tos <- file.path(tmpdir, "multi", c("m1.txt", "m2.txt", "m3.txt"))
+
+  suppressMessages(
+    testthat::with_mocked_bindings(
+      linkOrCopy(srcs, tos, symlink = FALSE, verbose = 0),
+      file.link = function(...) FALSE, .package = "base")
+  )
+
+  expect_true(all(file.exists(tos)))
+  expect_identical(readLines(tos[3], warn = FALSE), "payload3")
+})
+
+test_that("linkOrCopy tries a symlink before copying on unix", {
+  skip_on_os("windows")
+  testInit()
+
+  ## With symlink = TRUE and hard-linking unavailable, the symlink branch runs
+  ## before the copy fallback. Either outcome delivers the content; that is what
+  ## is asserted, not which mechanism won.
+  src <- file.path(tmpdir, "src.txt")
+  writeLines("payload", src)
+  to <- file.path(tmpdir, "linked.txt")
+
+  suppressMessages(
+    testthat::with_mocked_bindings(
+      linkOrCopy(src, to, symlink = TRUE, verbose = 0),
+      file.link = function(...) FALSE, .package = "base")
+  )
+
+  expect_true(file.exists(to))
+  expect_identical(readLines(to, warn = FALSE), "payload")
+})

--- a/tests/testthat/test-savePreDigestAndSidecar.R
+++ b/tests/testthat/test-savePreDigestAndSidecar.R
@@ -1,0 +1,75 @@
+## Two option/state-gated paths that nothing else reaches.
+##
+## 1. Cache(reproducible.savePreDigest = TRUE) writes a SECOND cache entry, the
+##    "preDigest", alongside the real one. It is a debugging aid for working out
+##    why a cacheId changed, and the whole block is skipped unless the option is
+##    on -- so it is invisible to every other test.
+##
+## 2. preProcess's checksum phase can skip re-verifying a file when a remote
+##    hash sidecar (`.<file>_<url>.hash`) says it was already verified. That
+##    branch builds a synthetic "OK" checksum row rather than re-hashing, and is
+##    only reachable when such a sidecar exists on disk.
+##
+## No network, no Drive.
+
+test_that("savePreDigest writes a second, preDigest-prefixed cache entry", {
+  testInit()
+
+  withr::local_options(reproducible.savePreDigest = TRUE,
+                       reproducible.showCachePreWarm = FALSE,
+                       reproducible.ask = FALSE)
+  cp <- checkPath(file.path(tmpdir, "cache"), create = TRUE)
+  fn <- function(a, b = 1) a + b
+
+  out <- Cache(fn, a = 1, cachePath = cp, verbose = 0)
+
+  ## The option must not change the answer -- it only adds a debugging artifact.
+  expect_identical(as.numeric(out), 2)
+
+  ## Two entries now: the result, and its preDigest twin.
+  expect_identical(length(unique(showCache(cp, verbose = -2)$cacheId)), 2L)
+  ## The twin is name-prefixed so it is distinguishable on disk.
+  expect_true(any(grepl("preDigest_", dir(cp, recursive = TRUE))))
+})
+
+test_that("savePreDigest works on the DBI backend too", {
+  skip_if_not_installed("RSQLite")
+  testInit()
+
+  withr::local_options(reproducible.useDBI = TRUE,
+                       reproducible.savePreDigest = TRUE,
+                       reproducible.showCachePreWarm = FALSE,
+                       reproducible.ask = FALSE)
+  skip_if_not(useDBI())
+  cp <- checkPath(file.path(tmpdir, "cacheDBI"), create = TRUE)
+  fn <- function(a, b = 1) a + b
+
+  out <- Cache(fn, a = 1, cachePath = cp, verbose = 0)
+
+  expect_identical(as.numeric(out), 2)
+  expect_identical(length(unique(showCache(cp, verbose = -2)$cacheId)), 2L)
+})
+
+test_that("a remote-hash sidecar pre-verifies a file instead of re-checksumming", {
+  testInit()
+
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  target <- file.path(dest, "a.txt")
+  writeLines("payload", target)
+
+  ## Written with the package's own helper so the naming convention cannot
+  ## drift from what .findRemoteHashSidecars() looks for.
+  url <- "https://example.com/some/path/a.txt"
+  hashFile <- makeRemoteHashFile(url = url, destinationPath = dest,
+                                 targetFile = "a.txt", remoteHash = "deadbeef",
+                                 algorithm = "sha1", write = TRUE)
+  expect_true(file.exists(hashFile))
+
+  ## With the sidecar present and the file on disk, preProcess takes the
+  ## pre-verified path: a synthetic "OK" row, no re-hashing, no download.
+  out <- prepInputs(targetFile = "a.txt", destinationPath = dest,
+                    fun = NA, verbose = -1)
+
+  expect_identical(basename(as.character(out)), "a.txt")
+  expect_identical(readLines(as.character(out), warn = FALSE), "payload")
+})

--- a/tests/testthat/test-tileGridOffline.R
+++ b/tests/testthat/test-tileGridOffline.R
@@ -1,0 +1,48 @@
+## Coverage for makeTileGridFromGADMcode()'s server-outage fallback
+## (R/downloadTileAndUpload.R).
+##
+## The tile grid is normally derived from a GADM boundary fetched by
+## geodata::gadm(). When that returns nothing -- "most likely geodata server is
+## down", per the comment -- the code substitutes a hardcoded extent so tiling
+## still works. That fallback had no test, and it is exactly the path that runs
+## when a build breaks in the field.
+##
+## Mocking gadm() to return NULL reaches it deterministically AND keeps this
+## test free of the multi-megabyte GADM download that the real path performs on
+## every cold cache.
+##
+## No network, no Drive.
+
+test_that("makeTileGridFromGADMcode falls back to a fixed extent when gadm returns NULL", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("geodata")
+  testInit("terra")
+
+  out <- testthat::with_mocked_bindings(
+    makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
+    gadm = function(...) NULL, .package = "geodata")
+
+  ## The contract callers rely on: a usable grid, not an error.
+  expect_type(out, "list")
+  expect_true(all(c("tileGrid", "numTiles", "area") %in% names(out)))
+  expect_s4_class(out$tileGrid, "SpatVector")
+
+  ## numTiles is honoured, so the grid actually has the requested shape.
+  expect_identical(out$numTiles, c(2, 2))
+  expect_equal(nrow(out$tileGrid), 4)
+})
+
+test_that("makeTileGridFromGADMcode fallback also handles the 'NULL' string", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("geodata")
+  testInit("terra")
+
+  ## Cache() can hand back the literal string "NULL" rather than NULL, which is
+  ## why the guard tests for both. Same fallback either way.
+  out <- testthat::with_mocked_bindings(
+    makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
+    gadm = function(...) "NULL", .package = "geodata")
+
+  expect_s4_class(out$tileGrid, "SpatVector")
+  expect_equal(nrow(out$tileGrid), 4)
+})


### PR DESCRIPTION
Test-only. No `R/` changes.

Coverage: **78.41% → 79.00%** (+61 lines, measured with covr, not estimated).

## What is covered, and why each was unreachable before

**`downloadFile()`'s local-archive shortcut** (`test-downloadLocalArchive.R`)
Skips the network entirely when a local copy of the archive already holds every
needed file. Driven through the **exported `downloadFile()`**, not `prepInputs()`
— going through `prepInputs` never reaches it, because `pp_resolve_needed_files()`
extracts from a local archive a full phase before `pp_download()`, so nothing is
missing by the time `downloadFile()` runs. Verified by tracing
`.listFilesInArchive`: 0 calls via `prepInputs`, 2 via `downloadFile()`. The file
header records this so the tests are not later "simplified" back to `prepInputs`,
which would silently stop covering the block while still passing.

**`linkOrCopy()`'s copy fallback** (`test-linkOrCopy.R`)
Fires when hard-linking fails — in practice, a destination on another
filesystem, which a test cannot arrange portably. `file.link` is mocked to fail.
Includes the vector case, since the fallback indexes with `from[!result]` and an
off-by-one there would silently drop inputs rather than error.

**`makeTileGridFromGADMcode()`'s outage fallback** (`test-tileGridOffline.R`)
When `geodata::gadm()` returns nothing ("most likely geodata server is down"),
a fixed extent is substituted so tiling still works. Mocking `gadm()` reaches it
*and* avoids the multi-megabyte GADM download the real path performs on every
cold cache. Covers both `NULL` and the literal `"NULL"` string, since `Cache()`
can return either — which is why the guard tests for both.

**`savePreDigest` and remote-hash sidecars** (`test-savePreDigestAndSidecar.R`)
Both gated on state nothing else in the suite sets. `savePreDigest` makes
`Cache()` write a second "preDigest" entry (asserted on both backends, and
asserted *not* to change the returned value). The sidecar path lets preProcess
skip re-hashing a file, building a synthetic `"OK"` row instead; the sidecar is
written with the package's own `makeRemoteHashFile()` so the test cannot drift
from what `.findRemoteHashSidecars()` searches for.

**`.looksLikeGoogleInterstitial` / `.parseGoogleConfirm`** (`test-googleInterstitial.R`)
These add **no coverage** — both were already 100% covered. Kept as regression
tests for a silent-corruption path: when a public Drive file is too large to
virus-scan, Drive returns an HTML page with HTTP 200 *instead of the file*, so
nothing errors and a dataset is quietly replaced by markup.

## Notes

- No network and no Drive credentials anywhere; all of it runs on CRAN.
- Not fixed, reported only: `R/preProcess.R:1758` has a leftover
  `if (is(result2, "try-error")) browser()` in `linkOrCopy`'s fallback. Inert
  non-interactively, but it does not belong in shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g