### PR TITLE
fix: stop mclapply deadlocking after terra::writeRaster; split parallelism options by resource

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,15 @@
   release, and they hung indefinitely. The writes `reproducible` controls now
   pass `NUM_THREADS=1`, and tiling falls back to serial — with a message saying
   why — if the session is already carrying such a pool.
+* **`prepInputs(numTiles = )` now works without geodata configured.** It builds
+  its tile grid from GADM boundaries, but called `geodata::gadm()` with no
+  `path`, which errors on any machine where `geodata::geodata_path()` has never
+  been set. The download location is now resolved explicitly, preferring
+  somewhere persistent: `geodata_path()`, then
+  `reproducible.destinationPathShared`, then `reproducible.inputPath` (under
+  `tempdir()`). If GADM cannot be retrieved at all, a **warning** now says so
+  and names the fixed extent used instead, rather than failing or silently
+  tiling the wrong area.
 * **Setting `mc.cores` no longer throttles downloads.** Concurrent connections
   defaulted to `parallelly::availableCores() - 1`, and because `availableCores()`
   honours `mc.cores`, capping CPU forking silently reduced downloads to a single

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
   capped by `mc.cores`; CPU work still is. `reproducible.parallel.streams` and
   `reproducible.parallel.maxConnections` are deprecated but still honoured, with
   the new options taking precedence when both are set.
+  `reproducible.parallel.cores = 1L` additionally disables the background
+  `showCache()` pre-warm fork, which costs one extra process.
 
 * **Five functions are no longer exported** — `internetExists()`,
   `downloadFile()`, `loadFile()`, `checkAndMakeCloudFolderID()` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,15 @@
 
 ## behaviour changes
 
+* **Parallelism is now controlled by three options, one per resource** —
+  `reproducible.parallel.cores` (CPU-bound work, i.e. tiling),
+  `reproducible.parallel.download` (concurrent ranged download connections) and
+  `reproducible.parallel.upload` (concurrent Google Drive uploads). The network
+  options are deliberately no longer derived from the core count, and are not
+  capped by `mc.cores`; CPU work still is. `reproducible.parallel.streams` and
+  `reproducible.parallel.maxConnections` are deprecated but still honoured, with
+  the new options taking precedence when both are set.
+
 * **Five functions are no longer exported** — `internetExists()`,
   `downloadFile()`, `loadFile()`, `checkAndMakeCloudFolderID()` and
   `prepInputsCOG()`. All are implementation details with better-maintained
@@ -63,6 +72,18 @@
   categorical (factor) rasters categorical.
 
 ## bug fixes
+
+* **Tiling no longer deadlocks after a `terra::writeRaster()`.** A default
+  `writeRaster()` allocates a GDAL thread pool of one thread per core that is
+  never released; forking such a process (as `prepInputs(numTiles = )` did via
+  `mclapply()`) left the children holding GDAL mutexes no surviving thread could
+  release, and they hung indefinitely. The writes `reproducible` controls now
+  pass `NUM_THREADS=1`, and tiling falls back to serial — with a message saying
+  why — if the session is already carrying such a pool.
+* **Setting `mc.cores` no longer throttles downloads.** Concurrent connections
+  defaulted to `parallelly::availableCores() - 1`, and because `availableCores()`
+  honours `mc.cores`, capping CPU forking silently reduced downloads to a single
+  connection.
 
 * **Changing `options(reproducible.cacheSaveFormat)` no longer invalidates the
   cache.** On the file-backed backend every entry was silently recomputed and

--- a/R/download.R
+++ b/R/download.R
@@ -1163,7 +1163,7 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   # below, which is byte-for-byte unchanged, so checksums are unaffected.
   pp <- if (isTRUE(wasRemapped)) .useParallelDownload(url, verbose = verbose) else list(use = FALSE, info = NULL)
   if (isTRUE(pp$use)) {
-    streams <- as.integer(getOption("reproducible.parallel.streams", 48L))
+    streams <- .parallelDownload()
     messagePreProcess("Downloading ", url, " using ", streams,
                       " ranged parts (capped at ",
                       .parallelMaxConnections(), " concurrent connections) ...", verbose = verbose)
@@ -1382,7 +1382,7 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 #' @keywords internal
 #' @rdname dot-useParallelDownload
 .useParallelDownload <- function(url,
-                                 streams = getOption("reproducible.parallel.streams", 48L),
+                                 streams = .parallelDownload(),
                                  threshold = getOption("reproducible.parallel.threshold", 10 * 1024^2),
                                  verbose = getOption("reproducible.verbose", 1)) {
   # Opt-in gate: the parallel path exists ONLY to accelerate downloads that the
@@ -1479,19 +1479,36 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 # the burst of concurrent TLS handshakes (independent of how many parts the file
 # is split into), which is what some stacks -- notably Windows -- reject when all
 # `reproducible.parallel.streams` open at once.
+## Degree of parallelism, by resource. These are deliberately NOT derived from
+## the core count: network concurrency is bounded by bandwidth and per-connection
+## server shaping, not by CPUs, and deriving it from `availableCores()` meant a
+## user setting `mc.cores` to limit forking silently throttled downloads to one
+## connection.
+##
+## `reproducible.parallel.streams`/`.maxConnections` are deprecated in favour of
+## `reproducible.parallel.download`; the new option wins when both are set.
+.parallelOptInt <- function(x, min = 1L) {
+  if (is.null(x)) return(NULL)
+  x <- suppressWarnings(as.integer(x)[1])
+  if (is.na(x)) NULL else max(min, x)
+}
+
+.parallelDownload <- function() {
+  n <- .parallelOptInt(getOption("reproducible.parallel.download", NULL))
+  if (is.null(n)) n <- .parallelOptInt(getOption("reproducible.parallel.streams", NULL))
+  if (is.null(n)) n <- .parallelOptInt(getOption("reproducible.parallel.maxConnections", NULL))
+  if (is.null(n)) 48L else n
+}
+
+.parallelUpload <- function() {
+  n <- .parallelOptInt(getOption("reproducible.parallel.upload", NULL))
+  if (is.null(n)) 7L else n
+}
+
+## Retained as the name used at the ranged-download call sites; concurrency and
+## part count are now the same quantity.
 .parallelMaxConnections <- function() {
-  mc <- suppressWarnings(as.integer(getOption("reproducible.parallel.maxConnections", NULL))[1])
-  if (is.na(mc)) {
-    mc <- tryCatch({
-      cores <- if (requireNamespace("parallelly", quietly = TRUE)) {
-        parallelly::availableCores()
-      } else {
-        parallel::detectCores() # base package; always available
-      }
-      as.integer(cores)[1] - 1L
-    }, error = function(e) NA_integer_)
-  }
-  if (is.na(mc) || mc < 1L) 1L else mc
+  .parallelDownload()
 }
 
 #' Download a file in parallel using HTTP Range requests

--- a/R/download.R
+++ b/R/download.R
@@ -1484,6 +1484,17 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 ##
 ## `reproducible.parallel.streams`/`.maxConnections` are deprecated in favour of
 ## `reproducible.parallel.download`; the new option wins when both are set.
+## R CMD check sets `_R_CHECK_LIMIT_CORES_`; CRAN policy allows at most 2
+## simultaneous processes, and parallel::mclapply() errors outright above that
+## ("N simultaneous processes spawned"). That is a limit on *processes*, so it
+## binds every fork count we choose -- including the network-bound upload one,
+## which otherwise deliberately ignores CPU settings.
+.forkLimit <- function(n) {
+  lim <- Sys.getenv("_R_CHECK_LIMIT_CORES_", "")
+  if (nzchar(lim) && !identical(tolower(lim), "false")) n <- min(n, 2L)
+  max(1L, as.integer(n))
+}
+
 .parallelOptInt <- function(x, min = 1L) {
   if (is.null(x)) return(NULL)
   x <- suppressWarnings(as.integer(x)[1])
@@ -1499,7 +1510,7 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 
 .parallelUpload <- function() {
   n <- .parallelOptInt(getOption("reproducible.parallel.upload", NULL))
-  if (is.null(n)) 7L else n
+  .forkLimit(if (is.null(n)) 7L else n)
 }
 
 ## Retained as the name used at the ranged-download call sites; concurrency and

--- a/R/download.R
+++ b/R/download.R
@@ -1471,14 +1471,11 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   }
 }
 
-# Maximum number of *simultaneous* connections for the parallel ranged download.
-# Controlled by `reproducible.parallel.maxConnections`; when that is unset (NULL)
-# or not a valid number, the ceiling is `availableCores() - 1` -- using
-# `parallelly::availableCores()` when that (Suggested) package is installed, else
-# falling back to base `parallel::detectCores()`. Always at least 1. This bounds
-# the burst of concurrent TLS handshakes (independent of how many parts the file
-# is split into), which is what some stacks -- notably Windows -- reject when all
-# `reproducible.parallel.streams` open at once.
+# Maximum number of *simultaneous* connections for the parallel ranged download,
+# and equivalently the number of byte-range parts the file is split into.
+# Controlled by `reproducible.parallel.download`; always at least 1. This also
+# bounds the burst of concurrent TLS handshakes, which is what some stacks --
+# notably Windows -- reject when too many are opened at once.
 ## Degree of parallelism, by resource. These are deliberately NOT derived from
 ## the core count: network concurrency is bounded by bandwidth and per-connection
 ## server shaping, not by CPUs, and deriving it from `availableCores()` meant a

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -25,7 +25,22 @@
 #' @param doUploads Logical. Whether to upload processed tiles.
 #'   Default is `getOption("reproducible.prepInputsDoUploads", FALSE)`.
 #' @param tileGrid Either length 3 character string, such as "CAN", to be sent to `geodata::gadm(...)`
-#'   or an actual `SpatVector` object with a grid of polygons
+#'   or an actual `SpatVector` object with a grid of polygons.
+#'
+#'   When a character code is used, the GADM boundaries must be downloaded, and
+#'   `geodata` requires somewhere to put them. That location is resolved in this
+#'   order, preferring somewhere persistent so the download happens only once:
+#'   \enumerate{
+#'     \item `geodata::geodata_path()`, if the user has configured one;
+#'     \item `getOption("reproducible.destinationPathShared")` (or its
+#'       deprecated alias `reproducible.inputPaths`), the option intended for
+#'       large files reused across projects;
+#'     \item `getOption("reproducible.inputPath")`, the package default, which
+#'       is under `tempdir()` and so is re-downloaded each session.
+#'   }
+#'   If the download cannot be completed -- no path, server outage, no network --
+#'   a warning is issued and a fixed Canada-wide extent is used instead, which
+#'   may not match the area of interest.
 #' @param numTiles Integer. Number of tiles to generate. Optional.
 #' @param plot.grid Logical. Whether to plot the tile grid and area of interest. Default is `FALSE`.
 #' @param purge Logical or Integer. `0/FALSE` (default) keeps existing `CHECKSUMS.txt` file and
@@ -503,10 +518,30 @@ best_square_grid <- function(m, n, min_tiles = 1, max_tiles = 1000) {
 makeTileGridFromGADMcode <- function(tileGrid, numTiles = NULL, crs) {
   ## an error here (no path, server down, network) routes into the same fallback
   ## as a NULL return, just below
-  g <- tryCatch(geodata::gadm(tileGrid, resolution = 2, path = .gadmPath()) |> Cache(),
-                error = function(e) NULL)
+  gadmErr <- NULL
+  ## resolving the location can itself fail (e.g. an unwritable directory), so
+  ## it is inside the same fallback
+  gadmPath <- tryCatch(.gadmPath(), error = function(e) {
+    gadmErr <<- conditionMessage(e)
+    NULL
+  })
+  g <- if (is.null(gadmPath)) {
+    NULL
+  } else {
+    tryCatch(geodata::gadm(tileGrid, resolution = 2, path = gadmPath) |> Cache(),
+             error = function(e) {
+               gadmErr <<- conditionMessage(e)
+               NULL
+             })
+  }
   if (is.null(g) || (is.character(g) && isTRUE(g == "NULL"))) {
-    # most likely geodata server is down
+    ## geodata unavailable: no path configured, server down, or no network. Say
+    ## so -- the fallback silently changes which area gets tiled.
+    warning(.message$gadmFallback(
+      tileGrid,
+      if (is.null(gadmPath)) "<no download location could be resolved>" else gadmPath,
+      gadmErr
+    ), call. = FALSE)
     tileExt <- terra::ext(c(xmin = -2342000, xmax = 3011000, ymin = 5860000, ymax = 9436000))
     tilePoly2 <- tileExt
   } else {

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -852,11 +852,16 @@ forkIsSafe <- function() {
   n <= numSystemCores()
 }
 
-## The *machine's* core count -- deliberately NOT availableCores(), which honours
-## `mc.cores`/cgroup settings. Those say how many workers the user wants; the
-## library thread pools we are detecting here are sized to the hardware, so a
-## user who sets `mc.cores = 2` must not make a clean 65-thread process look
-## unsafe to fork.
+## The *machine's* core count. Deliberately neither availableCores() nor
+## freeCores(), both of which answer "how many workers should I start":
+##   - availableCores() honours `mc.cores`, so `mc.cores = 2` would make a clean
+##     65-thread process look unsafe to fork.
+##   - freeCores() subtracts whatever else is running, so on a busy shared
+##     machine it might return 10 while a clean session still legitimately
+##     carries 64 BLAS threads -- again a false positive.
+## The pools being detected here (GDAL's, OpenBLAS's) are sized to the hardware,
+## so the hardware count is the only correct comparison. Use freeCores() for
+## deciding how much work to start (see .parallelCores), not here.
 numSystemCores <- function() {
   n <- NA_integer_
   if (.requireNamespace("parallelly")) {

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -286,7 +286,7 @@ tile_raster_write_auto <- function(raster_path, out_dir, tileGrid, all_tile_name
 
         terra::writeRaster(tile, spec$path, datatype = datatype,
                            overwrite = FALSE,
-                           gdal = c("COMPRESS=LZW", "TILED=YES"))
+                           gdal = c("COMPRESS=LZW", "TILED=YES", "NUM_THREADS=1"))
         return(paste("Saved:", spec$path))
       # }
     } else {
@@ -297,12 +297,16 @@ tile_raster_write_auto <- function(raster_path, out_dir, tileGrid, all_tile_name
   messagePreProcess("Creating tiles ...", verbose = verbose)
 
   # Choose parallel or sequential based on OS
-  if (isUnix() && requireNamespace("parallel")) {
+  if (isUnix() && requireNamespace("parallel") && forkIsSafe()) {
     numCoresToUse <- min(getOption("mc.cores"), numCoresToUse(max = length(tile_specs)))
     results <- parallel::mclapply(
       tile_specs, process_tile,
       mc.cores = numCoresToUse, datatype = datatype)
   } else {
+    if (isUnix() && !forkIsSafe()) {
+      messagePreProcess(.message$forkUnsafeSerial(nThreadsSelf(), numSystemCores()),
+                        verbose = verbose)
+    }
     results <- lapply(tile_specs, process_tile, datatype = datatype)
   }
 
@@ -361,7 +365,7 @@ upload_tiles_to_drive_url_parallel <- function(local_dir, drive_folder_url, this
   }
 
   # Upload in parallel on Linux/macOS, sequential on Windows
-  if (isUnix() && requireNamespace("parallel")) {
+  if (isUnix() && requireNamespace("parallel") && forkIsSafe()) {
     numCoresToUse <- min(getOption("mc.cores"), numCoresToUse(max = 7))
     # numCoresToUse <- numCoresToUse(max = 7) # more than 7 on a fast internet connection
                          # tends to be slower; but this will depend on connection speed
@@ -784,6 +788,51 @@ tryRastThenGetCRS <- function(targetFileFullPath) {
 #'
 #' @export
 #' @seealso [detectActiveCores()]
+## Number of threads in the *current* process, or NA where we cannot tell.
+## Linux exposes one directory per thread under /proc/self/task; macOS needs `ps -M`.
+nThreadsSelf <- function() {
+  if (dir.exists("/proc/self/task")) {
+    return(length(dir("/proc/self/task")))
+  }
+  if (isMac()) {
+    return(tryCatch(length(system2("ps", c("-M", "-p", Sys.getpid()), stdout = TRUE)) - 1L,
+                    error = function(e) NA_integer_, warning = function(w) NA_integer_))
+  }
+  NA_integer_
+}
+
+## `mclapply()` forks, and fork() only carries the calling thread into the child:
+## any mutex held by another thread stays locked there forever. A process whose
+## thread count exceeds its core count is carrying a library thread pool (in
+## practice GDAL's, created by a default terra::writeRaster()), and forking it
+## deadlocks. Both pools that matter are sized to the core count, so "more
+## threads than cores" separates the two states with a full core-count of margin.
+## Unknown thread count (NA) forks as before.
+forkIsSafe <- function() {
+  n <- nThreadsSelf()
+  if (is.na(n)) {
+    return(TRUE)
+  }
+  n <= numSystemCores()
+}
+
+## The *machine's* core count -- deliberately NOT availableCores(), which honours
+## `mc.cores`/cgroup settings. Those say how many workers the user wants; the
+## library thread pools we are detecting here are sized to the hardware, so a
+## user who sets `mc.cores = 2` must not make a clean 65-thread process look
+## unsafe to fork.
+numSystemCores <- function() {
+  n <- NA_integer_
+  if (.requireNamespace("parallelly")) {
+    n <- suppressWarnings(tryCatch(as.integer(parallelly::availableCores(methods = "system")),
+                                   error = function(e) NA_integer_))
+  }
+  if (is.na(n) || n < 1L) {
+    n <- suppressWarnings(as.integer(parallel::detectCores()))
+  }
+  if (is.na(n) || n < 1L) 1L else n
+}
+
 numCoresToUse <- function(min = 2, max = NULL) {
   if (.requireNamespace("parallelly")) {
     nctu <- max(min, min(max, parallelly::freeCores()))

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -298,7 +298,7 @@ tile_raster_write_auto <- function(raster_path, out_dir, tileGrid, all_tile_name
 
   # Choose parallel or sequential based on OS
   if (isUnix() && requireNamespace("parallel") && forkIsSafe()) {
-    numCoresToUse <- min(getOption("mc.cores"), numCoresToUse(max = length(tile_specs)))
+    numCoresToUse <- .parallelCores(maxN = length(tile_specs))
     results <- parallel::mclapply(
       tile_specs, process_tile,
       mc.cores = numCoresToUse, datatype = datatype)
@@ -366,9 +366,9 @@ upload_tiles_to_drive_url_parallel <- function(local_dir, drive_folder_url, this
 
   # Upload in parallel on Linux/macOS, sequential on Windows
   if (isUnix() && requireNamespace("parallel") && forkIsSafe()) {
-    numCoresToUse <- min(getOption("mc.cores"), numCoresToUse(max = 7))
-    # numCoresToUse <- numCoresToUse(max = 7) # more than 7 on a fast internet connection
-                         # tends to be slower; but this will depend on connection speed
+    ## network-bound, so NOT core-derived and not capped by `mc.cores`: more than
+    ## ~7 concurrent uploads tends to be slower, depending on connection speed
+    numCoresToUse <- .parallelUpload()
     results <- parallel::mclapply(
       tif_files, upload_one,
       mc.cores = numCoresToUse)
@@ -788,6 +788,42 @@ tryRastThenGetCRS <- function(targetFileFullPath) {
 #'
 #' @export
 #' @seealso [detectActiveCores()]
+numCoresToUse <- function(min = 2, max = NULL) {
+  if (.requireNamespace("parallelly")) {
+    nctu <- max(min, min(max, parallelly::freeCores()))
+    return(nctu)
+  }
+  # if (is.null(.pkgEnv$detectedCores)) {
+  #   ## see <https://parallelly.futureverse.org/#availablecores-vs-paralleldetectcores>
+  #   .pkgEnv$detectedCores <- max(1L, getOption("Ncpus", 1L), parallel::detectCores() - 1,
+  #                                logical = FALSE, na.rm = TRUE)
+  # }
+  # dc <- .pkgEnv$detectedCores
+  # if (is.null(max)) {
+  #   max <- dc
+  # }
+  # max <- min(dc -  # total
+  #              1 - # remove one for the current process
+  #              detectActiveCores(), # estimate actively used ones
+  #            max)
+  # max(min, max)
+}
+
+## CPU-bound parallelism (tiling). Unlike the network knobs this one *is* core
+## shaped, and `mc.cores` still applies because it is the standard base-R control
+## for forking. `reproducible.parallel.cores` overrides the detected default.
+.parallelCores <- function(maxN = NULL) {
+  n <- .parallelOptInt(getOption("reproducible.parallel.cores", NULL))
+  if (is.null(n)) {
+    n <- numCoresToUse(max = maxN)
+  } else if (!is.null(maxN)) {
+    n <- min(n, maxN)
+  }
+  mcc <- .parallelOptInt(getOption("mc.cores", NULL))
+  if (!is.null(mcc)) n <- min(n, mcc)
+  max(1L, as.integer(n))
+}
+
 ## Number of threads in the *current* process, or NA where we cannot tell.
 ## Linux exposes one directory per thread under /proc/self/task; macOS needs `ps -M`.
 nThreadsSelf <- function() {
@@ -833,26 +869,6 @@ numSystemCores <- function() {
   if (is.na(n) || n < 1L) 1L else n
 }
 
-numCoresToUse <- function(min = 2, max = NULL) {
-  if (.requireNamespace("parallelly")) {
-    nctu <- max(min, min(max, parallelly::freeCores()))
-    return(nctu)
-  }
-  # if (is.null(.pkgEnv$detectedCores)) {
-  #   ## see <https://parallelly.futureverse.org/#availablecores-vs-paralleldetectcores>
-  #   .pkgEnv$detectedCores <- max(1L, getOption("Ncpus", 1L), parallel::detectCores() - 1,
-  #                                logical = FALSE, na.rm = TRUE)
-  # }
-  # dc <- .pkgEnv$detectedCores
-  # if (is.null(max)) {
-  #   max <- dc
-  # }
-  # max <- min(dc -  # total
-  #              1 - # remove one for the current process
-  #              detectActiveCores(), # estimate actively used ones
-  #            max)
-  # max(min, max)
-}
 
 # Classify a remote-supplied hash string into a content-hash algorithm or
 # "etag-opaque" when no positive trust is possible. Google Drive ETag-shaped

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -829,7 +829,7 @@ numCoresToUse <- function(min = 2, max = NULL) {
   }
   mcc <- .parallelOptInt(getOption("mc.cores", NULL))
   if (!is.null(mcc)) n <- min(n, mcc)
-  max(1L, as.integer(n))
+  .forkLimit(n)
 }
 
 ## Number of threads in the *current* process, or NA where we cannot tell.

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -849,24 +849,38 @@ forkIsSafe <- function() {
   if (is.na(n)) {
     return(TRUE)
   }
-  n <= numSystemCores()
+  ## A clean process already carries about one thread per core (BLAS) plus the
+  ## main thread, so `n > cores` alone would false-positive on small machines
+  ## (3 threads on 2 cores). A GDAL pool adds another full core's worth, so
+  ## half a core count of headroom separates the two states at every size:
+  ##   2 cores  -> clean 3, poisoned 5, threshold 3
+  ##  80 cores  -> clean 65, poisoned 145, threshold 120
+  cores <- numSystemCores()
+  n <= cores + max(1L, cores %/% 2L)
 }
 
-## The *machine's* core count. Deliberately neither availableCores() nor
-## freeCores(), both of which answer "how many workers should I start":
+## The CPU count as the *thread-pool libraries themselves* see it: affinity- and
+## cgroup-aware (so it is 2 inside `taskset -c 0,1` or a 2-CPU container), but
+## deliberately ignoring `mc.cores`. Neither availableCores() nor freeCores()
+## is right here, because both answer "how many workers should I start":
 ##   - availableCores() honours `mc.cores`, so `mc.cores = 2` would make a clean
 ##     65-thread process look unsafe to fork.
 ##   - freeCores() subtracts whatever else is running, so on a busy shared
 ##     machine it might return 10 while a clean session still legitimately
 ##     carries 64 BLAS threads -- again a false positive.
-## The pools being detected here (GDAL's, OpenBLAS's) are sized to the hardware,
-## so the hardware count is the only correct comparison. Use freeCores() for
-## deciding how much work to start (see .parallelCores), not here.
+## `methods = "system"` is wrong too: it reports the raw CPU count, so inside a
+## CPU-limited container -- i.e. most CI -- it reads 80 while the pools size
+## themselves to 2, and the guard would never fire. Use freeCores() for deciding
+## how much work to start (see .parallelCores), not here.
 numSystemCores <- function() {
   n <- NA_integer_
   if (.requireNamespace("parallelly")) {
-    n <- suppressWarnings(tryCatch(as.integer(parallelly::availableCores(methods = "system")),
-                                   error = function(e) NA_integer_))
+    n <- suppressWarnings(tryCatch(
+      as.integer(parallelly::availableCores(
+        ## excludes the "mc.cores" method on purpose; `nproc` honours CPU affinity
+        methods = c("cgroups.cpuset", "cgroups.cpuquota", "nproc", "system")
+      )),
+      error = function(e) NA_integer_))
   }
   if (is.na(n) || n < 1L) {
     n <- suppressWarnings(as.integer(parallel::detectCores()))

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -815,7 +815,15 @@ numCoresToUse <- function(min = 2, max = NULL) {
 .parallelCores <- function(maxN = NULL) {
   n <- .parallelOptInt(getOption("reproducible.parallel.cores", NULL))
   if (is.null(n)) {
-    n <- numCoresToUse(max = maxN)
+    ## numCoresToUse() returns NULL when the Suggested `parallelly` is absent
+    ## (e.g. an `_R_CHECK_DEPENDS_ONLY_` leg); without a fallback that would
+    ## silently collapse to 1 and serialize all CPU work.
+    n <- .parallelOptInt(numCoresToUse(max = maxN))
+    if (is.null(n)) {
+      dc <- suppressWarnings(as.integer(parallel::detectCores())[1])
+      n <- if (is.na(dc) || dc < 2L) 2L else max(2L, dc - 1L)
+      if (!is.null(maxN)) n <- min(n, maxN)
+    }
   } else if (!is.null(maxN)) {
     n <- min(n, maxN)
   }

--- a/R/downloadTileAndUpload.R
+++ b/R/downloadTileAndUpload.R
@@ -477,8 +477,34 @@ best_square_grid <- function(m, n, min_tiles = 1, max_tiles = 1000) {
 }
 
 
+## `geodata::gadm()` has no default for `path`: it falls back to geodata_path(),
+## which errors ("you need to provide a path, or set a default path") on any
+## machine where the user has not configured one -- CI, and a new user. Prefer
+## their geodata config if they have one, then reproducible's shared-downloads
+## location (the option meant for exactly this: large files reused across
+## projects), and only then the package's own input default, which is under
+## tempdir() and so is safe to write to without asking.
+.gadmPath <- function() {
+  if (.requireNamespace("geodata")) {
+    p <- tryCatch(geodata::geodata_path(), error = function(e) "")
+    if (length(p) && nzchar(p[1])) {
+      return(p[1])
+    }
+  }
+  shared <- .getDestinationPathShared()
+  base <- if (length(shared) && nzchar(shared[1])) {
+    shared[1]
+  } else {
+    getOption("reproducible.inputPath", file.path(tempdir(), "reproducible", "input"))
+  }
+  checkPath(file.path(base, "geodata"), create = TRUE)
+}
+
 makeTileGridFromGADMcode <- function(tileGrid, numTiles = NULL, crs) {
-  g <- geodata::gadm(tileGrid, resolution = 2) |> Cache()
+  ## an error here (no path, server down, network) routes into the same fallback
+  ## as a NULL return, just below
+  g <- tryCatch(geodata::gadm(tileGrid, resolution = 2, path = .gadmPath()) |> Cache(),
+                error = function(e) NULL)
   if (is.null(g) || (is.character(g) && isTRUE(g == "NULL"))) {
     # most likely geodata server is down
     tileExt <- terra::ext(c(xmin = -2342000, xmax = 3011000, ymin = 5860000, ymax = 9436000))

--- a/R/messages.R
+++ b/R/messages.R
@@ -13,6 +13,23 @@
 .message$stopNeedArchive <- function(archive)
   paste0("Please install.packages('archive') to extract files from \n", archive)
 
+## A `terra::writeRaster()` with default options allocates one GDAL worker
+## thread per core, and that pool is never released for the life of the
+## session (not by gc(), not when the SpatRaster is dropped). Forking such a
+## process leaves the children holding GDAL mutexes that no surviving thread
+## can release, so they hang forever. Tiling therefore falls back to serial
+## whenever the process already carries more threads than it has cores.
+.message$forkUnsafeSerialTxt <-
+  "tiling serially: this session has more threads than cores, making fork() unsafe"
+
+.message$forkUnsafeSerial <- function(nThreads, nCores)
+  paste0(
+    .message$forkUnsafeSerialTxt, " (", nThreads, " threads > ", nCores, " cores). ",
+    "An earlier terra::writeRaster() created a GDAL thread pool that is never ",
+    "released. To keep tiling parallel, write with ",
+    "`terra::writeRaster(..., gdal = \"NUM_THREADS=1\")`."
+  )
+
 ## `fun` may be a function, a quoted call, a symbol, or the name of a function as
 ## a string (optionally "pkg::name"). Each form resolves through a different
 ## lookup, and each lookup failing on its own reports only what it happened to

--- a/R/messages.R
+++ b/R/messages.R
@@ -19,6 +19,19 @@
 ## process leaves the children holding GDAL mutexes that no surviving thread
 ## can release, so they hang forever. Tiling therefore falls back to serial
 ## whenever the process already carries more threads than it has cores.
+.message$gadmFallbackTxt <- "could not retrieve GADM boundaries"
+
+.message$gadmFallback <- function(tileGrid, path, err = NULL)
+  paste0(
+    .message$gadmFallbackTxt, " for ", encodeString(tileGrid, quote = "'"),
+    if (!is.null(err) && nzchar(err)) paste0(": ", err) else "",
+    ".\n  Using a fixed Canada-wide extent for the tile grid instead, so the ",
+    "tiles may not match your area of interest.",
+    "\n  Downloads were attempted into: ", path,
+    "\n  To keep them across sessions, set `geodata::geodata_path()` or ",
+    "`options(reproducible.destinationPathShared = )`."
+  )
+
 .message$forkUnsafeSerialTxt <-
   "tiling serially: this session has more threads than cores, making fork() unsafe"
 

--- a/R/options.R
+++ b/R/options.R
@@ -214,7 +214,29 @@
 #'     Default: `FALSE`. Used in [prepInputs()], [preProcess()],
 #'     [downloadFile()], and [postProcess()].
 #'   }
+#'   \item{`parallel.cores`}{
+#'     Default: `NULL`, meaning `parallelly::freeCores()`. Degree of parallelism
+#'     for **CPU-bound** work, i.e. tiling in [prepInputs()] when `numTiles` is
+#'     supplied. Being CPU work, it is additionally capped by `mc.cores`.
+#'   }
+#'   \item{`parallel.download`}{
+#'     Default: `NULL`, meaning `48L`. Number of concurrent ranged connections
+#'     used to fetch a single large file (equivalently, the number of byte-range
+#'     parts it is split into). Deliberately **not** derived from the core count:
+#'     network throughput is bounded by bandwidth and per-connection server
+#'     shaping, not by CPUs, so this is not capped by `mc.cores` either. Set `1L`
+#'     to force the single-stream path. As with the deprecated options it
+#'     replaces, this has no effect unless `reproducible.urlRemap` is set.
+#'   }
+#'   \item{`parallel.upload`}{
+#'     Default: `NULL`, meaning `7L`. Number of concurrent uploads to Google
+#'     Drive. Network-bound like `parallel.download`, so likewise not core-derived
+#'     and not capped by `mc.cores`; more than about 7 tends to be slower,
+#'     depending on connection speed.
+#'   }
 #'   \item{`parallel.streams`}{
+#'     `r lifecycle::badge("deprecated")` Use `parallel.download` instead, which
+#'     takes precedence when both are set. Still honoured when it alone is set.
 #'     Default: `48L`. The number of contiguous byte-range **parts** a single
 #'     large HTTPS file is split into. **This has no effect unless you have opted
 #'     in by setting `reproducible.urlRemap`** (see below): if no remap is set,
@@ -240,9 +262,10 @@
 #'     single-stream download, so checksums are unaffected.
 #'   }
 #'   \item{`parallel.maxConnections`}{
-#'     Default: `NULL`, meaning `parallelly::availableCores() - 1` (or
-#'     `parallel::detectCores() - 1` if the Suggested \pkg{parallelly} package is
-#'     not installed). The maximum
+#'     `r lifecycle::badge("deprecated")` Use `parallel.download` instead, which
+#'     takes precedence when both are set. Still honoured when it alone is set.
+#'     Previously defaulted to `parallelly::availableCores() - 1`, which meant a
+#'     user setting `mc.cores` to limit forking silently throttled downloads. The maximum
 #'     number of ranged parts that download **simultaneously**; the rest queue
 #'     until a connection frees up. This bounds the burst of concurrent TLS
 #'     handshakes, which some stacks (notably Windows) refuse when all
@@ -576,9 +599,12 @@ reproducibleOptions <- function() {
     reproducible.preDigestDump = NULL,              # NULL/FALSE off; TRUE -> message each call's preDigest; or a dir path -> one file per call
     reproducible.preDigestDumpPattern = NULL,       # optional regex on .functionName to limit which calls are dumped
     reproducible.parallel.connecttimeout = 30L,     # seconds; per-connection establishment timeout for ranged streams
-    reproducible.parallel.maxConnections = NULL,    # max simultaneous connections; NULL => parallelly::availableCores() - 1
+    reproducible.parallel.cores = NULL,             # CPU-bound work (tiling); NULL => parallelly::freeCores()
+    reproducible.parallel.download = NULL,          # concurrent ranged download connections; NULL => 48
+    reproducible.parallel.upload = NULL,            # concurrent Drive uploads; NULL => 7
+    reproducible.parallel.maxConnections = NULL,    # DEPRECATED -> reproducible.parallel.download
     reproducible.parallel.minConcurrentFrac = 0.25, # fall back to single stream if 1st attempt completes < this frac of parts
-    reproducible.parallel.streams = 48L,            # number of ranged parts; used only for urlRemap-redirected URLs
+    reproducible.parallel.streams = NULL,           # DEPRECATED -> reproducible.parallel.download
     reproducible.parallel.threshold = 10 * 1024^2,  # bytes; only files larger use the parallel path
     reproducible.quick = FALSE,
     reproducible.rasterRead = getEnv("R_REPRODUCIBLE_RASTER_READ",

--- a/R/options.R
+++ b/R/options.R
@@ -218,6 +218,8 @@
 #'     Default: `NULL`, meaning `parallelly::freeCores()`. Degree of parallelism
 #'     for **CPU-bound** work, i.e. tiling in [prepInputs()] when `numTiles` is
 #'     supplied. Being CPU work, it is additionally capped by `mc.cores`.
+#'     Setting it to `1L` also disables the background `showCache()` pre-warm
+#'     fork, which costs one extra process (see `showCachePreWarm` below).
 #'   }
 #'   \item{`parallel.download`}{
 #'     Default: `NULL`, meaning `48L`. Number of concurrent ranged connections

--- a/R/postProcessTo.R
+++ b/R/postProcessTo.R
@@ -1162,10 +1162,14 @@ writeTo <- function(from, writeTo, overwrite = getOption("reproducible.overwrite
             ## and `terra` can't overwrite it even if `overwrite = TRUE`
             ## this can happen when multiple modules touch the same object
             if (!any(file.exists(writeTo))) {
-              from <- terra::writeRaster(from,
-                                         filename = writeTo, overwrite = FALSE,
-                                         datatype = datatype
-              )
+              ## NUM_THREADS=1: a default write allocates a GDAL thread pool sized
+              ## to the core count that is never released, which makes any later
+              ## fork() (e.g. tiling) deadlock. `datatype = NULL` together with
+              ## `gdal =` throws Rcpp::not_compatible in terra, so drop the NULL.
+              wrArgs <- list(from, filename = writeTo, overwrite = FALSE,
+                             gdal = "NUM_THREADS=1")
+              if (!is.null(datatype)) wrArgs$datatype <- datatype
+              from <- do.call(terra::writeRaster, wrArgs)
               writeDone <- TRUE
             } else {
               stop("File can't be unlinked for overwrite.")

--- a/R/showCacheEtc.R
+++ b/R/showCacheEtc.R
@@ -1022,10 +1022,18 @@ sortedOrRegexp <- c("sorted", "regexp", "ask")
   if (isTRUE(useDBI())) return(invisible(NULL))
   if (!requireNamespace("parallel", quietly = TRUE)) return(invisible(NULL))
   ## The pre-warm costs one extra process, so it respects the user's CPU
-  ## parallelism setting: `reproducible.parallel.cores = 1` means "no parallel
-  ## CPU work", and that includes this fork. Anything >= 2 permits it (it only
-  ## ever spawns the single job, regardless of how much higher the setting is).
-  if (.parallelCores() < 2L) return(invisible(NULL))
+  ## parallelism setting: `reproducible.parallel.cores = 1` (or `mc.cores = 1`)
+  ## means "no parallel CPU work", and that includes this fork. Anything >= 2
+  ## permits it -- it only ever spawns the single job, however high the setting.
+  ##
+  ## Deliberately keyed on an EXPLICIT setting rather than a detected core
+  ## count: freeCores() can legitimately report 1 on a busy shared machine, and
+  ## it is unavailable entirely without the Suggested `parallelly`, neither of
+  ## which should silently switch the pre-warm off.
+  for (o in c("reproducible.parallel.cores", "mc.cores")) {
+    v <- .parallelOptInt(getOption(o, NULL))
+    if (!is.null(v) && v < 2L) return(invisible(NULL))
+  }
   x <- x[[1L]]
   pkgEnv <- memoiseEnv(cachePath = x)
   scAll <- pkgEnv[["shownCache"]]

--- a/R/showCacheEtc.R
+++ b/R/showCacheEtc.R
@@ -1021,6 +1021,11 @@ sortedOrRegexp <- c("sorted", "regexp", "ask")
   ## fork does -- is unnecessary there. Skip it entirely.
   if (isTRUE(useDBI())) return(invisible(NULL))
   if (!requireNamespace("parallel", quietly = TRUE)) return(invisible(NULL))
+  ## The pre-warm costs one extra process, so it respects the user's CPU
+  ## parallelism setting: `reproducible.parallel.cores = 1` means "no parallel
+  ## CPU work", and that includes this fork. Anything >= 2 permits it (it only
+  ## ever spawns the single job, regardless of how much higher the setting is).
+  if (.parallelCores() < 2L) return(invisible(NULL))
   x <- x[[1L]]
   pkgEnv <- memoiseEnv(cachePath = x)
   scAll <- pkgEnv[["shownCache"]]

--- a/man/dot-useParallelDownload.Rd
+++ b/man/dot-useParallelDownload.Rd
@@ -6,7 +6,7 @@
 \usage{
 .useParallelDownload(
   url,
-  streams = getOption("reproducible.parallel.streams", 48L),
+  streams = .parallelDownload(),
   threshold = getOption("reproducible.parallel.threshold", 10 * 1024^2),
   verbose = getOption("reproducible.verbose", 1)
 )

--- a/man/prepInputsWithTiles.Rd
+++ b/man/prepInputsWithTiles.Rd
@@ -40,7 +40,22 @@ that will be used; if it is a relative path, then it will be
 Default is \code{getOption("reproducible.prepInputsDoUploads", FALSE)}.}
 
 \item{tileGrid}{Either length 3 character string, such as "CAN", to be sent to \code{geodata::gadm(...)}
-or an actual \code{SpatVector} object with a grid of polygons}
+or an actual \code{SpatVector} object with a grid of polygons.
+
+When a character code is used, the GADM boundaries must be downloaded, and
+\code{geodata} requires somewhere to put them. That location is resolved in this
+order, preferring somewhere persistent so the download happens only once:
+\enumerate{
+\item \code{geodata::geodata_path()}, if the user has configured one;
+\item \code{getOption("reproducible.destinationPathShared")} (or its
+deprecated alias \code{reproducible.inputPaths}), the option intended for
+large files reused across projects;
+\item \code{getOption("reproducible.inputPath")}, the package default, which
+is under \code{tempdir()} and so is re-downloaded each session.
+}
+If the download cannot be completed -- no path, server outage, no network --
+a warning is issued and a fixed Canada-wide extent is used instead, which
+may not match the area of interest.}
 
 \item{numTiles}{Integer. Number of tiles to generate. Optional.}
 

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -219,35 +219,31 @@ faster, depending on the objects.
 Default: \code{FALSE}. Used in \code{\link[=prepInputs]{prepInputs()}}, \code{\link[=preProcess]{preProcess()}},
 \code{\link[=downloadFile]{downloadFile()}}, and \code{\link[=postProcess]{postProcess()}}.
 }
-\item{\code{parallel.streams}}{
-Default: \code{48L}. The number of contiguous byte-range \strong{parts} a single
-large HTTPS file is split into. \strong{This has no effect unless you have opted
-in by setting \code{reproducible.urlRemap}} (see below): if no remap is set,
-downloads are always single-stream, regardless of this value. Once opted
-in, the parallel path is used \strong{only for a URL that the \code{urlRemap} hook
-actually redirected} to a (Range-capable) mirror — \emph{not} for arbitrary
-range-capable origin servers reached without a redirect, since those may
-cap concurrent connections per IP (in which case parallel streams all
-stall and the download is slower than a single stream). For an eligible,
-redirected URL the file is split into this many parts — but only when the
-server advertises \code{Accept-Ranges: bytes} and the file is larger than
-\code{reproducible.parallel.threshold}; otherwise, and on any failure, it
-falls back transparently to a single stream. (A redirected mirror that
-\emph{does} turn out to cap concurrency is detected on the first attempt — see
-\code{reproducible.parallel.minConcurrentFrac} — and also falls back.)
-Splitting into many small
-parts keeps retries cheap (a dropped connection costs only one
-part re-fetch). The number that download \emph{at once} is separately capped by
-\code{reproducible.parallel.maxConnections}. Especially useful on networks that
-shape bandwidth per-connection. Set to \code{1L} to force single-stream
-downloads even when a remap is set. Requires the \pkg{curl} and
-\pkg{httr2} packages. The assembled file is byte-identical to a
-single-stream download, so checksums are unaffected.
+\item{\code{parallel.cores}}{
+Default: \code{NULL}, meaning \code{parallelly::freeCores()}. Degree of parallelism
+for \strong{CPU-bound} work, i.e. tiling in \code{\link[=prepInputs]{prepInputs()}} when \code{numTiles} is
+supplied. Being CPU work, it is additionally capped by \code{mc.cores}.
 }
-\item{\code{parallel.maxConnections}}{
-Default: \code{NULL}, meaning \code{parallelly::availableCores() - 1} (or
-\code{parallel::detectCores() - 1} if the Suggested \pkg{parallelly} package is
-not installed). The maximum
+\item{\code{parallel.download}}{
+Default: \code{NULL}, meaning \code{48L}. Number of concurrent ranged connections
+used to fetch a single large file (equivalently, the number of byte-range
+parts it is split into). Deliberately \strong{not} derived from the core count:
+network throughput is bounded by bandwidth and per-connection server
+shaping, not by CPUs, so this is not capped by \code{mc.cores} either. Set \code{1L}
+to force the single-stream path. As with the deprecated options it
+replaces, this has no effect unless \code{reproducible.urlRemap} is set.
+}
+\item{\code{parallel.upload}}{
+Default: \code{NULL}, meaning \code{7L}. Number of concurrent uploads to Google
+Drive. Network-bound like \code{parallel.download}, so likewise not core-derived
+and not capped by \code{mc.cores}; more than about 7 tends to be slower,
+depending on connection speed.
+}
+\item{\code{parallel.streams}}{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}})\code{Use}parallel.download\verb{instead, which takes precedence when both are set. Still honoured when it alone is set. Default:}48L\verb{. The number of contiguous byte-range **parts** a single large HTTPS file is split into. **This has no effect unless you have opted in by setting }reproducible.urlRemap\verb{** (see below): if no remap is set, downloads are always single-stream, regardless of this value. Once opted in, the parallel path is used **only for a URL that the }urlRemap\verb{hook actually redirected** to a (Range-capable) mirror — *not* for arbitrary range-capable origin servers reached without a redirect, since those may cap concurrent connections per IP (in which case parallel streams all stall and the download is slower than a single stream). For an eligible, redirected URL the file is split into this many parts — but only when the server advertises}Accept-Ranges: bytes\verb{and the file is larger than}reproducible.parallel.threshold\verb{; otherwise, and on any failure, it falls back transparently to a single stream. (A redirected mirror that *does* turn out to cap concurrency is detected on the first attempt — see }reproducible.parallel.minConcurrentFrac\verb{— and also falls back.) Splitting into many small parts keeps retries cheap (a dropped connection costs only one part re-fetch). The number that download *at once* is separately capped by}reproducible.parallel.maxConnections\verb{. Especially useful on networks that shape bandwidth per-connection. Set to }1L\verb{ to force single-stream downloads even when a remap is set. Requires the \pkg{curl} and \pkg{httr2} packages. The assembled file is byte-identical to a single-stream download, so checksums are unaffected. \} \\item\{}parallel.maxConnections\verb{\}\{ \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}})} Use \code{parallel.download} instead, which
+takes precedence when both are set. Still honoured when it alone is set.
+Previously defaulted to \code{parallelly::availableCores() - 1}, which meant a
+user setting \code{mc.cores} to limit forking silently throttled downloads. The maximum
 number of ranged parts that download \strong{simultaneously}; the rest queue
 until a connection frees up. This bounds the burst of concurrent TLS
 handshakes, which some stacks (notably Windows) refuse when all

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -223,6 +223,8 @@ Default: \code{FALSE}. Used in \code{\link[=prepInputs]{prepInputs()}}, \code{\l
 Default: \code{NULL}, meaning \code{parallelly::freeCores()}. Degree of parallelism
 for \strong{CPU-bound} work, i.e. tiling in \code{\link[=prepInputs]{prepInputs()}} when \code{numTiles} is
 supplied. Being CPU work, it is additionally capped by \code{mc.cores}.
+Setting it to \code{1L} also disables the background \code{showCache()} pre-warm
+fork, which costs one extra process (see \code{showCachePreWarm} below).
 }
 \item{\code{parallel.download}}{
 Default: \code{NULL}, meaning \code{48L}. Number of concurrent ranged connections

--- a/tests/testthat/helper-allEqual.R
+++ b/tests/testthat/helper-allEqual.R
@@ -8,13 +8,6 @@ skip_if_no_token <- function() {
   testthat::skip_if_not(googledrive::drive_has_token(), "No Drive token")
 }
 
-## NOTE: needs to be called after testInit("googledrive", needGoogleDriveAuth = TRUE)
-skip_if_service_account <- function() {
-  ## service accounts cannot upload to standard drive folders (no quota)
-  testthat::skip_if_not(!grepl("gserviceaccount", googledrive::drive_user()$emailAddress),
-                        message =  "Using service account")
-}
-
 ## Run `expr` and convert transient upstream HTTP/network errors into a skip
 ## so flaky CDN behaviour (e.g. GitHub raw returning 5xx during a request)
 ## does not surface as a test FAIL. Non-transient errors propagate unchanged.
@@ -101,37 +94,28 @@ skip_if_transient_stream_warnings <- function(expr) {
   invisible(result)
 }
 
-skip_if_service_account_releaseVer_NotLinux <- function() {
-  ## Service accounts (e.g. eliot-githubauthentication@...gserviceaccount.com)
-  ## have no Drive quota on user-owned folders, so they cannot complete the
-  ## upload-and-roundtrip path these tests exercise. We gate those tests on:
-  ##   (a) we're actually running unattended (CI or R CMD check non-interactive)
-  ##       AND the token currently in use IS a service account, AND
-  ##   (b) the runner is not the supported Linux/release combination.
+skip_if_not_releaseVer_Linux <- function() {
+  ## These tests do real Google Drive upload round-trips. They are slow, and
+  ## several CI legs hitting the same Drive folder at once can race with each
+  ## other, so they run on exactly one runner: Linux on the release R.
   ##
   ## R_VERSION_LABEL is a CI-only signal the team's runners set to declare
   ## "I am a release R job". A local R CMD check won't have it set, and
-  ## absence MUST NOT trigger a skip — only an explicit non-"release" value
-  ## should. Without this guard, every local `R CMD check` against a stored
-  ## service-account token skipped these tests for no good reason.
+  ## absence MUST NOT trigger a skip -- only an explicit non-"release" value
+  ## should, so local runs still exercise these tests.
 
-  on_ci    <- isTRUE(as.logical(Sys.getenv("CI", "false")))
-  isAuto   <- !interactive() || on_ci
-  isSA     <- isAuto && grepl(
-                "gserviceaccount",
-                googledrive::drive_user()$emailAddress)
   notLinux <- Sys.info()[["sysname"]] != "Linux"
   verLabel <- Sys.getenv("R_VERSION_LABEL")
   notRelease <- nzchar(verLabel) && verLabel != "release"
 
-  skip <- isSA && (notLinux || notRelease)
+  skip <- notLinux || notRelease
 
   if (requireNamespace("covr", quietly = TRUE) && covr::in_covr()) {
     skip <- FALSE
   }
   testthat::skip_if(
     skip,
-    "Service-account token + non-Linux or non-release R: skipping Drive upload tests"
+    "Drive upload tests run only on the Linux/release-R runner"
   )
 }
 

--- a/tests/testthat/test-cacheGeo.R
+++ b/tests/testthat/test-cacheGeo.R
@@ -136,7 +136,7 @@ test_that("lightweight tests for code coverage", {
 
   outSF <- sf::st_as_sf(out)
 
-  skip_if_service_account_releaseVer_NotLinux()
+  skip_if_not_releaseVer_Linux()
 
   gls <- googledrive::drive_ls(cloudFolderID)
   alreadyThere <- gls$name %in% c(targetFile, targetFile2)

--- a/tests/testthat/test-cloud.R
+++ b/tests/testthat/test-cloud.R
@@ -7,8 +7,8 @@ test_that("test Cache(useCloud=TRUE, ...)", {
     needGoogleDriveAuth = TRUE,
   )
 
-  ## service accounts cannot upload to standard drive folders (no quota)
-  skip_if_service_account_releaseVer_NotLinux()
+  ## slow Drive upload round-trip: one runner only
+  skip_if_not_releaseVer_Linux()
 
   withr::local_options(
     reproducible.cachePath = file.path(tempdir(), rndstr(1, 7)),
@@ -162,8 +162,8 @@ test_that("test Cache(useCloud=TRUE, ...) with raster-backed objs -- tif and grd
     opts = list(reproducible.ask = FALSE)
   )
 
-  ## service accounts cannot upload to standard drive folders (no quota)
-  skip_if_service_account_releaseVer_NotLinux()
+  ## slow Drive upload round-trip: one runner only
+  skip_if_not_releaseVer_Linux()
 
   googleSetupForUseCloud(cloudFolderID, tmpdir, tmpCache)
 
@@ -204,8 +204,8 @@ test_that("test Cache(useCloud=TRUE, ...) with raster-backed objs -- stack", {
     opts = list(reproducible.ask = FALSE)
   )
 
-  ## service accounts cannot upload to standard drive folders (no quota)
-  skip_if_service_account_releaseVer_NotLinux()
+  ## slow Drive upload round-trip: one runner only
+  skip_if_not_releaseVer_Linux()
 
   googleSetupForUseCloud(cloudFolderID, tmpdir, tmpCache)
   withr::local_options(reproducible.cachePath = tmpdir)
@@ -227,8 +227,8 @@ test_that("test Cache(useCloud=TRUE, ...) with raster-backed objs -- brick", {
     opts = list(reproducible.ask = FALSE)
   )
 
-  ## service accounts cannot upload to standard drive folders (no quota)
-  skip_if_service_account_releaseVer_NotLinux()
+  ## slow Drive upload round-trip: one runner only
+  skip_if_not_releaseVer_Linux()
 
   googleSetupForUseCloud(cloudFolderID, tmpdir, tmpCache)
   withr::local_options(reproducible.cachePath = tmpdir)

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -13,7 +13,7 @@ test_that("dlGeneric works", {
 test_that("prepInputs reads Google Drive spreadsheets", {
   skip_on_cran()
   skip_if_not_installed("googledrive")
-  skip_if_service_account_releaseVer_NotLinux()
+  skip_if_not_releaseVer_Linux()
   testInit(needGoogleDriveAuth = TRUE)
   userDist <- skip_on_transient_http(prepInputs(
     url = "https://docs.google.com/spreadsheets/d/1fOikb83aOuLlFYIn6pjmC7Jydjcy77TH",

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -225,7 +225,7 @@ test_that("test miscellaneous fns (part 2)", {
   ras <- terra::rast(terra::ext(0, 1, 0, 1), resolution = 1, vals = 1)
   ras <- terra::writeRaster(ras, filename = tmpfile[1], overwrite = TRUE)
 
-  skip_if_service_account_releaseVer_NotLinux()
+  skip_if_not_releaseVer_Linux()
 
   gdriveLs1 <- data.frame(name = "GADM", id = "sdfsd", drive_resource = list(sdfsd = 1))
   tmpCloudFolderID <- checkAndMakeCloudFolderID(create = TRUE)

--- a/tests/testthat/test-parallel-download-remap.R
+++ b/tests/testthat/test-parallel-download-remap.R
@@ -526,6 +526,9 @@ test_that("parallel.download supersedes the deprecated streams/maxConnections", 
 })
 
 test_that("parallel.upload and parallel.cores are independent knobs", {
+  ## these assert the *unconstrained* values; R CMD check sets
+  ## _R_CHECK_LIMIT_CORES_, which caps fork counts at 2 (covered separately below)
+  withr::local_envvar(c("_R_CHECK_LIMIT_CORES_" = NA))
   withr::local_options(reproducible.parallel.upload = NULL, mc.cores = 2L)
   expect_identical(reproducible:::.parallelUpload(), 7L) # network: mc.cores must not apply
 
@@ -745,4 +748,32 @@ test_that("a dropped part is retried (not a full re-download) and still byte-ide
   expect_true(isTRUE(ok)) # retry repaired it; no fall-through to single-stream
   expect_identical(file.size(dest), info$size)
   expect_identical(unname(tools::md5sum(dest)), unname(tools::md5sum(baseFile)))
+})
+
+test_that("fork counts respect _R_CHECK_LIMIT_CORES_, download does not", {
+  ## CRAN policy allows at most 2 simultaneous processes and mclapply() errors
+  ## above that, so every *fork* count must be capped -- including the
+  ## network-bound upload one. Download concurrency is curl connections within
+  ## one process, so it is deliberately left alone.
+  withr::local_options(
+    reproducible.parallel.upload = 7L,
+    reproducible.parallel.cores = 8L,
+    reproducible.parallel.download = 48L,
+    mc.cores = NULL
+  )
+
+  withr::with_envvar(c("_R_CHECK_LIMIT_CORES_" = "TRUE"), {
+    expect_identical(reproducible:::.parallelUpload(), 2L)
+    expect_identical(reproducible:::.parallelCores(), 2L)
+    expect_identical(reproducible:::.parallelDownload(), 48L)
+  })
+
+  withr::with_envvar(c("_R_CHECK_LIMIT_CORES_" = "false"), {
+    expect_identical(reproducible:::.parallelUpload(), 7L)
+    expect_identical(reproducible:::.parallelCores(), 8L)
+  })
+
+  withr::with_envvar(c("_R_CHECK_LIMIT_CORES_" = NA), {
+    expect_identical(reproducible:::.parallelUpload(), 7L)
+  })
 })

--- a/tests/testthat/test-parallel-download-remap.R
+++ b/tests/testthat/test-parallel-download-remap.R
@@ -497,13 +497,44 @@ test_that(".parallelMaxConnections returns a positive scalar integer by default"
   expect_gte(mc, 1L)
 })
 
-test_that(".parallelMaxConnections defaults to availableCores() - 1 when parallelly is present", {
-  skip_if_not_installed("parallelly") # parallelly is Suggested, not a hard dependency
-  withr::local_options(reproducible.parallel.maxConnections = NULL)
-  expect_identical(
-    reproducible:::.parallelMaxConnections(),
-    max(1L, as.integer(parallelly::availableCores())[1] - 1L)
+test_that(".parallelMaxConnections default is NOT derived from the core count", {
+  ## It used to default to availableCores() - 1. Because availableCores() honours
+  ## `mc.cores`, a user capping CPU forking silently throttled downloads to a
+  ## single connection. Network concurrency is bounded by bandwidth and
+  ## per-connection server shaping, not by CPUs.
+  withr::local_options(
+    reproducible.parallel.maxConnections = NULL,
+    reproducible.parallel.streams = NULL,
+    reproducible.parallel.download = NULL
   )
+  expect_identical(reproducible:::.parallelMaxConnections(), 48L)
+
+  withr::local_options(mc.cores = 2L)
+  expect_identical(reproducible:::.parallelMaxConnections(), 48L)
+})
+
+test_that("parallel.download supersedes the deprecated streams/maxConnections", {
+  withr::local_options(
+    reproducible.parallel.download = NULL,
+    reproducible.parallel.maxConnections = NULL,
+    reproducible.parallel.streams = 8L
+  )
+  expect_identical(reproducible:::.parallelDownload(), 8L) # deprecated still honoured
+
+  withr::local_options(reproducible.parallel.download = 32L)
+  expect_identical(reproducible:::.parallelDownload(), 32L) # new one wins
+})
+
+test_that("parallel.upload and parallel.cores are independent knobs", {
+  withr::local_options(reproducible.parallel.upload = NULL, mc.cores = 2L)
+  expect_identical(reproducible:::.parallelUpload(), 7L) # network: mc.cores must not apply
+
+  withr::local_options(reproducible.parallel.upload = 3L)
+  expect_identical(reproducible:::.parallelUpload(), 3L)
+
+  ## CPU work, by contrast, IS still capped by mc.cores
+  withr::local_options(reproducible.parallel.cores = 8L, mc.cores = 2L)
+  expect_identical(reproducible:::.parallelCores(), 2L)
 })
 
 test_that(".parallelMaxConnections honours an explicit option", {

--- a/tests/testthat/test-prepInputsUrlTiles.R
+++ b/tests/testthat/test-prepInputsUrlTiles.R
@@ -36,7 +36,11 @@ test_that("prepInputsUrlTiles", {
   terra::crs(b) <- "epsg:3978"
   extLrg <- terra::extend(b, 1e2)
   terra::crs(extLrg) <- "epsg:3978"
-  extLrg <- terra::writeRaster(x = extLrg, filename = fn, overwrite = TRUE)
+  ## NUM_THREADS=1: a default write allocates a GDAL thread pool sized to the
+  ##   core count that is never released, which would make the tiling fork()
+  ##   unsafe and send it down the serial fallback instead of the path we test
+  extLrg <- terra::writeRaster(x = extLrg, filename = fn, overwrite = TRUE,
+                               gdal = "NUM_THREADS=1")
   d <- googledrive::drive_upload(fn, path = googledrive::as_id(urlForTiles))
 
   mess1 <- capture_messages(
@@ -65,7 +69,11 @@ test_that("prepInputsUrlTiles", {
   terra::crs(b) <- "epsg:3978"
   extLrg <- terra::extend(b, 1e2)
   terra::crs(extLrg) <- "epsg:3978"
-  extLrg <- terra::writeRaster(x = extLrg, filename = fn, overwrite = TRUE)
+  ## NUM_THREADS=1: a default write allocates a GDAL thread pool sized to the
+  ##   core count that is never released, which would make the tiling fork()
+  ##   unsafe and send it down the serial fallback instead of the path we test
+  extLrg <- terra::writeRaster(x = extLrg, filename = fn, overwrite = TRUE,
+                               gdal = "NUM_THREADS=1")
   d <- googledrive::drive_upload(fn, path = googledrive::as_id(urlForTiles))
   b1 <- prepInputs(url = d$id, to = b, doUploads = TRUE, numTiles = c(2,2))
   withr::local_options(reproducible.prepInputsUrlTiles = NULL)

--- a/tests/testthat/test-prepInputsUrlTiles.R
+++ b/tests/testthat/test-prepInputsUrlTiles.R
@@ -3,6 +3,12 @@ test_that("prepInputsUrlTiles", {
   ## Deliberately NOT skip_on_ci(): skip_if_not_releaseVer_Linux() below confines
   ## this to the single Linux/release leg, so it runs on CI without racing
   ## against the other legs on the same Drive folder.
+  ##
+  ## Coverage runs are excluded, though: skip_if_not_releaseVer_Linux() bypasses
+  ## itself under covr, and this test forks and does a Drive round-trip, which is
+  ## exactly what coverage runs should not be carrying.
+  skip_if(isTRUE(requireNamespace("covr", quietly = TRUE) && covr::in_covr()),
+          "excluded from coverage runs")
 
   testInit(needGoogleDriveAuth = TRUE,
            c("terra", "googledrive"),

--- a/tests/testthat/test-prepInputsUrlTiles.R
+++ b/tests/testthat/test-prepInputsUrlTiles.R
@@ -51,16 +51,15 @@ test_that("prepInputsUrlTiles", {
                                gdal = "NUM_THREADS=1")
   d <- googledrive::drive_upload(fn, path = googledrive::as_id(urlForTiles))
 
-  mess1 <- capture_messages(
+  ## wrapped to keep the (very chatty) download/tiling output out of the test log
+  capture_messages(
     warns <- capture_warnings(
       a1 <- prepInputs(url = d$id, to = b, doUploads = TRUE, numTiles = c(2,2))
     )
   )
   expect_is(a1, "SpatRaster")
   withr::local_options(reproducible.prepInputsUrlTiles = NULL)
-  mess2 <- capture_messages(a2 <- prepInputs(url = d$id, to = b, useCache = FALSE))
-  cat(mess2, file = "~/tmp/mess2.txt")
-  cat(mess1, file = "~/tmp/mess1.txt")
+  capture_messages(a2 <- prepInputs(url = d$id, to = b, useCache = FALSE))
   a1b <- .wrap(a1)
   a2b <- .wrap(a2)
   expect_is(a2, "SpatRaster")
@@ -87,7 +86,6 @@ test_that("prepInputsUrlTiles", {
   withr::local_options(reproducible.prepInputsUrlTiles = NULL)
   b2 <- prepInputs(url = d$id, to = b)
   testthat::expect_equivalent(b1, b2)
-  save(a1, a2, b1, b2, file = "~/tmp/objs.rda")
   gls <- googledrive::drive_ls(urlForTiles)
 
   # clean up

--- a/tests/testthat/test-prepInputsUrlTiles.R
+++ b/tests/testthat/test-prepInputsUrlTiles.R
@@ -1,6 +1,8 @@
 test_that("prepInputsUrlTiles", {
   skip_on_cran()
-  skip_on_ci()
+  ## Deliberately NOT skip_on_ci(): skip_if_not_releaseVer_Linux() below confines
+  ## this to the single Linux/release leg, so it runs on CI without racing
+  ## against the other legs on the same Drive folder.
 
   testInit(needGoogleDriveAuth = TRUE,
            c("terra", "googledrive"),

--- a/tests/testthat/test-prepInputsUrlTiles.R
+++ b/tests/testthat/test-prepInputsUrlTiles.R
@@ -19,7 +19,7 @@ test_that("prepInputsUrlTiles", {
                        reproducible.inputPath = tmpdir,
                        mc.cores = 2L)# used by tiles
   outerDriveFolder <- "1KuBraAYnBpyxl3Nf0udc05fQlTPds2xY"
-  skip_if_service_account_releaseVer_NotLinux()
+  skip_if_not_releaseVer_Linux()
 
 
 

--- a/tests/testthat/test-tileGridOffline.R
+++ b/tests/testthat/test-tileGridOffline.R
@@ -18,9 +18,12 @@ test_that("makeTileGridFromGADMcode falls back to a fixed extent when gadm retur
   skip_if_not_installed("geodata")
   testInit("terra")
 
-  out <- testthat::with_mocked_bindings(
-    makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
-    gadm = function(...) NULL, .package = "geodata")
+  ## the fallback warns, because it silently changes which area gets tiled
+  expect_warning(
+    out <- testthat::with_mocked_bindings(
+      makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
+      gadm = function(...) NULL, .package = "geodata"),
+    .message$gadmFallbackTxt, fixed = TRUE)
 
   ## The contract callers rely on: a usable grid, not an error.
   expect_type(out, "list")
@@ -39,10 +42,45 @@ test_that("makeTileGridFromGADMcode fallback also handles the 'NULL' string", {
 
   ## Cache() can hand back the literal string "NULL" rather than NULL, which is
   ## why the guard tests for both. Same fallback either way.
-  out <- testthat::with_mocked_bindings(
-    makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
-    gadm = function(...) "NULL", .package = "geodata")
+  expect_warning(
+    out <- testthat::with_mocked_bindings(
+      makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
+      gadm = function(...) "NULL", .package = "geodata"),
+    .message$gadmFallbackTxt, fixed = TRUE)
 
   expect_s4_class(out$tileGrid, "SpatVector")
   expect_equal(nrow(out$tileGrid), 4)
+})
+
+test_that("a gadm() error also falls back, with a warning, rather than propagating", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("geodata")
+  testInit("terra")
+
+  ## The case that broke CI: no geodata path configured, so gadm() errors
+  ## outright rather than returning NULL.
+  expect_warning(
+    out <- testthat::with_mocked_bindings(
+      makeTileGridFromGADMcode("CAN", numTiles = c(2, 2), crs = "EPSG:3347"),
+      gadm = function(...) stop("you need to provide a path"),
+      .package = "geodata"),
+    .message$gadmFallbackTxt, fixed = TRUE)
+
+  expect_s4_class(out$tileGrid, "SpatVector")
+  expect_equal(nrow(out$tileGrid), 4)
+})
+
+test_that(".gadmPath prefers persistence over tempdir", {
+  skip_if_not_installed("geodata")
+
+  ## with a shared-downloads location set, downloads should land there, not in
+  ## the session temp default
+  shared <- file.path(tempdir(), paste0("shared", sample(1e6, 1)))
+  withr::local_options(reproducible.destinationPathShared = shared,
+                       reproducible.inputPaths = NULL)
+  p <- testthat::with_mocked_bindings(
+    reproducible:::.gadmPath(),
+    geodata_path = function(...) "", .package = "geodata")
+  expect_true(startsWith(normalizePath(p, mustWork = FALSE),
+                         normalizePath(shared, mustWork = FALSE)))
 })


### PR DESCRIPTION
Fixes an indefinite hang in `prepInputs(numTiles = )`, and separates the
parallelism options by the resource they actually govern.

## The deadlock

`test-prepInputsUrlTiles.R` hung forever on a many-core machine. Root cause:

A default `terra::writeRaster()` allocates a GDAL worker pool of **one thread
per core** (80 here). That pool is never released — not by `gc(full = TRUE)`,
not when the `SpatRaster` is dropped, not when idle. `fork()` carries only the
calling thread into the child, so `mclapply()` in `tile_raster_write_auto()`
produced children holding GDAL mutexes that no surviving thread could release:
parent parked in `poll_schedule_timeout`, children in `futex_do_wait`, forever.

Attribution is from `strace -k -e trace=clone`, per-clone creator:

| creator | threads |
|---|---|
| `libgdal` (`GDALRegister_COG` + `CPLCreateJoinableThread`) | 80 |
| `libopenblasp` | 63 (baseline) |
| `libcurl-gnutls` | 37 |

Ruled out as the source along the way: OpenBLAS, OpenMP/data.table, GDAL config,
and this package's own parallel-download pool (`streams=1, maxCon=2` gave a
byte-identical thread timeline and still deadlocked).

Only the per-call `gdal = "NUM_THREADS=1"` creation option prevents the pool.
`GDAL_NUM_THREADS` (env and `setGDALconfig`) and `terraOptions(threads=)` are
both ignored, and priming the pool small does not hold. This is arguably a
terra/GDAL bug and will be reported upstream; meanwhile:

* the writes this package controls pass `NUM_THREADS=1`, so it no longer
  poisons its own forks
* both `mclapply` sites are guarded: a process already carrying more threads
  than the machine has cores is holding such a pool, so tile serially rather
  than hang, with a message saying how to keep it parallel. **The clean path
  still forks** — this is a fallback, not a new default.

## `mc.cores` was throttling the network

`.parallelMaxConnections()` defaulted to `parallelly::availableCores() - 1`, and
`availableCores()` honours `mc.cores`. So capping CPU forking silently cut
downloads from 79 concurrent connections to **1**, and Drive uploads from 7 to 2.

Three options, one per resource:

| option | governs | default |
|---|---|---|
| `reproducible.parallel.cores` | CPU work (tiling) | `freeCores()`, capped by `mc.cores` |
| `reproducible.parallel.download` | ranged download connections | `48` |
| `reproducible.parallel.upload` | concurrent Drive uploads | `7` |

`parallel.streams` / `parallel.maxConnections` are deprecated but still
honoured; the new options win when both are set. `parallel.cores = 1` also
disables the `showCache()` pre-warm fork.

## Also here

* Drive upload tests gated on the Linux/release runner. The old helper only
  skipped when the credential *was* a service account, so since the move away
  from those it was a no-op and these slow upload round-trips were running on
  every CI leg, able to race on the same Drive folder.
* Moves the fork-safety helpers below `numCoresToUse()`: they had landed between
  its roxygen block and its definition, which on the next `roxygenise()` would
  have exported `.parallelCores()` and dropped `numCoresToUse()` from NAMESPACE.

## Verification

* `test-prepInputsUrlTiles.R` — now **forks** and passes 5/5 where it hung
* `test-parallel-download-remap.R` — 110 assertions, 0 failures (one test
  asserted the old core-derived default, i.e. encoded the bug; replaced with one
  asserting the default is *not* core-derived and that `mc.cores` doesn't move it)
* postProcess suites — 142 assertions, 0 failures
* `test-cache.R` 303, `test-showCacheAsyncInstall.R` 19 — 0 failures

`R CMD check --as-cran` has not been re-run since these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnN9Y5MimmzomaCCuFRPfS