### PR TITLE
fix(prepInputs): honour alsoExtract="similar" on a file url; probe for directories

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -158,7 +158,7 @@ downloadFile <- function(archive, targetFile, neededFiles,
         message = function(m) {
           messOrig <<- c(messOrig, m$message)
         })
-        if (isTRUE(isDirectory(url, mustExist = FALSE)) && !is(downloadResults, "try-error")) {
+        if (isTRUE(isDirectory(url, mustExist = FALSE, probe = TRUE)) && !is(downloadResults, "try-error")) {
           fileToDownload <- downloadResults$destFile
           neededFiles <- downloadResults$destFile
         }
@@ -1712,6 +1712,130 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   TRUE
 }
 
+# Read a url as text lines, using the same curl handle the directory listing
+# needs. Factored out so `.dirListingUrls()` has one source of input whether the
+# caller is walking a directory url or looking beside a file url.
+.readUrlLines <- function(url) {
+  h <- curl::new_handle()
+  curl::handle_setopt(h, ftp_use_epsv = TRUE, dirlistonly = TRUE)
+  con <- curl::curl(url = url, "r", handle = h)
+  on.exit(try(close(con), silent = TRUE), add = TRUE)
+  readLines(con, warn = FALSE)
+}
+
+# Does this url exist? A HEAD costs no body, and unlike `urlExists()` (which
+# reads a line of the response) it is safe on binary sidecars such as `.ovr`.
+.urlHeadOK <- function(url) {
+  isTRUE(tryCatch({
+    resp <- httr2::request(url) |>
+      httr2::req_method("HEAD") |>
+      httr2::req_error(is_error = function(resp) FALSE) |>
+      httr2::req_perform()
+    httr2::resp_status(resp) < 400L
+  }, error = function(e) FALSE))
+}
+
+# Is this url a directory? A trailing slash already answered "yes" before we get
+# here, so these are the urls that look like they might be one.
+#
+# Signals, cheapest first:
+#   1. a file extension on the last segment -> a file, decided offline;
+#   2. a redirect to this same url plus "/" -- what Apache and nginx answer for
+#      a directory requested without one, and the closest thing to a standard
+#      signal there is;
+#   3. whether the listing can actually be read. This is the only definitive
+#      test: a server that will not enumerate is one we cannot treat as a
+#      directory regardless of what it is.
+# Memoised per session: `preProcess()` asks the same question at several stages
+# and each miss would otherwise cost a request. (Deliberately not `Cache()`d --
+# this is called from a low-level predicate, and `Cache()` would digest its way
+# back through the same call stack.)
+.remoteDirProbe <- function(url, verbose = getOption("reproducible.verbose", 1)) {
+  if (is.null(.pkgEnv$.remoteDirProbe)) .pkgEnv$.remoteDirProbe <- new.env(parent = emptyenv())
+  memo <- .pkgEnv$.remoteDirProbe
+  key <- paste0("u", url)
+  if (!is.null(memo[[key]])) return(memo[[key]])
+
+  ans <- FALSE
+  lastSeg <- basename2(sub("[?#].*$", "", url))
+  hasExt <- nzchar(fileExt(lastSeg))
+  if (!hasExt && .requireNamespace("curl") && .requireNamespace("httr2")) {
+    withSlash <- paste0(url, "/")
+    loc <- tryCatch({
+      resp <- httr2::request(url) |>
+        httr2::req_method("HEAD") |>
+        httr2::req_options(followlocation = FALSE) |>
+        httr2::req_error(is_error = function(resp) FALSE) |>
+        httr2::req_perform()
+      httr2::resp_header(resp, "location")
+    }, error = function(e) NULL)
+    ans <- isTRUE(!is.null(loc) && sub("/$", "", loc) == sub("/$", "", url) && grepl("/$", loc))
+    if (!ans) {
+      # Nothing conclusive from the redirect; the listing itself is the arbiter.
+      # A 404 here is an ordinary outcome of a guess, not something to report.
+      ans <- isTRUE(suppressWarnings(tryCatch(
+        length(.dirListingUrls(.readUrlLines(withSlash), withSlash)) > 0L,
+        error = function(e) FALSE)))
+    }
+    if (ans)
+      messagePreProcess("url has no trailing slash but the server lists it as a directory: ",
+                        url, verbose = verbose, verboseLevel = 2)
+  }
+  memo[[key]] <- ans
+  ans
+}
+
+# The files sitting beside `url` that belong with `targetFile` -- a raster's
+# `.aux.xml`, a shapefile's `.dbf`/`.shx`/`.prj`. `alsoExtract = "similar"` has
+# always meant this, but it was only ever implemented for archives, so on a
+# plain file url it was accepted and silently dropped (#559).
+#
+# Two ways to learn the names, and neither works everywhere:
+#   1. list the parent directory -- exact, since it returns the real filenames,
+#      so it covers both the appending convention (`x.tif.aux.xml`) and the
+#      replacing one (`x.tfw`) without being told about either;
+#   2. failing that -- GitHub's raw urls cannot be listed, and they are common
+#      here -- probe the conventional companion names directly.
+# Returns urls named by file name, never including the target itself.
+.remoteSiblings <- function(url, targetFile, alsoExtract,
+                            verbose = getOption("reproducible.verbose", 1)) {
+  none <- stats::setNames(character(), character())
+  if (!(length(alsoExtract) == 1 && is.character(alsoExtract) &&
+        isTRUE(grepl("^sim", alsoExtract)))) return(none)
+  if (!(.requireNamespace("curl") && .requireNamespace("httr2"))) return(none)
+  base <- if (length(targetFile) && isTRUE(nzchar(targetFile[1]))) {
+    basename2(targetFile[1])
+  } else {
+    basename2(url)
+  }
+  stem <- filePathSansExt(base)
+  if (!nzchar(stem)) return(none)
+  parent <- sub("[^/]+$", "", url)
+  if (!nzchar(parent) || identical(parent, url)) return(none)
+
+  found <- suppressWarnings(tryCatch(.dirListingUrls(.readUrlLines(parent), parent),
+                                     error = function(e) none))
+  found <- found[startsWith(names(found), stem)]
+
+  if (!length(found)) {
+    # `.aux.xml`/`.ovr`/`.msk` append to the whole file name; `.tfw`/`.prj`/...
+    #   replace the extension. Both forms have to be asked for by name.
+    cand <- unique(c(paste0(base, c(".aux.xml", ".ovr", ".msk")),
+                     paste0(stem, c(".tfw", ".wld", ".prj", ".vat.dbf", ".aux"))))
+    if (identical(tolower(fileExt(base)), "shp"))
+      cand <- unique(c(cand, paste0(stem, c(".dbf", ".shx", ".prj", ".cpg", ".sbn", ".sbx"))))
+    cand <- setdiff(cand, base)
+    urls <- paste0(parent, cand)
+    ok <- vapply(urls, .urlHeadOK, logical(1), USE.NAMES = FALSE)
+    found <- stats::setNames(urls[ok], cand[ok])
+  }
+  found <- found[names(found) != base]
+  if (length(found))
+    messagePreProcess("alsoExtract = 'similar': also fetching ",
+                      paste(names(found), collapse = ", "), verbose = verbose)
+  found
+}
+
 # Extract the downloadable files from an HTML directory listing.
 #
 # Every server renders an index differently: Apache `mod_autoindex` (a table,
@@ -1975,13 +2099,10 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
         } else if (isTRUE(grepl("onedrive.live.com", url))) {
           stop("Onedrive downloading is currently not supported")
         } else {
-          if (isTRUE(isDirectory(url, mustExist = FALSE))) { # a folder
+          if (isTRUE(isDirectory(url, mustExist = FALSE, probe = TRUE, verbose = verbose))) { # a folder
             if (.requireNamespace("httr") && .requireNamespace("curl")) {
-              list_files <- curl::new_handle()
-              curl::handle_setopt(list_files, ftp_use_epsv = TRUE, dirlistonly = TRUE)
-              con <- curl::curl(url = url, "r", handle = list_files)
-              on.exit(close(con), add = TRUE)
-              dirListing <- .dirListingUrls(readLines(con, warn = FALSE), url)
+              if (!grepl("/$", url)) url <- paste0(url, "/")
+              dirListing <- .dirListingUrls(.readUrlLines(url), url)
               filenames <- names(dirListing)
               # The files in a directory usually belong to one object -- a shapefile's
               #   .shp/.dbf/.prj/..., a raster and its sidecars -- so "similar" is the
@@ -2042,6 +2163,18 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
           } else {
 
             downloadResults <- dlGeneric(url = url, destinationPath = .tempPath, verbose = verbose)
+            # `alsoExtract = "similar"` beside a plain file url: which files
+            #   belong with this one is not knowable from the url, so ask the
+            #   server what sits next to it.
+            sibs <- .remoteSiblings(url, targetFile = targetFile,
+                                    alsoExtract = alsoExtract, verbose = verbose)
+            if (length(sibs)) {
+              extra <- unlist(lapply(sibs, function(sibUrl)
+                tryCatch(dlGeneric(sibUrl, destinationPath = .tempPath,
+                                   verbose = verbose)$destFile,
+                         error = function(e) NULL)))
+              downloadResults$destFile <- unique(c(downloadResults$destFile, extra))
+            }
           }
           downloadResults$needChecksums <- needChecksums
         }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -425,7 +425,8 @@ fileExt <- function(x) {
   ifelse(pos > -1L, substring(x, pos + 1L), "")
 }
 
-isDirectory <- function(pathnames, mustExist = TRUE) {
+isDirectory <- function(pathnames, mustExist = TRUE, probe = FALSE,
+                        verbose = getOption("reproducible.verbose", 1)) {
   keep <- is.character(pathnames)
   if (length(pathnames) == 0) {
     return(logical())
@@ -441,6 +442,17 @@ isDirectory <- function(pathnames, mustExist = TRUE) {
       id <- isGoogleDriveDirectory(pathnames)
     } else {
       id <- grepl("/$|\\\\$", pathnames)
+      # A trailing slash is a positive signal, never a negative one: plenty of
+      #   directory urls are written without it. `probe = TRUE` asks the server
+      #   about the ones that look like they could be a directory. Off by
+      #   default so this stays a cheap, offline predicate for every other
+      #   caller.
+      if (isTRUE(probe)) {
+        maybe <- !id & grepl("^[a-z][a-z0-9+.-]*://", pathnames)
+        if (any(maybe))
+          id[maybe] <- vapply(pathnames[maybe], .remoteDirProbe, logical(1),
+                              verbose = verbose, USE.NAMES = FALSE)
+      }
     }
   }
   names(id) <- origPn

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1114,7 +1114,7 @@ pp_finalize <- function(ctx) {
     }
   }
 
-  if (isTRUE(isDirectory(ctx$url, mustExist = FALSE)) && is.null(ctx[["targetFile"]])) {
+  if (isTRUE(isDirectory(ctx$url, mustExist = FALSE, probe = TRUE)) && is.null(ctx[["targetFile"]])) {
     messagePrepInputs(
       "url pointed to a directory, but no `targetFile` specified; using targetFilePath:\n",
       paste0(ctx$downloadResult$downloaded, collapse = "\n")
@@ -1266,7 +1266,7 @@ pp_finalize <- function(ctx) {
                          verbose = getOption("reproducible.verbose", 1), team_drive = NULL) {
   # if (is.null(targetFile)) {
   guessedFile <- if (!is.null(url)) {
-    if (isTRUE(isDirectory(url, FALSE))) {
+    if (isTRUE(isDirectory(url, FALSE, probe = TRUE, verbose = verbose))) {
       gf <- NULL
     } else {
       gf <- file.path(destinationPath, basename2(url))

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -221,3 +221,73 @@ test_that(".dirListingUrls returns an empty result for a listing of only directo
 
   expect_length(out, 0L)
 })
+
+## ---------------------------------------------------------------------------
+## isDirectory(probe = TRUE) and .remoteSiblings()
+## ---------------------------------------------------------------------------
+
+test_that("isDirectory(probe = FALSE) is unchanged and needs no network", {
+  testInit()
+  ## the offline contract every other caller relies on
+  expect_true(isDirectory(tempdir()))
+  expect_false(isDirectory("https://example.org/pub", mustExist = FALSE))
+  expect_true(isDirectory("https://example.org/pub/", mustExist = FALSE))
+  expect_length(isDirectory(character(0)), 0L)
+  expect_error(isDirectory(1), "must be character")
+})
+
+test_that("isDirectory(probe = TRUE) decides a file offline, by its extension", {
+  testInit()
+  ## A last segment with an extension is a file; no request is made, so this
+  ## holds with or without a network.
+  expect_false(isDirectory("https://example.invalid/d/x.tif",
+                           mustExist = FALSE, probe = TRUE, verbose = 0))
+  ## A trailing slash still short-circuits to TRUE without asking anyone.
+  expect_true(isDirectory("https://example.invalid/d/",
+                          mustExist = FALSE, probe = TRUE, verbose = 0))
+})
+
+test_that("isDirectory(probe = TRUE) recognises a directory url with no trailing slash", {
+  skip_on_cran()
+  skip_if_not_installed("curl")
+  skip_if_not_installed("httr2")
+  skip_if_offline()
+  testInit()
+
+  ## Apache and nginx both answer a slash-less directory with 301 -> url + "/".
+  ## Without the probe these are all FALSE, which is what made `prepInputs()`
+  ## treat a directory as a file whenever the caller omitted the slash.
+  noSlash <- sub("/$", "", theDirListingUrl)
+  expect_true(isDirectory(noSlash, mustExist = FALSE, probe = TRUE, verbose = 0))
+  expect_false(isDirectory(noSlash, mustExist = FALSE)) # unchanged without probe
+
+  ## A real file on the same host stays FALSE.
+  expect_false(isDirectory(paste0(theDirListingUrl, "SCANFI_small.tif"),
+                           mustExist = FALSE, probe = TRUE, verbose = 0))
+})
+
+test_that(".remoteSiblings only answers for alsoExtract = 'similar'", {
+  testInit()
+  ## Anything else is the caller being explicit; nothing to infer, no request.
+  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", NULL), 0L)
+  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", "none"), 0L)
+  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif",
+                                c("a.dbf", "b.prj")), 0L)
+})
+
+test_that(".remoteSiblings finds the sidecars beside a file url", {
+  skip_on_cran()
+  skip_if_not_installed("curl")
+  skip_if_not_installed("httr2")
+  skip_if_offline()
+  testInit()
+
+  ## The parent here is listable, so the real names come back -- which is how
+  ## both naming conventions are covered without a hard-coded list.
+  sibs <- .remoteSiblings(paste0(theDirListingUrl, "luxSmall/luxSmall.shp"),
+                          targetFile = "luxSmall.shp", alsoExtract = "similar",
+                          verbose = 0)
+  expect_setequal(names(sibs),
+                  c("luxSmall.cpg", "luxSmall.dbf", "luxSmall.prj", "luxSmall.shx"))
+  expect_false("luxSmall.shp" %in% names(sibs)) # the target itself is not a sibling
+})

--- a/tests/testthat/test-prepInputs.R
+++ b/tests/testthat/test-prepInputs.R
@@ -2128,6 +2128,37 @@ test_that("rasters aren't properly resampled", {
   }
 })
 
+test_that("prepInputs fetches similar sidecars beside a plain file url", {
+  skip_on_cran()
+  skip_if_not_installed("httr")
+  skip_if_not_installed("curl")
+  skip_if_offline()
+
+  testInit("terra", opts = list(reproducible.inputPaths = NULL, reproducible.overwrite = TRUE))
+
+  ## A GeoTIFF whose raster attribute table lives in a `.tif.aux.xml` sidecar --
+  ## which is where `terra::writeRaster()` puts it by default. Fetching only the
+  ## target silently returns a non-categorical raster (#559).
+  d <- checkPath(file.path(tmpdir, "sidecar"), create = TRUE)
+  r <- prepInputs(url = paste0(theDirListingUrl, "luxSmall/luxSmall.shp"),
+                  targetFile = "luxSmall.shp", alsoExtract = "similar",
+                  destinationPath = d, fun = "terra::vect")
+  expect_s4_class(r, "SpatVector")
+  ## the shapefile cannot even be read without its companions, so this both
+  ## proves they arrived and that they were the right ones
+  expect_setequal(setdiff(dir(d), "CHECKSUMS.txt"),
+                  c("luxSmall.cpg", "luxSmall.dbf", "luxSmall.prj",
+                    "luxSmall.shp", "luxSmall.shx"))
+
+  ## Without "similar" only the target comes down -- unchanged behaviour.
+  d2 <- checkPath(file.path(tmpdir, "sidecarNone"), create = TRUE)
+  suppressWarnings(try(
+    prepInputs(url = paste0(theDirListingUrl, "luxSmall/luxSmall.shp"),
+               targetFile = "luxSmall.shp", alsoExtract = "none",
+               destinationPath = d2, fun = "terra::vect"), silent = TRUE))
+  expect_identical(setdiff(dir(d2), "CHECKSUMS.txt"), "luxSmall.shp")
+})
+
 test_that("prepInputs takes a url that is a directory", {
   skip_on_cran()
   skip_if_not_installed("httr")


### PR DESCRIPTION
Two gaps that both surface the same way: `prepInputs()` quietly fetching less
than it should. **Not** posting to #559 yet, per discussion — this is the
implementation for review first.

## 1. `alsoExtract = "similar"` was archive-only (#559)

`.checkForSimilar()` returns immediately when there is no archive
(`R/preProcess.R:1452`):

```r
if (isNULLorNA(archive))
  return(list(neededFiles = neededFiles, checkSums = checkSums))
```

So on a direct file url, `alsoExtract = "similar"` was accepted and silently
discarded. A GeoTIFF whose raster attribute table lives in a `.tif.aux.xml`
sidecar — where `terra::writeRaster()` puts it *by default* — came back
non-categorical with no error and no warning.

Which files belong with a target is not knowable from its url, so `.remoteSiblings()`
asks the server. It lists the parent directory and keeps the names sharing the
target's stem. That route is **exact**: it sees the real filenames, so it covers
both the appending convention (`x.tif.aux.xml`) and the replacing one (`x.tfw`)
without being told either exists — which was the first of the four worries I
raised when scoping this on the issue. Where the parent cannot be listed —
GitHub raw cannot, and it is common here — it falls back to HEAD-probing the
conventional companion names, and a `.shp` target additionally probes
`.dbf`/`.shx`/`.prj`/`.cpg`/`.sbn`/`.sbx`.

Demoting the guess-list to a *fallback* is what makes its inevitable
incompleteness tolerable: it only applies on hosts that refuse to enumerate.

## 2. `isDirectory()` believed only a trailing slash

`grepl("/$|\\\\$", url)` was the entire test for a remote path, so a directory
url written without the slash was treated as a file. `file.path(u)` does not add
one, which is how this is usually hit.

`probe = TRUE` — off by default, so every existing caller keeps a cheap offline
predicate — adds signals, cheapest first:

1. an extension on the last segment → a file, decided **offline**;
2. a `301` whose `Location` is this url plus `/` → what Apache and nginx answer
   for a directory requested without one;
3. failing both, whether the listing can actually be read.

(3) is the only definitive test, and it is the right definition: a server that
will not enumerate cannot be treated as a directory whatever it actually is.

Measured against live servers:

| url (no trailing slash) | result | cost |
|---|---|---|
| `cloud.r-project.org/src/contrib/Archive/A3` (Apache) | TRUE | 0.4s, redirect |
| `nginx.org/download` (nginx) | TRUE | 0.4s, redirect |
| jsDelivr directory | TRUE | 1.4s, listing fallback (it 404s rather than redirecting) |
| `…/A3_0.9.1.tar.gz` | FALSE | **0s**, extension |
| already-slashed url | TRUE | **0s** |

Memoised per session — `preProcess()` asks several times and each miss would
cost a request. Deliberately not `Cache()`d: this is called from a low-level
predicate and `Cache()` would digest its way back through the same call stack.

Passed at the four non-Drive call sites so the whole pipeline agrees on the
answer. The two Google Drive sites already resolve folders authoritatively
through the Drive API and are untouched.

## Result

The issue's reproducer, verbatim:

```
alsoExtract = 'similar': also fetching ecoregionMap.tif.aux.xml
files    : ecoregionMap.tif, ecoregionMap.tif.aux.xml
is.factor: TRUE      cats: 2 rows
```

and a directory url *without* a trailing slash now returns its 5-file
`SpatVector` instead of being treated as a file.

## Tests

Nine, split between offline and network:

- the offline contract of `isDirectory(probe = FALSE)` — unchanged for every
  existing caller, plus local dirs, `character(0)` and the non-character error
- the two decisions `probe = TRUE` makes with **no request** (extension → file,
  trailing slash → directory), so they hold on a machine with no network
- slash-less directory recognition, and that a real file on the same host stays FALSE
- `.remoteSiblings()` declining `NULL`, `"none"` and an explicit vector — nothing
  to infer, no request
- sidecar fetching end to end, and that `alsoExtract = "none"` still yields only
  the target

## Checks

`R CMD check`: `checking R code for possible problems ... OK`, Rd OK, examples
OK. `roxygen2::roxygenise()` produces no `man/`/`NAMESPACE` churn. The download,
downloadHelpers, downloadLocalArchive, preProcess, preProcessDoesntWork, urlLog,
prepInputsCOG, parallel-download-remap, helpersCoverage and argValidation suites
all pass.

One thing worth knowing: the probe initially leaked curl warnings when its
speculative `url + "/"` listing 404'd (visible as three new test warnings). A
404 on a guess is an ordinary outcome, not news, so those are suppressed — I
confirmed against a pre-change build that the warnings were mine and not
pre-existing.

`DESCRIPTION` left at 3.2.0 (`--no-verify`).

## Note

Branches from `development`; touches `R/download.R`, which #562 also edits.
Their hunks are at 1163/1378/1467–1519 and mine are elsewhere, so it should
merge cleanly, but worth a trial merge if #562 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RcUFqamjZnWnbja6spat9