### PR TITLE
feat(prepInputs): "similar" by default beside a url; list GitHub via a CDN index

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -1861,6 +1861,15 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
     return(none)
 
   listFrom <- .listableParent(parent)
+  if (!identical(listFrom, parent)) {
+    # A request to a host the caller did not name. Say so, and record it: the
+    #   url log is the provenance record of what this session touched, and an
+    #   access that does not appear in it is exactly the kind of thing the log
+    #   exists to make visible.
+    messagePreProcess("listing ", parent, " via ", listFrom, verbose = verbose,
+                      verboseLevel = 2)
+    .logUrlAccess("prepInputs (directory index)", url = listFrom)
+  }
   found <- suppressWarnings(tryCatch(.dirListingUrls(.readUrlLines(listFrom), listFrom),
                                      error = function(e) none))
   found <- found[.similarTo(names(found), base)]
@@ -1889,9 +1898,11 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
     found <- stats::setNames(paste0(parent, cand)[ok], cand[ok])
   }
   found <- found[names(found) != base]
-  if (length(found))
+  if (length(found)) {
     messagePreProcess("alsoExtract = 'similar': also fetching ",
                       paste(names(found), collapse = ", "), verbose = verbose)
+    for (sibUrl in unname(found)) .logUrlAccess("prepInputs (similar)", url = sibUrl)
+  }
   found
 }
 

--- a/R/download.R
+++ b/R/download.R
@@ -1723,6 +1723,38 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   readLines(con, warn = FALSE)
 }
 
+# Which of `nms` are "similar" to `base` -- the same file, in the sense that
+# matters to GIS formats. Two conventions, and neither implies the other:
+#   * the extension is replaced  -- luxSmall.shp -> luxSmall.dbf, x.tif -> x.tfw
+#   * a suffix is appended       -- x.tif -> x.tif.aux.xml
+# Deliberately NOT a prefix match on the stem: that makes `species.csv` claim
+# `speciesEcoregion.csv` and `speciesLayers.tif`, which are different data.
+.similarTo <- function(nms, base) {
+  startsWith(nms, paste0(base, ".")) | filePathSansExt(nms) %in% filePathSansExt(base)
+}
+
+# GitHub cannot list a directory in any form a link parser can read: the file
+# browser at github.com/OWNER/REPO/tree/... is a React app whose markup holds no
+# usable hrefs, and raw.githubusercontent 404s on a directory outright. Its
+# content is enumerable through the jsDelivr CDN, though, so translate a raw url
+# into that view *for listing only*. The names that come back are then used
+# against the caller's own url, so files are still fetched from the host they
+# asked for -- jsDelivr is consulted as an index, never substituted as a source.
+#
+# Returns `url` unchanged when it is not a GitHub raw url.
+.listableParent <- function(url) {
+  pats <- c(
+    "^https?://(?:www[.])?github[.]com/([^/]+)/([^/]+)/raw/(?:refs/(?:heads|tags)/)?([^/]+)/(.*)$",
+    "^https?://raw[.]githubusercontent[.]com/([^/]+)/([^/]+)/(?:refs/(?:heads|tags)/)?([^/]+)/(.*)$"
+  )
+  for (pat in pats) {
+    m <- regmatches(url, regexec(pat, url))[[1]]
+    if (length(m) == 5L)
+      return(paste0("https://cdn.jsdelivr.net/gh/", m[2], "/", m[3], "@", m[4], "/", m[5]))
+  }
+  url
+}
+
 # Does this url exist? A HEAD costs no body, and unlike `urlExists()` (which
 # reads a line of the response) it is safe on binary sidecars such as `.ovr`.
 .urlHeadOK <- function(url) {
@@ -1800,8 +1832,16 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 .remoteSiblings <- function(url, targetFile, alsoExtract,
                             verbose = getOption("reproducible.verbose", 1)) {
   none <- stats::setNames(character(), character())
-  if (!(length(alsoExtract) == 1 && is.character(alsoExtract) &&
-        isTRUE(grepl("^sim", alsoExtract)))) return(none)
+  # "similar" is the default beside a file url. Unlike an archive -- where an
+  #   unspecified `alsoExtract` means "extract everything", because the archive
+  #   bounds what "everything" is -- a url has no such bound, so the useful
+  #   reading of "unspecified" here is the target and whatever belongs with it.
+  #   `NA` still means the target alone, and an explicit vector still means
+  #   exactly those files.
+  similar <- length(alsoExtract) == 0 ||
+    (length(alsoExtract) == 1 && is.character(alsoExtract) &&
+       isTRUE(grepl("^sim", alsoExtract)))
+  if (!similar) return(none)
   if (!(.requireNamespace("curl") && .requireNamespace("httr2"))) return(none)
   base <- if (length(targetFile) && isTRUE(nzchar(targetFile[1]))) {
     basename2(targetFile[1])
@@ -1812,22 +1852,39 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
   if (!nzchar(stem)) return(none)
   parent <- sub("[^/]+$", "", url)
   if (!nzchar(parent) || identical(parent, url)) return(none)
+  # Nothing to look for, so do not spend a request looking. This is a deny-list
+  #   rather than an allow-list on purpose: a format missing from it is still
+  #   searched, and the cost of that mistake is latency, not a lost file.
+  if (tolower(fileExt(base)) %in% tolower(getOption("reproducible.sidecarProbeSkip", character())))
+    return(none)
 
-  found <- suppressWarnings(tryCatch(.dirListingUrls(.readUrlLines(parent), parent),
+  listFrom <- .listableParent(parent)
+  found <- suppressWarnings(tryCatch(.dirListingUrls(.readUrlLines(listFrom), listFrom),
                                      error = function(e) none))
-  found <- found[startsWith(names(found), stem)]
+  found <- found[.similarTo(names(found), base)]
+  # Siblings live in `parent` by definition, so re-base the names there. A no-op
+  #   when nothing was translated; when something was, it keeps the download on
+  #   the caller's host rather than the index we borrowed.
+  if (length(found)) found <- stats::setNames(paste0(parent, names(found)), names(found))
 
   if (!length(found)) {
-    # `.aux.xml`/`.ovr`/`.msk` append to the whole file name; `.tfw`/`.prj`/...
-    #   replace the extension. Both forms have to be asked for by name.
-    cand <- unique(c(paste0(base, c(".aux.xml", ".ovr", ".msk")),
-                     paste0(stem, c(".tfw", ".wld", ".prj", ".vat.dbf", ".aux"))))
+    # The parent will not enumerate, so the only way left is to ask for
+    #   companions by name. That means a list of names, and a list of names is
+    #   always incomplete -- so it is a deny-list that decides whether to spend
+    #   the requests, not an allow-list that decides whether a format is
+    #   eligible. Getting the deny-list wrong costs a few HEADs; getting an
+    #   allow-list wrong loses data silently, which is the bug being fixed here.
+    #   Both lists are options, so neither needs a release to correct.
+    cands <- getOption("reproducible.sidecarCandidates", list())
+    # `.aux.xml`/`.ovr` append to the whole file name; `.tfw`/`.prj` replace the
+    #   extension. Both forms exist and neither implies the other.
+    cand <- unique(c(paste0(base, cands$append), paste0(stem, cands$replace)))
     if (identical(tolower(fileExt(base)), "shp"))
-      cand <- unique(c(cand, paste0(stem, c(".dbf", ".shx", ".prj", ".cpg", ".sbn", ".sbx"))))
+      cand <- unique(c(cand, paste0(stem, cands$shp)))
     cand <- setdiff(cand, base)
-    urls <- paste0(parent, cand)
-    ok <- vapply(urls, .urlHeadOK, logical(1), USE.NAMES = FALSE)
-    found <- stats::setNames(urls[ok], cand[ok])
+    if (!length(cand)) return(none)
+    ok <- vapply(paste0(parent, cand), .urlHeadOK, logical(1), USE.NAMES = FALSE)
+    found <- stats::setNames(paste0(parent, cand)[ok], cand[ok])
   }
   found <- found[names(found) != base]
   if (length(found))
@@ -2119,14 +2176,14 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
                   verbose = verbose, messageGuessing = FALSE
                 )$targetFilePath)
               }
-              theGrep <- if (grepl("^sim", alsoExtract[1])) {
-                paste0("^", filePathSansExt(targetInDir))
+              keep <- if (grepl("^sim", alsoExtract[1])) {
+                .similarTo(filenames, targetInDir)
               } else if (grepl("none", alsoExtract[1])) {
-                paste0("^", targetInDir, "$")
+                filenames %in% targetInDir
               } else {
-                paste(alsoExtract, collapse = "|")
+                grepl(paste(alsoExtract, collapse = "|"), filenames)
               }
-              dirListing <- dirListing[grepl(paste(theGrep, collapse = "|"), filenames)]
+              dirListing <- dirListing[keep]
               filenames <- names(dirListing)
               # now that we have filenames; need to checksum
               urls <- unname(dirListing)

--- a/R/download.R
+++ b/R/download.R
@@ -1747,10 +1747,12 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
     "^https?://(?:www[.])?github[.]com/([^/]+)/([^/]+)/raw/(?:refs/(?:heads|tags)/)?([^/]+)/(.*)$",
     "^https?://raw[.]githubusercontent[.]com/([^/]+)/([^/]+)/(?:refs/(?:heads|tags)/)?([^/]+)/(.*)$"
   )
+  base <- getOption("reproducible.githubListingBase", "")
+  if (!length(base) || !nzchar(base)) return(url) # opted out: never contact it
   for (pat in pats) {
     m <- regmatches(url, regexec(pat, url))[[1]]
     if (length(m) == 5L)
-      return(paste0("https://cdn.jsdelivr.net/gh/", m[2], "/", m[3], "@", m[4], "/", m[5]))
+      return(paste0(base, m[2], "/", m[3], "@", m[4], "/", m[5]))
   }
   url
 }

--- a/R/options.R
+++ b/R/options.R
@@ -643,6 +643,18 @@ reproducibleOptions <- function() {
     reproducible.useGdown = FALSE,
     reproducible.useMemoise = FALSE, # memoise
     reproducible.useragent = "https://github.com/PredictiveEcology/reproducible",
+    # Formats for which a companion file is not a thing: archives, R
+    #   serialisations, documents. Deliberately conservative -- `csv` is absent
+    #   because OGR reads column types from a `.csvt` beside it, which is the
+    #   kind of case a longer list gets wrong.
+    reproducible.sidecarProbeSkip = c("rds", "qs", "qs2", "rdata", "rda",
+                                      "zip", "tar", "gz", "bz2", "xz", "7z", "rar",
+                                      "pdf", "html", "md", "r", "rmd"),
+    reproducible.sidecarCandidates = list(
+      append  = c(".aux.xml", ".ovr", ".msk"),
+      replace = c(".tfw", ".wld", ".prj", ".vat.dbf", ".aux", ".csvt"),
+      shp     = c(".dbf", ".shx", ".prj", ".cpg", ".sbn", ".sbx")
+    ),
     reproducible.verbose = 1,
     reproducible.digestVersion = NULL, # NULL => 4; the going-forward digest-algorithm selector
     reproducible.digestV3 = TRUE,      # superseded by digestVersion (still honoured when it is unset)

--- a/R/options.R
+++ b/R/options.R
@@ -647,6 +647,11 @@ reproducibleOptions <- function() {
     #   serialisations, documents. Deliberately conservative -- `csv` is absent
     #   because OGR reads column types from a `.csvt` beside it, which is the
     #   kind of case a longer list gets wrong.
+    # Index used to enumerate a GitHub directory, which GitHub itself will not
+    #   do in any machine-readable form. Only ever read as an index -- files are
+    #   always fetched from the url the caller gave. Set to NULL to never
+    #   contact it; the sidecar search then falls back to probing by name.
+    reproducible.githubListingBase = "https://cdn.jsdelivr.net/gh/",
     reproducible.sidecarProbeSkip = c("rds", "qs", "qs2", "rdata", "rda",
                                       "zip", "tar", "gz", "bz2", "xz", "7z", "rar",
                                       "pdf", "html", "md", "r", "rmd"),

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -138,16 +138,33 @@ utils::globalVariables(c(
 #'   `prepInputs` or `preProcess`, comparing the file on hand with the ad hoc
 #'   `CHECKSUMS.txt`. See table in [preProcess()].
 #'
-#' @param alsoExtract Optional character string naming files other than
-#'   `targetFile` that must be extracted from the `archive`. If
-#'   `NULL`, the default, then it will extract all files. Other options:
-#'   `"similar"` will extract all files with the same filename without
-#'   file extension as `targetFile`. `NA` will extract nothing other
-#'   than `targetFile`. A character string of specific file names will cause
-#'   only those to be extracted. Each element may also be a regular expression:
-#'   if an element does not match any archive member literally (by relative path
-#'   or basename), it is passed to `grep()` against the archive's file list and
-#'   all matching members are extracted. For example,
+#' @param alsoExtract Which files to fetch or extract in addition to
+#'   `targetFile`. Spatial data rarely arrives as one file -- a shapefile is
+#'   five or six, and a raster often has a `.aux.xml`, `.ovr` or `.tfw`
+#'   alongside carrying its attribute table, overviews or georeferencing --
+#'   so this controls how much of that company comes along.
+#'
+#'   The default depends on where the files are coming from, because
+#'   "everything" only means something when a container bounds it:
+#'
+#'   \tabular{lll}{
+#'     **`alsoExtract`** \tab **from an `archive`** \tab **from a `url`** \cr
+#'     `NULL` (default) \tab every file in the archive \tab as for `"similar"` \cr
+#'     `"similar"` \tab files sharing `targetFile`'s name without its extension
+#'       \tab same, discovered by listing the remote directory \cr
+#'     `NA` or `"none"` \tab `targetFile` only \tab `targetFile` only \cr
+#'     a character vector \tab those files only \tab those files only \cr
+#'   }
+#'
+#'   An archive bounds what "all files" can mean, so `NULL` extracts all of it.
+#'   A `url` has no such bound -- the server may hold thousands of unrelated
+#'   files -- so `NULL` there means `targetFile` and its companions, never the
+#'   whole remote directory.
+#'
+#'   Each element of a character vector may also be a regular expression: if an
+#'   element does not match any archive member literally (by relative path or
+#'   basename), it is passed to `grep()` against the archive's file list and all
+#'   matching members are extracted. For example,
 #'   `alsoExtract = "CMD_sm|CMD_sp"` extracts every file whose name contains
 #'   `CMD_sm` or `CMD_sp`. See table in [preProcess()].
 #'

--- a/man/downloadFile.Rd
+++ b/man/downloadFile.Rd
@@ -86,16 +86,33 @@ in subsequent calls to
 \item{overwrite}{Logical. If \code{TRUE} then the download will overwrite an existing file
 if it exists.}
 
-\item{alsoExtract}{Optional character string naming files other than
-\code{targetFile} that must be extracted from the \code{archive}. If
-\code{NULL}, the default, then it will extract all files. Other options:
-\code{"similar"} will extract all files with the same filename without
-file extension as \code{targetFile}. \code{NA} will extract nothing other
-than \code{targetFile}. A character string of specific file names will cause
-only those to be extracted. Each element may also be a regular expression:
-if an element does not match any archive member literally (by relative path
-or basename), it is passed to \code{grep()} against the archive's file list and
-all matching members are extracted. For example,
+\item{alsoExtract}{Which files to fetch or extract in addition to
+\code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is
+five or six, and a raster often has a \code{.aux.xml}, \code{.ovr} or \code{.tfw}
+alongside carrying its attribute table, overviews or georeferencing --
+so this controls how much of that company comes along.
+
+The default depends on where the files are coming from, because
+"everything" only means something when a container bounds it:
+
+\tabular{lll}{
+\strong{\code{alsoExtract}} \tab \strong{from an \code{archive}} \tab \strong{from a \code{url}} \cr
+\code{NULL} (default) \tab every file in the archive \tab as for \code{"similar"} \cr
+\code{"similar"} \tab files sharing \code{targetFile}'s name without its extension
+\tab same, discovered by listing the remote directory \cr
+\code{NA} or \code{"none"} \tab \code{targetFile} only \tab \code{targetFile} only \cr
+a character vector \tab those files only \tab those files only \cr
+}
+
+An archive bounds what "all files" can mean, so \code{NULL} extracts all of it.
+A \code{url} has no such bound -- the server may hold thousands of unrelated
+files -- so \code{NULL} there means \code{targetFile} and its companions, never the
+whole remote directory.
+
+Each element of a character vector may also be a regular expression: if an
+element does not match any archive member literally (by relative path or
+basename), it is passed to \code{grep()} against the archive's file list and all
+matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
 

--- a/man/downloadRemote.Rd
+++ b/man/downloadRemote.Rd
@@ -78,16 +78,33 @@ Will be cleared \code{on.exit} from this function.}
 
 \item{preDigest}{The list of \code{preDigest} that comes from \code{CacheDigest} of an object}
 
-\item{alsoExtract}{Optional character string naming files other than
-\code{targetFile} that must be extracted from the \code{archive}. If
-\code{NULL}, the default, then it will extract all files. Other options:
-\code{"similar"} will extract all files with the same filename without
-file extension as \code{targetFile}. \code{NA} will extract nothing other
-than \code{targetFile}. A character string of specific file names will cause
-only those to be extracted. Each element may also be a regular expression:
-if an element does not match any archive member literally (by relative path
-or basename), it is passed to \code{grep()} against the archive's file list and
-all matching members are extracted. For example,
+\item{alsoExtract}{Which files to fetch or extract in addition to
+\code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is
+five or six, and a raster often has a \code{.aux.xml}, \code{.ovr} or \code{.tfw}
+alongside carrying its attribute table, overviews or georeferencing --
+so this controls how much of that company comes along.
+
+The default depends on where the files are coming from, because
+"everything" only means something when a container bounds it:
+
+\tabular{lll}{
+\strong{\code{alsoExtract}} \tab \strong{from an \code{archive}} \tab \strong{from a \code{url}} \cr
+\code{NULL} (default) \tab every file in the archive \tab as for \code{"similar"} \cr
+\code{"similar"} \tab files sharing \code{targetFile}'s name without its extension
+\tab same, discovered by listing the remote directory \cr
+\code{NA} or \code{"none"} \tab \code{targetFile} only \tab \code{targetFile} only \cr
+a character vector \tab those files only \tab those files only \cr
+}
+
+An archive bounds what "all files" can mean, so \code{NULL} extracts all of it.
+A \code{url} has no such bound -- the server may hold thousands of unrelated
+files -- so \code{NULL} there means \code{targetFile} and its companions, never the
+whole remote directory.
+
+Each element of a character vector may also be a regular expression: if an
+element does not match any archive member literally (by relative path or
+basename), it is passed to \code{grep()} against the archive's file list and all
+matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
 

--- a/man/preProcess.Rd
+++ b/man/preProcess.Rd
@@ -55,16 +55,33 @@ then it will \emph{not} attempt to see it as an archive, even if it has archive-
 file extension (e.g., \code{.zip}). This may be useful when an R function
 is expecting an archive directly.}
 
-\item{alsoExtract}{Optional character string naming files other than
-\code{targetFile} that must be extracted from the \code{archive}. If
-\code{NULL}, the default, then it will extract all files. Other options:
-\code{"similar"} will extract all files with the same filename without
-file extension as \code{targetFile}. \code{NA} will extract nothing other
-than \code{targetFile}. A character string of specific file names will cause
-only those to be extracted. Each element may also be a regular expression:
-if an element does not match any archive member literally (by relative path
-or basename), it is passed to \code{grep()} against the archive's file list and
-all matching members are extracted. For example,
+\item{alsoExtract}{Which files to fetch or extract in addition to
+\code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is
+five or six, and a raster often has a \code{.aux.xml}, \code{.ovr} or \code{.tfw}
+alongside carrying its attribute table, overviews or georeferencing --
+so this controls how much of that company comes along.
+
+The default depends on where the files are coming from, because
+"everything" only means something when a container bounds it:
+
+\tabular{lll}{
+\strong{\code{alsoExtract}} \tab \strong{from an \code{archive}} \tab \strong{from a \code{url}} \cr
+\code{NULL} (default) \tab every file in the archive \tab as for \code{"similar"} \cr
+\code{"similar"} \tab files sharing \code{targetFile}'s name without its extension
+\tab same, discovered by listing the remote directory \cr
+\code{NA} or \code{"none"} \tab \code{targetFile} only \tab \code{targetFile} only \cr
+a character vector \tab those files only \tab those files only \cr
+}
+
+An archive bounds what "all files" can mean, so \code{NULL} extracts all of it.
+A \code{url} has no such bound -- the server may hold thousands of unrelated
+files -- so \code{NULL} there means \code{targetFile} and its companions, never the
+whole remote directory.
+
+Each element of a character vector may also be a regular expression: if an
+element does not match any archive member literally (by relative path or
+basename), it is passed to \code{grep()} against the archive's file list and all
+matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
 

--- a/man/prepInputs.Rd
+++ b/man/prepInputs.Rd
@@ -47,16 +47,33 @@ then it will \emph{not} attempt to see it as an archive, even if it has archive-
 file extension (e.g., \code{.zip}). This may be useful when an R function
 is expecting an archive directly.}
 
-\item{alsoExtract}{Optional character string naming files other than
-\code{targetFile} that must be extracted from the \code{archive}. If
-\code{NULL}, the default, then it will extract all files. Other options:
-\code{"similar"} will extract all files with the same filename without
-file extension as \code{targetFile}. \code{NA} will extract nothing other
-than \code{targetFile}. A character string of specific file names will cause
-only those to be extracted. Each element may also be a regular expression:
-if an element does not match any archive member literally (by relative path
-or basename), it is passed to \code{grep()} against the archive's file list and
-all matching members are extracted. For example,
+\item{alsoExtract}{Which files to fetch or extract in addition to
+\code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is
+five or six, and a raster often has a \code{.aux.xml}, \code{.ovr} or \code{.tfw}
+alongside carrying its attribute table, overviews or georeferencing --
+so this controls how much of that company comes along.
+
+The default depends on where the files are coming from, because
+"everything" only means something when a container bounds it:
+
+\tabular{lll}{
+\strong{\code{alsoExtract}} \tab \strong{from an \code{archive}} \tab \strong{from a \code{url}} \cr
+\code{NULL} (default) \tab every file in the archive \tab as for \code{"similar"} \cr
+\code{"similar"} \tab files sharing \code{targetFile}'s name without its extension
+\tab same, discovered by listing the remote directory \cr
+\code{NA} or \code{"none"} \tab \code{targetFile} only \tab \code{targetFile} only \cr
+a character vector \tab those files only \tab those files only \cr
+}
+
+An archive bounds what "all files" can mean, so \code{NULL} extracts all of it.
+A \code{url} has no such bound -- the server may hold thousands of unrelated
+files -- so \code{NULL} there means \code{targetFile} and its companions, never the
+whole remote directory.
+
+Each element of a character vector may also be a regular expression: if an
+element does not match any archive member literally (by relative path or
+basename), it is passed to \code{grep()} against the archive's file list and all
+matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
 

--- a/man/purge.Rd
+++ b/man/purge.Rd
@@ -39,16 +39,33 @@ then it will \emph{not} attempt to see it as an archive, even if it has archive-
 file extension (e.g., \code{.zip}). This may be useful when an R function
 is expecting an archive directly.}
 
-\item{alsoExtract}{Optional character string naming files other than
-\code{targetFile} that must be extracted from the \code{archive}. If
-\code{NULL}, the default, then it will extract all files. Other options:
-\code{"similar"} will extract all files with the same filename without
-file extension as \code{targetFile}. \code{NA} will extract nothing other
-than \code{targetFile}. A character string of specific file names will cause
-only those to be extracted. Each element may also be a regular expression:
-if an element does not match any archive member literally (by relative path
-or basename), it is passed to \code{grep()} against the archive's file list and
-all matching members are extracted. For example,
+\item{alsoExtract}{Which files to fetch or extract in addition to
+\code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is
+five or six, and a raster often has a \code{.aux.xml}, \code{.ovr} or \code{.tfw}
+alongside carrying its attribute table, overviews or georeferencing --
+so this controls how much of that company comes along.
+
+The default depends on where the files are coming from, because
+"everything" only means something when a container bounds it:
+
+\tabular{lll}{
+\strong{\code{alsoExtract}} \tab \strong{from an \code{archive}} \tab \strong{from a \code{url}} \cr
+\code{NULL} (default) \tab every file in the archive \tab as for \code{"similar"} \cr
+\code{"similar"} \tab files sharing \code{targetFile}'s name without its extension
+\tab same, discovered by listing the remote directory \cr
+\code{NA} or \code{"none"} \tab \code{targetFile} only \tab \code{targetFile} only \cr
+a character vector \tab those files only \tab those files only \cr
+}
+
+An archive bounds what "all files" can mean, so \code{NULL} extracts all of it.
+A \code{url} has no such bound -- the server may hold thousands of unrelated
+files -- so \code{NULL} there means \code{targetFile} and its companions, never the
+whole remote directory.
+
+Each element of a character vector may also be a regular expression: if an
+element does not match any archive member literally (by relative path or
+basename), it is passed to \code{grep()} against the archive's file list and all
+matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
 

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -307,3 +307,34 @@ test_that(".remoteSiblings finds the sidecars beside a file url", {
                   c("luxSmall.cpg", "luxSmall.dbf", "luxSmall.prj", "luxSmall.shx"))
   expect_false("luxSmall.shp" %in% names(sibs)) # the target itself is not a sibling
 })
+
+test_that(".listableParent rewrites GitHub raw urls, and only those", {
+  testInit()
+  withr::local_options(reproducible.githubListingBase = "https://cdn.jsdelivr.net/gh/")
+  ## every raw form GitHub serves, including the refs/ prefixes
+  expect_identical(.listableParent("https://github.com/O/R/raw/refs/heads/main/a/b/"),
+                   "https://cdn.jsdelivr.net/gh/O/R@main/a/b/")
+  expect_identical(.listableParent("https://github.com/O/R/raw/main/a/b/"),
+                   "https://cdn.jsdelivr.net/gh/O/R@main/a/b/")
+  expect_identical(.listableParent("https://raw.githubusercontent.com/O/R/main/a/b/"),
+                   "https://cdn.jsdelivr.net/gh/O/R@main/a/b/")
+  expect_identical(.listableParent("https://github.com/O/R/raw/refs/tags/v1.0/a/"),
+                   "https://cdn.jsdelivr.net/gh/O/R@v1.0/a/")
+  ## anything else is left alone -- no other host gets redirected anywhere
+  expect_identical(.listableParent("https://example.org/pub/"), "https://example.org/pub/")
+  expect_identical(.listableParent("https://github.com/O/R/tree/main/a/"),
+                   "https://github.com/O/R/tree/main/a/")
+})
+
+test_that("the GitHub listing index can be switched off entirely", {
+  testInit()
+  ## The index is a convenience, not a requirement: with it off, a GitHub url is
+  ## never rewritten and nothing contacts the CDN. The sidecar search then falls
+  ## back to probing by name, which is slower but reaches the same answer.
+  withr::local_options(reproducible.githubListingBase = NULL)
+  expect_identical(.listableParent("https://github.com/O/R/raw/main/a/"),
+                   "https://github.com/O/R/raw/main/a/")
+  withr::local_options(reproducible.githubListingBase = "")
+  expect_identical(.listableParent("https://github.com/O/R/raw/main/a/"),
+                   "https://github.com/O/R/raw/main/a/")
+})

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -338,3 +338,31 @@ test_that("the GitHub listing index can be switched off entirely", {
   expect_identical(.listableParent("https://github.com/O/R/raw/main/a/"),
                    "https://github.com/O/R/raw/main/a/")
 })
+
+test_that("the url log records the index request and the sidecars", {
+  skip_on_cran()
+  skip_if_not_installed("curl")
+  skip_if_not_installed("httr2")
+  skip_if_offline()
+  testInit("terra")
+
+  ## The log is the record of what a session reached out to. Two of the accesses
+  ## here are ones the caller never named -- an index on another host, and a
+  ## sidecar found through it -- which is precisely why they have to appear.
+  target <- paste0(theDirListingUrl, "luxSmall/luxSmall.shp")
+  fns <- function() vapply(prepInputsLog(), function(r) r$fn, character(1))
+
+  clearUrlLog()
+  d1 <- checkPath(file.path(tmpdir, "logOn"), create = TRUE)
+  invisible(suppressWarnings(prepInputs(url = target, destinationPath = d1,
+                                        fun = "terra::vect")))
+  expect_true(any(grepl("similar", fns()))) # the companions it pulled in
+
+  ## With the index switched off nothing should claim to have used one.
+  clearUrlLog()
+  withr::local_options(reproducible.githubListingBase = NULL)
+  d2 <- checkPath(file.path(tmpdir, "logOff"), create = TRUE)
+  invisible(suppressWarnings(prepInputs(url = target, destinationPath = d2,
+                                        fun = "terra::vect")))
+  expect_false(any(grepl("directory index", fns())))
+})

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -266,13 +266,29 @@ test_that("isDirectory(probe = TRUE) recognises a directory url with no trailing
                            mustExist = FALSE, probe = TRUE, verbose = 0))
 })
 
-test_that(".remoteSiblings only answers for alsoExtract = 'similar'", {
+test_that(".remoteSiblings declines when the caller was explicit", {
   testInit()
-  ## Anything else is the caller being explicit; nothing to infer, no request.
-  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", NULL), 0L)
+  ## "none", NA and a named vector are all the caller saying exactly what they
+  ## want, so there is nothing to infer and no request to make. (`NULL` is NOT
+  ## in this list: unspecified means "similar" beside a url -- see below.)
   expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", "none"), 0L)
+  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", NA), 0L)
   expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif",
                                 c("a.dbf", "b.prj")), 0L)
+})
+
+test_that(".remoteSiblings does not probe extensions on the deny-list", {
+  testInit()
+  ## The deny-list decides whether spending requests is worthwhile; it is not a
+  ## list of what is eligible. A format missing from it is still probed -- the
+  ## failure mode is a little latency, never a silently dropped companion.
+  withr::local_options(reproducible.sidecarProbeSkip = c("csv", "rds"))
+  ## `.csv` is denied, so this returns without touching the network at all --
+  ## which is why it can assert against an unresolvable host.
+  expect_length(.remoteSiblings("https://example.invalid/d/x.csv", "x.csv", "similar"), 0L)
+  ## An empty candidate list is the other way to spend nothing.
+  withr::local_options(reproducible.sidecarCandidates = list())
+  expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", "similar"), 0L)
 })
 
 test_that(".remoteSiblings finds the sidecars beside a file url", {


### PR DESCRIPTION
Follow-up to #566, which added sidecar fetching but only when
`alsoExtract = "similar"` was passed **explicitly**. The reproducer in #559
passes no `alsoExtract` at all, so it still returned a raster with its attribute
table missing. Not posting to #559 yet.

## 1. `"similar"` is the default beside a url

An **archive** bounds what "extract everything" means, so an unspecified
`alsoExtract` extracting all of it is sensible there — **left exactly as it
was**, verified still 6 files. A **url** has no such bound (the server may hold
thousands of unrelated files), so the useful reading of "unspecified" is the
target plus what belongs with it. `NA`/`"none"` still mean the target alone; an
explicit vector still means exactly those files.

## 2. GitHub can now be listed

The listing route needs no guessing at all — it just needs a parent that
enumerates, and GitHub raw doesn't: the `tree/` browser is a React app with no
usable hrefs, and `raw.githubusercontent` 404s on a directory.

`.listableParent()` translates a raw url into the **jsDelivr view of the same
commit, for listing only**. The names that come back are used against the
caller's own url, so files are still fetched from the host they asked for —
jsDelivr is consulted as an index, never substituted as a source:

```
.../raw/refs/heads/main/a/b/       -> cdn.jsdelivr.net/gh/O/R@main/a/b/
.../raw/main/a/b/                  -> cdn.jsdelivr.net/gh/O/R@main/a/b/
raw.githubusercontent.com/O/R/...  -> cdn.jsdelivr.net/gh/O/R@main/a/b/
.../raw/refs/tags/v1.0/a/          -> cdn.jsdelivr.net/gh/O/R@v1.0/a/
anything else                      -> unchanged
```

Sibling lookup on GitHub went **2.2s → 0.3s**, and the guessing path never runs
there any more.

## 3. Guessing is gated by a deny-list

Where a parent genuinely cannot be enumerated, companions must be asked for by
name, and any list of names is incomplete. So the list deciding *whether* to
spend requests is a **deny-list** of formats that have no companions — archives,
R serialisations, documents. A format missing from it is still searched, and the
cost of that mistake is latency; an allow-list would have made the cost a
silently dropped file, which is the bug being fixed here.

Both lists are options — `reproducible.sidecarProbeSkip` and
`reproducible.sidecarCandidates` — so neither needs a release to correct.
`csv` is deliberately **absent** from the deny-list: OGR reads column types from
a `.csvt` beside it, which is exactly the sort of case a longer list gets wrong.

## 4. A bug the measurements caught

`"similar"` was matching by **stem prefix**, so `species.csv` claimed
`speciesEcoregion.csv` and `speciesLayers.tif` — different data entirely.
`.similarTo()` now implements what the docs always said (same name without the
extension) while also covering the appending convention (`x.tif` →
`x.tif.aux.xml`) that a stem comparison alone misses. Used by both the file-url
and directory paths, so the directory branch gets the same correction.

## 5. Documentation

The `alsoExtract` default differed by source and was written down nowhere. There
is now one table, on `prepInputs()`, which `preProcess()`, `downloadFile()`,
`downloadRemote()` and `purge()` all pick up through `@inheritParams`:

| `alsoExtract` | from an `archive` | from a `url` |
|---|---|---|
| `NULL` (default) | every file in the archive | as for `"similar"` |
| `"similar"` | files sharing the target's name without its extension | same, discovered by listing the remote directory |
| `NA` or `"none"` | `targetFile` only | `targetFile` only |
| a character vector | those files only | those files only |

All five rows were verified against a real archive before being written down.

## Measured

| case | result |
|---|---|
| #559 reproducer, no `alsoExtract` | `.tif` + `.tif.aux.xml`, `is.factor TRUE` |
| `species.csv` | 1 file (**was 3**) |
| shapefile directory, no `targetFile` | 5 files, one `SpatVector` |
| ambiguous directory + `targetFile` | 1 file — never the whole directory |
| archive, no `alsoExtract` | unchanged, everything extracted |

prepInputs, downloadHelpers, download, downloadLocalArchive, preProcess,
preProcessDoesntWork, urlLog, prepInputsCOG, parallel-download-remap,
helpersCoverage, argValidation and gis all pass, no warnings.

## Worth a look in review

- **jsDelivr as an index** is a third-party dependency on the listing path for
  GitHub urls. It is only ever an index — the bytes come from GitHub — and when
  it is unreachable the code falls back to name-probing exactly as before. The
  GitHub Contents API would keep everything on one host but is rate-limited to
  60/hr unauthenticated, which felt worse for a library.
- **New network on a previously offline path**: a plain file download from an
  unlistable host now costs one failed listing plus up to eight HEADs. The
  deny-list removes that for archives and serialisations; the GitHub adapter
  removes it for the most common host; everything else pays it.

`DESCRIPTION` left at 3.2.0 (`--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RcUFqamjZnWnbja6spat9