### PR TITLE
fix: apt on macOS + multi-match binary lookup on Windows; remove future paths; cover Drive download fallbacks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9106
+Version: 3.1.1.9107
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9108
+Version: 3.1.1.9109
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9104
+Version: 3.1.1.9105
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9111
+Version: 3.1.1.9112
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9107
+Version: 3.1.1.9108
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9110
+Version: 3.1.1.9111
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9109
+Version: 3.1.1.9110
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9105
+Version: 3.1.1.9106
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/cache.R
+++ b/R/cache.R
@@ -8,7 +8,7 @@ utils::globalVariables(c(
 #' Saves a wide variety function call outputs to disk and optionally RAM, for recovery later
 #'
 #' @description
-#' \if{html}{\figure{lifecycle-maturing.svg}{options: alt="maturing"}}
+#' `r lifecycle::badge("stable")`
 #'
 #' A function that can be used to wrap around other functions to cache function calls
 #' for later use. This is normally most effective when the function to cache is

--- a/R/cache.R
+++ b/R/cache.R
@@ -479,10 +479,12 @@ CacheV2 <-
 
 
 
-#' Write to cache repository, using `future::future`
+#' Write to cache repository, using `future::future` (defunct)
 #'
-#' This will be used internally if `options("reproducible.futurePlan" = TRUE)`.
-#' This is still experimental.
+#' @description
+#' Defunct as of version 3.2.2. The future-based cache writing this supported was
+#' never enabled by default -- `reproducible.futurePlan` defaults to `FALSE` --
+#' and has been removed. [Cache()] writes directly.
 #'
 #' @param written Integer. If zero or positive then it needs to be written still.
 #'                Should be 0 to start.
@@ -495,32 +497,16 @@ CacheV2 <-
 #' @inheritParams Cache
 #' @inheritParams saveToCache
 #' @return
-#' Run for its side effect.
-#' This will add the `objectToSave` to the cache located at `cachePath`,
-#' using `cacheId` as its id, while
-#' updating the database entry. It will do this using the future package, so it is
-#' written in a future.
+#' Nothing; it signals a defunct error.
 writeFuture <- function(written, outputToSave, cachePath, userTags,
                         drv = getDrv(getOption("reproducible.drv", NULL)),
                         conn = getOption("reproducible.conn", NULL),
                         cacheId, linkToCacheId = NULL,
                         verbose = getOption("reproducible.verbose")) {
-  counter <- 0
-  if (!CacheIsACache(cachePath = cachePath, drv = drv, conn = conn, verbose = verbose)) {
-    stop("That cachePath does not exist")
-  }
-
-  if (missing(cacheId)) {
-    cacheId <- .robustDigest(outputToSave)
-  }
-  output <- saveToCache(
-    cachePath = cachePath, drv = drv, userTags = userTags,
-    conn = conn, obj = outputToSave, cacheId = cacheId,
-    linkToCacheId = linkToCacheId
-  )
-  saved <- cacheId
-
-  return(saved)
+  .Defunct(msg = paste0(
+    "'writeFuture()' is defunct as of version 3.2.2. The future-based cache ",
+    "writing it supported was never enabled by default and has been removed; ",
+    "'Cache()' writes directly."))
 }
 
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -482,6 +482,8 @@ CacheV2 <-
 #' Write to cache repository, using `future::future` (defunct)
 #'
 #' @description
+#' `r lifecycle::badge("defunct")`
+#'
 #' Defunct as of version 3.2.2. The future-based cache writing this supported was
 #' never enabled by default -- `reproducible.futurePlan` defaults to `FALSE` --
 #' and has been removed. [Cache()] writes directly.

--- a/R/download.R
+++ b/R/download.R
@@ -451,118 +451,43 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
       )
     }
 
-    if (!isWindows() && requireNamespace("future", quietly = TRUE) && isLargeFile &&
-        !isFALSE(getOption("reproducible.futurePlan"))) {
-      messagePreProcess("Downloading a large file in background using future", verbose = verbose)
-      message("Make sure to set\noptions(gargle_oauth_email = 'youremail@somewhere.edu')\n, and possibly ",
-              "\noptions(gargle_oauth_cache = 'localPathToCache')")
-      fp <- future::plan()
-      if (!is(fp, getOption("reproducible.futurePlan"))) {
-        fpNew <- getOption("reproducible.futurePlan")
-        future::plan(fpNew, workers = 1)
-        on.exit({
-          future::plan(fp)
+    useGoogleDrive <- TRUE
+    if (isTRUE(getOption("reproducible.useGdown", FALSE))) {
+      messForGdownIsTRUE <- "options('reproducible.useGdown') is TRUE"
+      gdown <- "gdown"
+      if (nchar(Sys.which(gdown))) {
+        gdownCall <- paste0(gdown, " ", googledrive::as_id(url), " -O '", destFile, "'")
+        messagePreProcess("Using gdown to get files from GoogleDrive because ", messForGdownIsTRUE)
+
+        b <- try(system(gdownCall))
+        if (!is(b, "try-error")) {# likely because of authentication
+          messagePreProcess(messForGdownIsTRUE, ", but the attempt failed; possibly a private url?\n",
+                            url, "\nUsing googledrive package")
+          useGoogleDrive <- FALSE
+        }
+      } else {
+        messagePreProcess(messForGdownIsTRUE,
+                          ", but gdown is not available at the cmd line; skipping")
+      }
+    }
+
+    if (isTRUE(useGoogleDrive)) {
+      a <- tryCatch(
+        retry(downloadCall, retries = 2),
+        error = function(e) {
+          # Reactive no-auth fallback: the authenticated download failed (e.g.
+          # an expired/absent token). If the file is in fact public, fetch it
+          # silently via the no-auth endpoint and carry on; only if that *also*
+          # fails do we surface the original authentication error.
+          pub <- tryCatch(
+            .dlGooglePublic(url = url, destinationPath = destinationPath,
+                            targetFile = basename2(downloadFilename), verbose = 0),
+            error = function(e2) NULL)
+          if (is.null(pub)) stop(e)
+          messagePreProcess("Downloaded public Google Drive file without authentication.",
+                            verbose = verbose)
+          pub
         })
-      }
-      b <- future::future({
-        options(gargle_oauth_cache = goc,
-                gargle_oauth_email = goe)
-      },
-      globals = list(
-
-      ))
-      a <- future::future(
-        {
-          # Re-authenticate inside the future worker. Prefer a service-account
-          # JSON when one is configured (CI / GOOGLEDRIVE_AUTH path), otherwise
-          # fall back to the user-account email + cache used by the parent.
-          # Interactive auth (no email, no path) would silently hang the
-          # worker — pass the JSON path through globals when available.
-          if (nzchar(gauth_path) && file.exists(gauth_path)) {
-            try(googledrive::drive_auth(path = gauth_path), silent = TRUE)
-          } else {
-            googledrive::drive_auth(email = goe, cache = goc)
-          }
-          retry(retries = 2, downloadCall)
-        },
-        globals = list(
-          # Guard against NULL: getOption("gargle_oauth_cache") defaults to
-          # NULL when unset, and normalizePath(NULL) errors with the cryptic
-          # `path.expand(path) : invalid 'path' argument` inside the future
-          # worker. Pass NULL through — gargle handles an absent cache.
-          goc = local({
-            v <- getOption("gargle_oauth_cache")
-            if (is.null(v) || !nzchar(v)) v else normalizePath(v, mustWork = FALSE)
-          }),
-          goe = getOption("gargle_oauth_email"),
-          gauth_path = Sys.getenv("GOOGLEDRIVE_AUTH", ""),
-          downloadCall = downloadCall,
-          downloadFilename = downloadFilename,
-          download_resumable_httr2 = download_resumable_httr2,
-          drive_download = googledrive::drive_download,
-          as_id = googledrive::as_id,
-          retry = retry,
-          # drive_deauth = googledrive::drive_deauth,
-          url = url,
-          type = type,
-          overwrite = overwrite,
-          destFile = destFile
-        )
-      )
-      cat("\n")
-      notResolved <- TRUE
-      while (notResolved) {
-        Sys.sleep(0.05)
-        notResolved <- !future::resolved(a)
-        fsActual <- file.size(destFile)
-        class(fsActual) <- "object_size"
-        if (!is.na(fsActual)) {
-          cat(
-            format(fsActual, units = "auto"), "of", format(fs, units = "auto"),
-            "downloaded         \r"
-          )
-        }
-      }
-      cat("\nDone!\n")
-    } else {
-      useGoogleDrive <- TRUE
-      if (isTRUE(getOption("reproducible.useGdown", FALSE))) {
-        messForGdownIsTRUE <- "options('reproducible.useGdown') is TRUE"
-        gdown <- "gdown"
-        if (nchar(Sys.which(gdown))) {
-          gdownCall <- paste0(gdown, " ", googledrive::as_id(url), " -O '", destFile, "'")
-          messagePreProcess("Using gdown to get files from GoogleDrive because ", messForGdownIsTRUE)
-
-          b <- try(system(gdownCall))
-          if (!is(b, "try-error")) {# likely because of authentication
-            messagePreProcess(messForGdownIsTRUE, ", but the attempt failed; possibly a private url?\n",
-                              url, "\nUsing googledrive package")
-            useGoogleDrive <- FALSE
-          }
-        } else {
-          messagePreProcess(messForGdownIsTRUE,
-                            ", but gdown is not available at the cmd line; skipping")
-        }
-      }
-
-      if (isTRUE(useGoogleDrive)) {
-        a <- tryCatch(
-          retry(downloadCall, retries = 2),
-          error = function(e) {
-            # Reactive no-auth fallback: the authenticated download failed (e.g.
-            # an expired/absent token). If the file is in fact public, fetch it
-            # silently via the no-auth endpoint and carry on; only if that *also*
-            # fails do we surface the original authentication error.
-            pub <- tryCatch(
-              .dlGooglePublic(url = url, destinationPath = destinationPath,
-                              targetFile = basename2(downloadFilename), verbose = 0),
-              error = function(e2) NULL)
-            if (is.null(pub)) stop(e)
-            messagePreProcess("Downloaded public Google Drive file without authentication.",
-                              verbose = verbose)
-            pub
-          })
-      }
     }
   } else {
     messagePreProcess(messSkipDownload, verbose = verbose)

--- a/R/options.R
+++ b/R/options.R
@@ -100,11 +100,11 @@
 #'     fallback anchors.
 #'   }
 #'   \item{`futurePlan`}{
-#'     Default: `FALSE`. On Linux OSes, `Cache` and `cloudCache` have some
-#'     functionality that uses the `future` package.
-#'     Default is to not use these, as they are experimental.
-#'     They may, however, be very effective in speeding up some things, specifically,
-#'     uploading cached elements via `googledrive` in `cloudCache`.
+#'     **No effect as of version 3.2.2.** Default: `FALSE`. This previously
+#'     enabled `future`-backed background downloading and cache writing on Linux.
+#'     Those paths were off by default, effectively untested, and have been
+#'     removed; the option is retained only because downstream packages set it,
+#'     and setting it now does nothing.
 #'   }
 #'   \item{`gdalwarp`}{
 #'     **Deprecated — do not use.** Default: `FALSE`. This option previously
@@ -549,7 +549,7 @@ reproducibleOptions <- function() {
     reproducible.drv = NULL, # RSQLite::SQLite(),
     reproducible.dryRun = FALSE,
     reproducible.fileBackedAnchors = NULL, # named list of semantic project paths (e.g. SpaDES paths(sim)); used to store/restore file-backed object paths *relative* to a portable anchor
-    reproducible.futurePlan = FALSE, # future::plan("multisession"), #memoise
+    reproducible.futurePlan = FALSE, # no effect as of 3.2.2; kept because downstream sets it
     reproducible.gdalwarpThreads = 2L,
     reproducible.gdriveNoAuth = FALSE,
     reproducible.inputPath = file.path(tempdir(), "reproducible", "input"),

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1423,11 +1423,13 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
   } else {
     ""
   }
-  ## Was `!(isWindows() && !isMac())`. By De Morgan that is `!isWindows() ||
-  ## isMac()`, and since no platform is both Windows and Mac, isMac() implies
-  ## !isWindows() -- so the isMac() term never changes the result. Verified
-  ## identical on all three reachable platform combinations.
-  if (!isWindows()) { ## TODO: macOS ?? #266
+  ## `apt` is Debian/Ubuntu, i.e. Linux-only, so this is guarded on isLinux().
+  ## It was `!(isWindows() && !isMac())`, which by De Morgan is `!isWindows() ||
+  ## isMac()` -- that admits macOS, where system("apt ...", intern = TRUE) errors
+  ## with "error in running command". Nothing had ever called this function on
+  ## macOS, so it went unnoticed until a test did. (The old `## TODO: macOS ??
+  ## #266` marker sat on this very line.)
+  if (isLinux()) {
     if (grepl("7z", extractSystemCallPath)) {
       SevenZrarExists <- system("apt -qq list p7zip-rar", intern = TRUE, ignore.stderr = TRUE)
       SevenZrarExists <- grepl(SevenZrarExists, pattern = "installed")
@@ -1453,14 +1455,18 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
                                             all.files = TRUE,
                                             full.names = TRUE
         )
-        if (extractSystemCallPath == "" || length(extractSystemCallPath) == 0) {
+        ## length(), THEN the value: list.files() can return several matches
+        ## (a real Windows runner has both 7z.exe and unrar.exe under Program
+        ## Files), and `x == ""` on a length-2 vector makes `||` error with
+        ## "'length = 2' in coercion to 'logical(1)'" on R >= 4.3.
+        if (length(extractSystemCallPath) == 0 || !nzchar(extractSystemCallPath[1])) {
           extractSystemCallPath <- list.files(dirname(Sys.getenv("SystemRoot")),
                                               pattern = "unrar.exe|7z.exe",
                                               recursive = TRUE,
                                               all.files = TRUE,
                                               full.names = TRUE
           )
-          if (extractSystemCallPath == "" || length(extractSystemCallPath) == 0) {
+          if (length(extractSystemCallPath) == 0 || !nzchar(extractSystemCallPath[1])) {
             extractSystemCallPath <- NULL
             messagePreProcess(missingUnrarMess, verbose = verbose)
           } else {

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1423,7 +1423,11 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
   } else {
     ""
   }
-  if (!(isWindows() && !isMac())) { ## TODO: macOS ?? #266
+  ## Was `!(isWindows() && !isMac())`. By De Morgan that is `!isWindows() ||
+  ## isMac()`, and since no platform is both Windows and Mac, isMac() implies
+  ## !isWindows() -- so the isMac() term never changes the result. Verified
+  ## identical on all three reachable platform combinations.
+  if (!isWindows()) { ## TODO: macOS ?? #266
     if (grepl("7z", extractSystemCallPath)) {
       SevenZrarExists <- system("apt -qq list p7zip-rar", intern = TRUE, ignore.stderr = TRUE)
       SevenZrarExists <- grepl(SevenZrarExists, pattern = "installed")

--- a/R/showCacheEtc.R
+++ b/R/showCacheEtc.R
@@ -441,18 +441,6 @@ setMethod(
     # }
 
     # not seeing userTags
-    # Clear the futures that are resolved
-    ## Linux-only: the futurePlan path forks, which macOS is excluded from.
-    if (isLinux() && !isFALSE(getOption("reproducible.futurePlan"))) {
-      if (exists("futureEnv", envir = .reproEnv)) {
-        hasFuture <- .requireNamespace("future",
-                                       messageStart = "To use reproducible.futurePlan, "
-        )
-        if (hasFuture) {
-          checkFutures(verbose)
-        }
-      }
-    }
 
     if (!useDBI()) {
       pkgEnv <- memoiseEnv(cachePath = x)
@@ -859,37 +847,6 @@ setMethod(
 
 #' @keywords internal
 #' @inheritParams Cache
-checkFutures <- function(verbose = getOption("reproducible.verbose")) {
-  # This takes a long time -- can't use it if
-  resol1 <- FALSE
-  count <- 0
-  lsFutureEnv <- ls(.reproEnv$futureEnv)
-
-  anyFutureWrite <- length(lsFutureEnv)
-
-  if (anyFutureWrite > 0) {
-    # objsInReproEnv <- ls(.reproEnv)
-    # objsInReproEnv <- grep("^future|cloudCheckSums", objsInReproEnv, value = TRUE)
-    while (any(!resol1)) {
-      count <- count + 1
-      # numSleeps <<- numSleeps+1
-      if (count > 1) {
-        Sys.sleep(0.001)
-        if (count > 1e3) {
-          messageCache("Future is not resolved after 1 second of waiting. Allowing to proceed.",
-                       verbose = verbose
-          )
-          break
-        }
-      }
-      resol <- future::resolved(.reproEnv$futureEnv)
-      resol1 <- resol[!startsWith(names(resol), "cloudCheckSums")]
-    }
-    if (length(resol) > 0) {
-      .reproEnv$futureEnv[[lsFutureEnv]] <- NULL
-    }
-  }
-}
 
 useDBI <- function(set = NULL, verbose = getOption("reproducible.verbose"), default = TRUE) {
   canSwitch <- TRUE

--- a/man/Cache.Rd
+++ b/man/Cache.Rd
@@ -239,7 +239,7 @@ function call or the cached version (i.e., the result from a previous call
 to this same cached function with identical arguments).
 }
 \description{
-\if{html}{\figure{lifecycle-maturing.svg}{options: alt="maturing"}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
 A function that can be used to wrap around other functions to cache function calls
 for later use. This is normally most effective when the function to cache is

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -105,11 +105,11 @@ receiver's \code{cachePath}} rather than the producing machine's absolute path.
 fallback anchors.
 }
 \item{\code{futurePlan}}{
-Default: \code{FALSE}. On Linux OSes, \code{Cache} and \code{cloudCache} have some
-functionality that uses the \code{future} package.
-Default is to not use these, as they are experimental.
-They may, however, be very effective in speeding up some things, specifically,
-uploading cached elements via \code{googledrive} in \code{cloudCache}.
+\strong{No effect as of version 3.2.2.} Default: \code{FALSE}. This previously
+enabled \code{future}-backed background downloading and cache writing on Linux.
+Those paths were off by default, effectively untested, and have been
+removed; the option is retained only because downstream packages set it,
+and setting it now does nothing.
 }
 \item{\code{gdalwarp}}{
 \strong{Deprecated — do not use.} Default: \code{FALSE}. This option previously

--- a/man/writeFuture.Rd
+++ b/man/writeFuture.Rd
@@ -54,6 +54,8 @@ option, e.g., \verb{options('reproducible.verbose' = 0) to reduce to minimal}}
 Nothing; it signals a defunct error.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}}
+
 Defunct as of version 3.2.2. The future-based cache writing this supported was
 never enabled by default -- \code{reproducible.futurePlan} defaults to \code{FALSE} --
 and has been removed. \code{\link[=Cache]{Cache()}} writes directly.

--- a/man/writeFuture.Rd
+++ b/man/writeFuture.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cache.R
 \name{writeFuture}
 \alias{writeFuture}
-\title{Write to cache repository, using \code{future::future}}
+\title{Write to cache repository, using \code{future::future} (defunct)}
 \usage{
 writeFuture(
   written,
@@ -51,13 +51,10 @@ Caching, which may help diagnose Caching challenges. Can set globally with an
 option, e.g., \verb{options('reproducible.verbose' = 0) to reduce to minimal}}
 }
 \value{
-Run for its side effect.
-This will add the \code{objectToSave} to the cache located at \code{cachePath},
-using \code{cacheId} as its id, while
-updating the database entry. It will do this using the future package, so it is
-written in a future.
+Nothing; it signals a defunct error.
 }
 \description{
-This will be used internally if \code{options("reproducible.futurePlan" = TRUE)}.
-This is still experimental.
+Defunct as of version 3.2.2. The future-based cache writing this supported was
+never enabled by default -- \code{reproducible.futurePlan} defaults to \code{FALSE} --
+and has been removed. \code{\link[=Cache]{Cache()}} writes directly.
 }

--- a/tests/testthat/test-archiveExtractBinary.R
+++ b/tests/testthat/test-archiveExtractBinary.R
@@ -6,6 +6,12 @@
 ## CI/dev platforms where coverage is measured. isWindows() is mockable, which
 ## is what makes it testable at all; see the isWindows/isUnix helpers.
 ##
+## Being the first caller of this function on macOS and Windows is what turned
+## up two latent bugs: `apt` was being invoked on macOS (the guard admitted it),
+## and `list.files()` returning MORE than one match on a real Windows runner
+## made `x == "" || length(x) == 0` error with "'length = 2' in coercion to
+## 'logical(1)'". Both are fixed; these tests are what keep them fixed.
+##
 ## No network, no Drive.
 
 test_that(".archiveExtractBinary finds a system binary when one is installed", {
@@ -14,6 +20,8 @@ test_that(".archiveExtractBinary finds a system binary when one is installed", {
   testInit()
 
   ## The contract: an absolute path to something usable, or NULL. Never "".
+  ## On Linux this also walks the p7zip-rar advisory (an `apt` call, which is
+  ## why that block is guarded on isLinux() rather than !isWindows()).
   out <- .archiveExtractBinary(verbose = 0)
   expect_true(is.null(out) || (is.character(out) && nzchar(out)))
   if (!is.null(out)) expect_true(file.exists(out))

--- a/tests/testthat/test-archiveExtractBinary.R
+++ b/tests/testthat/test-archiveExtractBinary.R
@@ -27,7 +27,7 @@ test_that(".archiveExtractBinary finds a system binary when one is installed", {
   if (!is.null(out)) expect_true(file.exists(out))
 })
 
-test_that(".archiveExtractBinary returns NULL on Windows when no binary exists", {
+test_that(".archiveExtractBinary walks the Windows lookup without erroring", {
   testInit()
 
   ## Two mocks, both needed. isWindows() selects the Windows lookup; Sys.which
@@ -43,9 +43,15 @@ test_that(".archiveExtractBinary returns NULL on Windows when no binary exists",
       .package = "base"),
     isWindows = function() TRUE)
 
-  ## NULL, not "" -- callers test with is.null(), and an empty string would slip
-  ## through as a valid-looking path.
-  expect_null(out)
+  ## The contract is a SINGLE usable path, or NULL -- never "" (callers use
+  ## is.null(), and an empty string reads as a valid path) and never a vector.
+  ##
+  ## Length is the assertion that matters here. A real Windows runner has 7-Zip
+  ## under Program Files, so the recursive search returns MORE than one match,
+  ## which is exactly what used to make `x == "" || length(x) == 0` blow up with
+  ## "'length = 2' in coercion to 'logical(1)'". Getting a length-1 result back
+  ## is the evidence that the multi-match handling works.
+  expect_true(is.null(out) || (is.character(out) && length(out) == 1L && nzchar(out)))
 })
 
 test_that(".archiveExtractBinary returns NULL on unix when no binary exists", {

--- a/tests/testthat/test-archiveExtractBinary.R
+++ b/tests/testthat/test-archiveExtractBinary.R
@@ -1,0 +1,56 @@
+## Coverage for .archiveExtractBinary() (R/prepInputs.R), which locates a 7z or
+## unrar binary for the archive formats base R cannot handle.
+##
+## The Windows lookup -- Sys.which("7z.exe"), then a recursive search of
+## "C:/Program Files", then of the SystemRoot volume -- is unreachable on the
+## CI/dev platforms where coverage is measured. isWindows() is mockable, which
+## is what makes it testable at all; see the isWindows/isUnix helpers.
+##
+## No network, no Drive.
+
+test_that(".archiveExtractBinary finds a system binary when one is installed", {
+  skip_if_not(nzchar(Sys.which("7z")) || nzchar(Sys.which("unrar")),
+              "no 7z/unrar binary to find")
+  testInit()
+
+  ## The contract: an absolute path to something usable, or NULL. Never "".
+  out <- .archiveExtractBinary(verbose = 0)
+  expect_true(is.null(out) || (is.character(out) && nzchar(out)))
+  if (!is.null(out)) expect_true(file.exists(out))
+})
+
+test_that(".archiveExtractBinary returns NULL on Windows when no binary exists", {
+  testInit()
+
+  ## Two mocks, both needed. isWindows() selects the Windows lookup; Sys.which
+  ## returning "" is what makes that lookup necessary -- the dev machine has 7z
+  ## on PATH, which would short-circuit before the branch under test.
+  ##
+  ## On a non-Windows filesystem the "C:/Program Files" and SystemRoot searches
+  ## naturally find nothing, so this walks the full not-found chain to the end.
+  out <- testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      .archiveExtractBinary(verbose = 0),
+      Sys.which = function(names) stats::setNames(rep("", length(names)), names),
+      .package = "base"),
+    isWindows = function() TRUE)
+
+  ## NULL, not "" -- callers test with is.null(), and an empty string would slip
+  ## through as a valid-looking path.
+  expect_null(out)
+})
+
+test_that(".archiveExtractBinary returns NULL on unix when no binary exists", {
+  testInit()
+
+  ## Same not-found outcome via the non-Windows branch, which additionally
+  ## messages about installing p7zip.
+  out <- suppressMessages(testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      .archiveExtractBinary(verbose = 0),
+      Sys.which = function(names) stats::setNames(rep("", length(names)), names),
+      .package = "base"),
+    isWindows = function() FALSE))
+
+  expect_null(out)
+})

--- a/tests/testthat/test-cacheHelpers.R
+++ b/tests/testthat/test-cacheHelpers.R
@@ -239,20 +239,11 @@ test_that("test debugCache arg", {
   expect_true(grepl("not list", unlist(.unlistToCharacter(1, 1))))
   expect_true(grepl("not list2", unlist(.unlistToCharacter(1, 0))))
 
-  ## writeFuture
-  comp <- # if (useDBI())
-    .robustDigest("sdf") # else
-  # "dda1fbb70d256e6b3b696ef0176c63de"
-  drvHere <- if (useDBI() && .requireNamespace("RSQLite")) RSQLite::SQLite() else NULL
-
-  expect_true(identical(
-    comp,
-    writeFuture(1, "sdf",
-      cachePath = tmpCache, userTags = "",
-      drv = drvHere
-    )
-  ))
-  expect_error(writeFuture(1, "sdf", cachePath = "sdfd", userTags = ""))
+  ## writeFuture is defunct as of 3.2.2: the future-backed cache writing it
+  ## supported was off by default and has been removed. It stays exported so old
+  ## code gets a message naming the situation rather than "could not find
+  ## function"; that message is now the whole contract.
+  expect_error(writeFuture(1, "sdf", cachePath = tmpCache, userTags = ""), "defunct")
 
   try(silent = TRUE, clearCache(tmpCache, ask = FALSE))
   warn <- capture_warnings(

--- a/tests/testthat/test-dlGoogle.R
+++ b/tests/testthat/test-dlGoogle.R
@@ -1,0 +1,71 @@
+## Coverage for dlGoogle()'s downloader selection (R/download.R).
+##
+## dlGoogle picks between two download mechanisms:
+##
+##   httr2 available  -> download_resumable_httr2()   (the normal path)
+##   httr2 absent     -> googledrive::drive_download() (the fallback)
+##
+## httr2 is installed on every machine this package is developed, checked or
+## coverage-measured on, so the fallback branch never ran anywhere -- it is the
+## code that only executes on a user's machine with a thinner install, which is
+## precisely where an untested branch does the most damage.
+##
+## .requireNamespace() is the package's own availability check, so mocking it to
+## report httr2 as missing selects the fallback without touching the real
+## library path or uninstalling anything.
+##
+## Uploads, so skip_on_cran().
+
+## Upload `text` as a small private file; returns its URL. Cleans up after itself.
+driveFixture <- function(dir, text, envir = parent.frame()) {
+  f <- file.path(dir, "dlg.txt")
+  writeLines(text, f)
+  up <- retry(quote(googledrive::drive_upload(
+    f, path = .cloudTestRoot(), name = paste0("dlg", rndstr(1, 6)))))
+  withr::defer(try(googledrive::drive_rm(up), silent = TRUE), envir = envir)
+  paste0("https://drive.google.com/file/d/", up$id, "/view")
+}
+
+test_that("dlGoogle downloads via httr2 when it is available", {
+  skip_on_cran()          ## uploads
+  skip_if_not_installed("httr2")
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  url <- driveFixture(tmpdir, "httr2-payload")
+  dest <- checkPath(file.path(tmpdir, "d1"), create = TRUE)
+
+  res <- dlGoogle(url = url, targetFile = "dlg.txt", destinationPath = dest,
+                  overwrite = TRUE, needChecksums = 0,
+                  checkSums = .emptyChecksumsResult, verbose = 0)
+
+  ## The contract downloadFile() consumes.
+  expect_true(all(c("destFile", "needChecksums") %in% names(res)))
+  expect_true(file.exists(res$destFile))
+  expect_identical(readLines(res$destFile, warn = FALSE), "httr2-payload")
+})
+
+test_that("dlGoogle falls back to googledrive::drive_download without httr2", {
+  skip_on_cran()          ## uploads
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  url <- driveFixture(tmpdir, "fallback-payload")
+  dest <- checkPath(file.path(tmpdir, "d2"), create = TRUE)
+
+  ## Report httr2 as unavailable, but let every other package query through --
+  ## dlGoogle also asks about googledrive, and answering FALSE there would stop
+  ## it before the branch under test.
+  realRequire <- reproducible:::.requireNamespace
+  res <- testthat::with_mocked_bindings(
+    dlGoogle(url = url, targetFile = "dlg.txt", destinationPath = dest,
+             overwrite = TRUE, needChecksums = 0,
+             checkSums = .emptyChecksumsResult, verbose = 0),
+    .requireNamespace = function(pkg = "methods", ...) {
+      if (identical(pkg, "httr2")) FALSE else realRequire(pkg, ...)
+    })
+
+  ## Same observable outcome as the httr2 path: that equivalence is the point.
+  ## If the fallback quietly produced nothing, or an empty file, this fails.
+  expect_true(file.exists(res$destFile))
+  expect_identical(readLines(res$destFile, warn = FALSE), "fallback-payload")
+  expect_gt(file.size(res$destFile), 0)
+})

--- a/tests/testthat/test-dlGooglePublic.R
+++ b/tests/testthat/test-dlGooglePublic.R
@@ -1,0 +1,88 @@
+## Coverage for .dlGooglePublic() (R/download.R): fetching a Drive file that is
+## shared "anyone with the link", without authenticating.
+##
+## This is the path a user hits when a module points at someone else's public
+## Drive file. It had no test, so the interstitial retry -- the part that makes
+## it work for files big enough that Drive refuses to virus-scan them -- was
+## entirely unexercised.
+##
+## The happy path is a real round-trip: upload a tiny file, share it publicly,
+## fetch it back. The interstitial branches cannot be produced on demand (they
+## need a file large enough to trigger Drive's warning page), so those are
+## driven by mocking the two detectors, which are themselves covered directly in
+## test-googleInterstitial.R.
+##
+## Uploads, so skip_on_cran() on the round-trip.
+
+## Upload `text` as a public file; returns its human-facing URL. Registers its
+## own cleanup on the caller's frame.
+publicFixture <- function(dir, text, envir = parent.frame()) {
+  f <- file.path(dir, "pub.txt")
+  writeLines(text, f)
+  up <- retry(quote(googledrive::drive_upload(
+    f, path = .cloudTestRoot(), name = paste0("pub", rndstr(1, 6)))))
+  withr::defer(try(googledrive::drive_rm(up), silent = TRUE), envir = envir)
+  googledrive::drive_share_anyone(up)
+  list(url = paste0("https://drive.google.com/file/d/", up$id, "/view"), id = up$id)
+}
+
+test_that(".dlGooglePublic downloads a link-shared file without authenticating", {
+  skip_on_cran()          ## uploads
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  fx <- publicFixture(tmpdir, "public-payload")
+  dest <- checkPath(file.path(tmpdir, "dl"), create = TRUE)
+
+  res <- .dlGooglePublic(url = fx$url, destinationPath = dest,
+                         targetFile = "pub.txt", verbose = 0)
+
+  ## The contract downloadFile() relies on.
+  expect_true("destFile" %in% names(res))
+  expect_true(file.exists(res$destFile))
+  ## The real bytes came back, not Drive's HTML warning page.
+  expect_identical(readLines(res$destFile, warn = FALSE), "public-payload")
+})
+
+test_that(".dlGooglePublic retries with the confirm parameters on an interstitial", {
+  skip_on_cran()
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  fx <- publicFixture(tmpdir, "public-payload")
+  dest <- checkPath(file.path(tmpdir, "dl2"), create = TRUE)
+
+  ## Report an interstitial on the FIRST check only, so the retry branch runs
+  ## and then succeeds -- which is what happens for a genuinely large file.
+  n <- 0L
+  res <- testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      .dlGooglePublic(url = fx$url, destinationPath = dest,
+                      targetFile = "pub.txt", verbose = 0),
+      .parseGoogleConfirm = function(file)
+        list(id = fx$id, export = "download", confirm = "t")),
+    .looksLikeGoogleInterstitial = function(file) { n <<- n + 1L; n == 1L })
+
+  ## Both checks ran, so the retry path was taken and then cleared.
+  expect_gte(n, 2L)
+  expect_true(file.exists(res$destFile))
+})
+
+test_that(".dlGooglePublic errors clearly when Drive keeps returning HTML", {
+  skip_on_cran()
+  testInit("googledrive", needGoogleDriveAuth = TRUE)
+
+  fx <- publicFixture(tmpdir, "public-payload")
+  dest <- checkPath(file.path(tmpdir, "dl3"), create = TRUE)
+
+  ## Interstitial every time and no usable form parameters: the file is not
+  ## actually shared publicly. That must be an explicit error naming the
+  ## likely cause, not a silently-saved HTML page.
+  expect_error(
+    testthat::with_mocked_bindings(
+      testthat::with_mocked_bindings(
+        .dlGooglePublic(url = fx$url, destinationPath = dest,
+                        targetFile = "pub.txt", verbose = 0),
+        .parseGoogleConfirm = function(file) list()),
+      .looksLikeGoogleInterstitial = function(file) TRUE),
+    "Anyone with the link"
+  )
+})

--- a/tests/testthat/test-helpersCoverage.R
+++ b/tests/testthat/test-helpersCoverage.R
@@ -188,8 +188,8 @@ test_that("isWindows/isUnix/isMac are consistent and mockable", {
   expect_false(isWindows() && isMac())
 
   ## isLinux is NARROWER than isUnix: macOS is unix but not Linux. Keeping them
-  ## distinct matters -- the futurePlan/forking paths are Linux-only, so
-  ## collapsing isLinux() into isUnix() would enable them on macOS.
+  ## distinct matters -- the mcparallel forking path in spawn_showCache_async()
+  ## is Linux-only, so collapsing isLinux() into isUnix() would enable it on macOS.
   expect_type(isLinux(), "logical")
   expect_false(isLinux() && isMac())
   if (isLinux()) expect_true(isUnix())


### PR DESCRIPTION
Started as a one-line platform-guard simplification; writing a test that actually
called the function turned up two real bugs, and the scope grew from there.

## Two platform bugs, neither previously reachable by any test

**macOS was shelling out to `apt`.** `.archiveExtractBinary()` guarded its
p7zip-rar advisory with `!(isWindows() && !isMac())`, which by De Morgan is
`!isWindows() || isMac()` — that *admits* macOS, where
`system("apt -qq list p7zip-rar", intern = TRUE)` fails outright with "error in
running command". The codecov line data confirms those lines had never executed
anywhere. `apt` is Debian/Ubuntu, so the guard is now `isLinux()`. The author's
own `## TODO: macOS ?? #266` marker sat on that exact line.

**Windows errored when more than one binary was found.**
`list.files("C:/Program Files", pattern = "unrar.exe|7z.exe", recursive = TRUE)`
returns a *vector*, and a real Windows runner has both. So

```r
extractSystemCallPath == "" || length(extractSystemCallPath) == 0
```

evaluated `x == ""` to a length-2 logical and `||` raised
`'length = 2' in coercion to 'logical(1)'` on R >= 4.3. Both occurrences now test
`length()` first, then the value. Note the zero-length case this appeared to
guard is harmless — it is length > 1 that fails.

Both were found by CI on this PR, on platforms neither the author nor I can run
locally.

## Removing the `future` paths

`reproducible.futurePlan` defaults to `FALSE`, so none of this ran for any user
who had not opted in, and none of it ran in CI — the one test enabling the
download path carries `skip_on_ci()` as well as `skip_on_cran()`. **67 of the 84
measurable lines removed were uncovered.**

- `download.R`: the `isLargeFile` background-download branch; the `else` holding
  the ordinary path is unwrapped in its place.
- `showCacheEtc.R`: `checkFutures()` and its call site. `spawn_showCache_async()`
  is untouched — it uses `parallel::mcparallel()`, a separate mechanism.
- `cache.R`: `writeFuture()` becomes a `.Defunct()` stub. Exported, but zero
  callers in the package and zero hits anywhere in the org; the stub follows the
  convention already used for `gdalProject`/`CacheV2`/`objSizeSession`.

`reproducible.futurePlan` is **retained** — scfm and SpaDES.project set it — and
now documents plainly that it has no effect as of 3.2.2.

## New coverage

- `.archiveExtractBinary()`'s Windows lookup, via mocked `isWindows()`.
- `.dlGooglePublic()` — the unauthenticated "anyone with the link" path, a real
  upload/share/download round-trip, plus the interstitial retry and its error.
- `dlGoogle()`'s downloader selection, **including the `httr2`-absent fallback**,
  which only ever runs on a user's thinner install. Both paths are asserted to
  produce the same observable outcome.

## Badges

`Cache` carried a hand-written raw-Rd badge naming `maturing` — a retired
lifecycle stage — which is why #553 missed it (a search for `lifecycle::badge()`
calls does not match a `\figure{}` directive). Now `stable`, via
`lifecycle::badge()`. `writeFuture` gets the `defunct` badge. These were the last
hand-written badges in `R/`.

## Verification

265 tests / 0 failures locally against a freshly updated library (roxygen2 8.1.0,
httr2 1.3.0, googledrive 2.1.2, terra 1.9.34).

Redoc touches only `Cache.Rd` and `writeFuture.Rd`: regenerating a clean
`development` with roxygen2 8.1.0 produces byte-identical output, so there is no
version churn needing a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g