### PR TITLE
fix(cache): changing cacheSaveFormat no longer silently invalidates the whole cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9116
+Version: 3.1.1.9117
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-21
-Version: 3.1.1.9117
+Version: 3.1.1.9118
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,19 @@
 
 ## bug fixes
 
+* Changing `options(reproducible.cacheSaveFormat)` no longer invalidates the
+  cache. On the file-backed backend (`useDBI = FALSE`, the default) every entry
+  was silently recomputed and both the old and new files were left on disk;
+  under DBI the same change migrated correctly. The cause was
+  `onlyStorageFiles()` building its match pattern from `CacheStoredFile()`
+  without a `cachePath`: with `reproducible.cachePath` unset — the normal state
+  when a caller passes `cachePath=` directly to `Cache()` — that returns
+  `character(0)`, so the pattern matched nothing and the changed-format recovery
+  never fired. Only the `!useDBI()` path used that helper, hence the asymmetry.
+  Two further defects on the same path are fixed alongside it: `loadFile()`
+  errored with `object 'fe' not found` when given `format=`, and the
+  format-retry loop gave up after the first candidate instead of trying the
+  rest.
 * `.archiveExtractBinary()` no longer runs `apt` on macOS. The platform guard
   was `!(isWindows() && !isMac())`, which admits macOS, where
   `system("apt ...", intern = TRUE)` fails outright. It is now `isLinux()`,

--- a/R/DBI.R
+++ b/R/DBI.R
@@ -1084,14 +1084,16 @@ movedCache <- function(new, old, drv = getDrv(getOption("reproducible.drv", NULL
 #' @keywords internal
 loadFile <- function(file, cacheId, cachePath, # in case it needs swapCacheFormat
                      drv, conn, verbose = getOption("reproducible.verbose"), ...) {
+  ## `fe` is the format implied by the file's extension, and is compared against
+  ## the format that actually read it further down. It must be defined on BOTH
+  ## branches: previously it was set only in the `else`, so supplying `format=`
+  ## -- the only way to reach the swap-on-mismatch code -- failed with
+  ## "object 'fe' not found".
+  fe <- fileExt(file)
   if (!is.null(list(...)$format))
     cacheSaveFormat <- list(...)$format
-  else {
-    # if (is.null(cacheSaveFormat)) {
-    fe <- fileExt(file)
+  else
     cacheSaveFormat <- fe
-  # }
-  }
   qsFormats <- c(.qsFormat, .qs2Format)
   isQsAny <- cacheSaveFormat %in% qsFormats
   # isQs2 <- cacheSaveFormat %in% .qs2Format
@@ -1131,8 +1133,11 @@ loadFile <- function(file, cacheId, cachePath, # in case it needs swapCacheForma
         }
         break
       } else {
-        # if (csf %in% tail(csfs, 1))
-        stop(obj) # this will be caught by most outer calls to loadFile
+        ## Only give up once every candidate format has been tried. Stopping on
+        ## the first failure made the loop single-shot, so a file readable by a
+        ## later format in `csfs` was reported as unreadable.
+        if (csf %in% tail(csfs, 1))
+          stop(obj) # this will be caught by most outer calls to loadFile
       }
     }
     # obj <- qs2::qs_read(file = file[isQsAny], nthreads = getOption("reproducible.nThreads", 1))
@@ -1222,15 +1227,24 @@ suffixMultipleDBFiles <- function() {
 
 suffixLockFile <- function() ".lock"
 
-onlyStorageFiles <- function(files, cacheId) {
-  # files2 <- grep(gsub("\\.", "\\\\.", paste0(suffixMultipleDBFiles(), "|", suffixLockFile(), "$")),
-  #   files,
-  #   invert = TRUE, value = TRUE
-  # )
-  shouldBeFiles <- unname(sapply(.cacheSaveFormats, function(form)
-    basename(CacheStoredFile(cacheId = cacheId, cacheSaveFormat = form, readOnly = TRUE))))
-  shouldBeFiles <- paste(shouldBeFiles, collapse = "|")
-  grep(shouldBeFiles, files, value = TRUE)
+onlyStorageFiles <- function(files, cacheId, cachePath) {
+  ## `cachePath` is required, and is deliberately NOT defaulted to
+  ## getOption("reproducible.cachePath"): that option is unset whenever the
+  ## caller passes cachePath= straight to Cache(), and CacheStoredFile() then
+  ## returns character(0). The pattern became the literal
+  ## "character(0)|character(0)|character(0)", matched nothing, and
+  ## checkSameCacheId() returned nothing -- so the changed-cacheSaveFormat
+  ## recovery never fired and the entire cache silently re-computed. Requiring
+  ## the argument makes that failure impossible to reintroduce. See
+  ## test-cacheSaveFormatSwitch.R.
+  ##
+  ## CacheStoredFile() is used rather than pasting the names together, so this
+  ## follows automatically if the storage naming convention ever changes.
+  shouldBeFiles <- unname(vapply(.cacheSaveFormats, function(form)
+    basename(CacheStoredFile(cachePath = cachePath, cacheId = cacheId,
+                             cacheSaveFormat = form, readOnly = TRUE)),
+    FUN.VALUE = character(1)))
+  grep(paste(shouldBeFiles, collapse = "|"), files, value = TRUE)
 }
 
 formatCheck <- function(cachePath, cacheId, cacheSaveFormat = getOption("reproducible.cacheSaveFormat")) {
@@ -1433,7 +1447,11 @@ checkSameCacheId <- function(f) {
   sameCacheID <- grep("\\.lock$", dir(dirname(f), pattern = cacheId), invert = TRUE, value = TRUE)
   sameCacheID <- grep(paste0(paste(.cacheSaveFormats, collapse = "|"), "$"), sameCacheID, value = TRUE)
   if (!useDBI() && length(sameCacheID) > 1) {
-    sameCacheID <- onlyStorageFiles(sameCacheID, cacheId)
+    ## dirname(f) is the storage dir (cacheOutputs/), so its parent is the
+    ## cachePath. Derived from `f` rather than from the option, which is unset
+    ## when the caller passed cachePath= directly.
+    sameCacheID <- onlyStorageFiles(sameCacheID, cacheId,
+                                    cachePath = dirname(dirname(f)))
   }
   sameCacheID
 }

--- a/tests/testthat/test-cacheSaveFormatSwitch.R
+++ b/tests/testthat/test-cacheSaveFormatSwitch.R
@@ -1,0 +1,99 @@
+## Changing options(reproducible.cacheSaveFormat) must NOT invalidate the cache.
+##
+## The entry is migrated to the new format (loadFromCacheSwitchFormat ->
+## swapCacheFileFormat) rather than recomputed. This regressed on the file-backed
+## backend and went unnoticed for a telling reason, which shapes these tests:
+##
+##   `reproducible.cachePath` MUST BE UNSET here.
+##
+## onlyStorageFiles() built its match pattern via CacheStoredFile() without a
+## cachePath. With the option SET it resolved fine; with it unset -- the normal
+## state when a caller passes cachePath= straight to Cache() -- CacheStoredFile()
+## returned character(0), the pattern became the literal
+## "character(0)|character(0)|character(0)", and checkSameCacheId() matched
+## nothing. The changed-format recovery then never fired and every entry
+## recomputed. Because testInit() sets reproducible.cachePath, a test written the
+## usual way passes against the broken code and proves nothing.
+##
+## The assertion is on EVALUATION COUNT, not the returned value: the value is
+## correct either way, which is exactly what made the bug silent.
+##
+## No network, no Drive.
+
+## Cache `x + 1` under `from`, then request it under `to`, and report how many
+## times the body actually ran. 1 = cache worked; 2 = silently recomputed.
+runsAcrossFormatSwitch <- function(cachePath, from, to) {
+  runs <- 0L
+  expensive <- function(x) {
+    runs <<- runs + 1L
+    x + 1
+  }
+  withr::local_options(reproducible.cacheSaveFormat = from)
+  first <- Cache(expensive, x = 1, cachePath = cachePath, verbose = 0)
+  withr::local_options(reproducible.cacheSaveFormat = to)
+  second <- Cache(expensive, x = 1, cachePath = cachePath, verbose = 0)
+  list(runs = runs, first = as.numeric(first), second = as.numeric(second))
+}
+
+test_that("changing cacheSaveFormat recovers from cache rather than recomputing", {
+  skip_if_not_installed("qs2")
+  testInit()
+
+  for (useDBI in c(FALSE, TRUE)) {
+    if (useDBI && !requireNamespace("RSQLite", quietly = TRUE)) next
+    for (fmts in list(c("rds", "qs2"), c("qs2", "rds"))) {
+      ## cachePath deliberately unset -- see the file header. This is the
+      ## condition under which the bug appears at all.
+      withr::local_options(reproducible.cachePath = NULL,
+                           reproducible.useDBI = useDBI,
+                           reproducible.showCachePreWarm = FALSE,
+                           reproducible.ask = FALSE)
+      if (useDBI && !useDBI()) next
+
+      cp <- checkPath(file.path(tmpdir, paste0("fmt-", useDBI, "-", paste(fmts, collapse = ""))),
+                      create = TRUE)
+      res <- runsAcrossFormatSwitch(cp, fmts[1], fmts[2])
+
+      lbl <- paste0("useDBI=", useDBI, " ", fmts[1], "->", fmts[2])
+      ## THE assertion: the body ran once, not twice.
+      expect_identical(res$runs, 1L, label = paste(lbl, "evaluations"))
+      ## The value was always right -- assert it so a "fix" that breaks
+      ## correctness to satisfy the count cannot pass.
+      expect_identical(res$second, 2, label = paste(lbl, "value"))
+    }
+  }
+})
+
+test_that("the migrated entry leaves exactly one object file, in the new format", {
+  skip_if_not_installed("qs2")
+  testInit()
+
+  withr::local_options(reproducible.cachePath = NULL,
+                       reproducible.useDBI = FALSE,
+                       reproducible.showCachePreWarm = FALSE,
+                       reproducible.ask = FALSE)
+  cp <- checkPath(file.path(tmpdir, "migrate"), create = TRUE)
+  invisible(runsAcrossFormatSwitch(cp, "rds", "qs2"))
+
+  ## Migration, not accumulation: the old .rds must be gone. Previously BOTH
+  ## formats were left on disk, the orphan never collected.
+  objFiles <- grep("dbFile|lock", dir(CacheStorageDir(cp)), invert = TRUE, value = TRUE)
+  expect_length(objFiles, 1L)
+  expect_match(objFiles, "\\.qs2$")
+})
+
+test_that("onlyStorageFiles keeps object files and drops metadata/lock files", {
+  testInit()
+
+  ## The unit underneath the above. It must pick the storage file out of a
+  ## listing that also holds the per-cacheId metadata and lock files -- and it
+  ## must do so without depending on reproducible.cachePath.
+  withr::local_options(reproducible.cachePath = NULL)
+  cp <- checkPath(file.path(tmpdir, "osf"), create = TRUE)
+  cid <- "abc123"
+  files <- c(paste0(cid, ".dbFile.rds"), paste0(cid, ".lock"), paste0(cid, ".rds"))
+
+  kept <- onlyStorageFiles(files, cid, cachePath = cp)
+
+  expect_identical(kept, paste0(cid, ".rds"))
+})


### PR DESCRIPTION
On the file-backed backend (`useDBI = FALSE`, **the default**), changing
`options(reproducible.cacheSaveFormat)` silently invalidated the whole cache:
every entry recomputed, and both old and new files were left on disk. Under DBI
the same change migrated correctly — that asymmetry is what took the longest to
explain.

## Demonstration

A function that counts its own executions. If the cache works, it runs once.

```
--- useDBI = TRUE    rds -> qs2 ---
  after 2nd call: <id>.qs2                     <- migrated, old one gone
  function ran  : 1 time(s)  -> recovered from cache

--- useDBI = FALSE   rds -> qs2 ---            (before this PR)
  with qs2 requested, BEFORE the 2nd call:
    CacheDBFileSingle(default) -> <id>.dbFile.qs2 | exists: FALSE  <- decides MISS
    CacheDBFileSingle('check') -> <id>.dbFile.rds | exists: TRUE   <- would have resolved
    showCache() still lists it : TRUE                              <- data never lost
  after 2nd call: <id>.dbFile.qs2, <id>.dbFile.rds, <id>.lock, <id>.qs2, <id>.rds
  function ran  : 2 time(s)  -> *** CACHE MISS: recomputed ***
```

## Root cause

The recovery logic was **already there and correct** — `GPT2.R` detects the
missing object file, calls `checkSameCacheId()`, and redirects to whatever
format is on disk. One helper underneath it returned nothing.

`onlyStorageFiles()` built its match pattern from `CacheStoredFile()` **without
a `cachePath`**, falling back to `getOption("reproducible.cachePath")`. That
option is unset whenever a caller passes `cachePath=` straight to `Cache()` —
the normal interactive pattern — and `CacheStoredFile()` then returns
`character(0)`. The pattern became the literal string

```
"character(0)|character(0)|character(0)"
```

matching nothing. So `checkSameCacheId()` returned nothing, the recovery never
fired, and `Cache()` concluded "miss".

`onlyStorageFiles()` is called **only** under `!useDBI()` — hence the asymmetry.

## Three fixes, needed together

Fixing the first alone just moves execution into the next.

1. **`onlyStorageFiles()` requires `cachePath`.** Deliberately *not* defaulted to
   the option — defaulting is what allowed the silent failure. Still routed
   through `CacheStoredFile()` so it follows any future change to storage
   naming. `checkSameCacheId()` derives the path from the file it was handed.
2. **`loadFile()`'s `fe`** was assigned only in the `else` branch but used
   unconditionally, so `format=` — the only route to the swap-on-mismatch code —
   failed with `object 'fe' not found`. Hoisted.
3. **The format-retry loop** called `stop()` on the *first* failure, so a file
   readable by a later candidate was reported unreadable. The guard preventing
   this was present but commented out; restored.

## Why no existing test caught it

`testInit()` sets `reproducible.cachePath`, so `CacheStoredFile()` resolved and
the pattern was valid. **The bug only appears with that option unset.** A test
written the ordinary way passes against the broken code and proves nothing — so
`test-cacheSaveFormatSwitch.R` sets it to `NULL` explicitly and records why in
its header.

It also asserts on **evaluation count**, not returned value: the value was always
correct, which is what made this silent. The only symptom is a pipeline that
mysteriously stops being fast.

## Verification

- Regression test **fails without the fix (5 failures)**, passes with it (11
  assertions) — both backends, both directions, plus a check that migration
  leaves exactly one object file rather than orphaning the old.
- Broad local run: **695 tests, 0 failures** across cache/DBI/showCache/cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpnSjDxRXjZT8a5UpwHs4g