### PR TITLE
fix(cloud): restore the documented auto-derived cloudFolderID (#541)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -129,7 +129,6 @@
   macOS, nor errors on Windows when more than one archive binary is installed.
 * Single-stream downloads no longer hang for certain servers; parallel ranged
   downloads are used only where the server supports them.
-* Cloud caching no longer invents a Google Drive folder when none is supplied.
 * Assorted message and reporting fixes in `messageColoured()`/`cliCol()`,
   `getRelative()`, and direct `preProcess()` calls.
 # reproducible 3.1.1

--- a/R/cache.R
+++ b/R/cache.R
@@ -121,18 +121,6 @@ Cache <- function(FUN, ..., dryRun = getOption("reproducible.dryRun", FALSE),
 
   CacheDBFileCheckAndCreate(cachePaths[[1]], drv, conn, verbose = verbose) # checks that we are using multiDBfile backend
 
-  # Cloud caching needs a destination folder. If none was passed, fall back to
-  # the option. If there is still no cloudFolderID, do NOT silently invent one
-  # from the local cache path (a derived folder differs from machine to machine
-  # and silently breaks shared/cloud caching) -- a NULL cloudFolderID means
-  # "no cloud target", so skip cloud caching for this call (local cache only).
-  if (is.null(cloudFolderID))
-    cloudFolderID <- getOption("reproducible.cloudFolderID", NULL)
-  if (cloudWriteOrRead(useCloud) && is.null(cloudFolderID)) {
-    .cloudFolderUnsetMessageOnce(verbose = verbose)
-    useCloud <- FALSE
-  }
-
   if (cloudWrite(useCloud)) {
     cloudFolderID <- checkAndMakeCloudFolderID(cloudFolderID, cachePaths[[1]], create = TRUE, verbose = verbose)
     gdriveLs <- retry(quote(driveLs(cloudFolderID, keyFull$key, cachePath = cachePaths[[1]], verbose = verbose)))

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -2,27 +2,6 @@ utils::globalVariables(c(
   "cacheId", "checksumsFilename", "checksumsID", "id"
 ))
 
-# One-time (per session) notice that cloud caching is being skipped because no
-# cloudFolderID is set. reproducible deliberately does NOT auto-create a cloud
-# folder from the local cache path: that folder differs across machines and
-# would silently break shared/cloud caching.
-# NOTE: keep this defined ABOVE the roxygen block below. If it sits between that
-# block and checkAndMakeCloudFolderID, roxygen2 misattaches the `@export` to this
-# internal helper and drops the export of checkAndMakeCloudFolderID.
-.cloudFolderUnsetMessageOnce <- function(verbose = getOption("reproducible.verbose", 1)) {
-  if (isTRUE(.pkgEnv$.cloudFolderUnsetEmitted)) return(invisible())
-  messageCache(
-    "useCloud is on but no cloudFolderID is set (neither the argument nor ",
-    "options(reproducible.cloudFolderID)); skipping cloud caching (local cache ",
-    "only). reproducible does not create a cloud folder automatically. To enable ",
-    "cloud caching, set the same folder on every machine, e.g. ",
-    "options(reproducible.cloudFolderID = googledrive::as_id(\"<id>\")).",
-    verbose = verbose
-  )
-  .pkgEnv$.cloudFolderUnsetEmitted <- TRUE
-  invisible()
-}
-
 #' Check for presence of `checkFolderID` (for `Cache(useCloud)`)
 #'
 #' Will check for presence of a `cloudFolderID` and make a new one

--- a/tests/testthat/test-cloud.R
+++ b/tests/testthat/test-cloud.R
@@ -73,9 +73,7 @@ test_that("test Cache(useCloud=TRUE, ...)", {
 
   withr::local_options("reproducible.cloudFolderID" = NULL)
   # on.exit(try(googledrive::drive_rm(cloudFolderFromCacheRepo(tmpdir))), add = TRUE)
-  ## The "no cloudFolderID set" notice fires once per session; clear the flag so
-  ## it is emitted into mess5 below regardless of what ran before this test.
-  .pkgEnv$.cloudFolderUnsetEmitted <- NULL
+  # Try two different cloud folders -- based on tmpdir and tmpCache
   warn5 <- capture_warnings({
     mess5 <- capture_messages({
       a2 <- Cache(rnorm, 3, cachePath = tmpdir, useCloud = TRUE)
@@ -83,14 +81,9 @@ test_that("test Cache(useCloud=TRUE, ...)", {
   })
   options("reproducible.cloudFolderID" = NULL)
 
-  ## No cloudFolderID -> cloud caching is deliberately SKIPPED, not auto-created
-  ## (abb3fc22). A folder derived from the local cachePath differs across
-  ## machines and would silently break sharing, so reproducible refuses and says
-  ## so. These expectations previously asserted the old auto-create behaviour;
-  ## they went unnoticed for years because the tests never ran -- the configured
-  ## credential was a service account, which cannot upload at all. See #541.
-  expect_true(any(grepl("no cloudFolderID is set", mess5)))
-  expect_false(any(grepl("Uploading", mess5)))
+  ## No cloudFolderID -> the folder is derived from the last two levels of the
+  ## cachePath and created, per ?Cache; the object is then uploaded to it (#541).
+  expect_true(any(grepl("Uploading", mess5)))
   expect_false(any(grepl("Download", mess5)))
 
 
@@ -101,9 +94,9 @@ test_that("test Cache(useCloud=TRUE, ...)", {
     })
   })
 
-  ## As above: skipped, not uploaded. The one-per-session notice has already
-  ## fired for mess5, so only the behaviour is asserted here.
-  expect_false(any(grepl("Uploading", mess6)))
+  ## As above, but a different cachePath -> a different derived cloud folder,
+  ## so this object is not there yet either and is uploaded.
+  expect_true(any(grepl("Uploading", mess6)))
   expect_false(any(grepl("Download", mess6)))
   expect_false(any(grepl(.message$LoadedCacheResult(), mess6)))
   expect_true(isTRUE(all.equal(length(warn6), 0)))

--- a/tests/testthat/test-cloudFolderID-offline.R
+++ b/tests/testthat/test-cloudFolderID-offline.R
@@ -19,27 +19,6 @@ test_that("checkAndMakeCloudFolderID warns when an explicit cloudFolderID cannot
   )
 })
 
-test_that(".cloudFolderUnsetMessageOnce emits at most once per session", {
-  withr::defer(assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv))
-  assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv)
-  expect_message(reproducible:::.cloudFolderUnsetMessageOnce(), "no cloudFolderID")
-  expect_no_message(reproducible:::.cloudFolderUnsetMessageOnce()) # not repeated
-})
-
-test_that("useCloud = TRUE with no cloudFolderID skips cloud and caches locally (Option A)", {
-  withr::local_options(
-    reproducible.cloudFolderID = NULL,
-    reproducible.cachePath = withr::local_tempdir(),
-    reproducible.useMemoise = FALSE
-  )
-  withr::defer(assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv))
-  assign(".cloudFolderUnsetEmitted", NULL, envir = reproducible:::.pkgEnv)
-  # If cloud were attempted with no credentials it would error in
-  # googledrive::drive_auth(); reaching a local result proves cloud was skipped.
-  out <- Cache(rnorm, 3, useCloud = TRUE)
-  expect_length(out, 3)
-})
-
 test_that("checkAndMakeCloudFolderID does NOT warn when cloudFolderID is NULL (documented default)", {
   skip_if_not_installed("googledrive")
   # A NULL cloudFolderID deriving a folder from the cache path is the documented


### PR DESCRIPTION
Closes #541 by restoring the behaviour `?Cache` documents.

## What

Reverts the behaviour change in abb3fc22. `Cache(useCloud = TRUE)` with no `cloudFolderID` again derives the Drive folder from the last two levels of the `cachePath`, creates it, and uploads.

## Why

`?Cache` has always documented — and still documents, unchanged — the auto-derive:

> `cloudFolderID`: If left as `NULL`, the function will create a cloud folder with name from last two folder levels of the `cachePath` path: `paste0(basename(dirname(cachePath)), "_", basename(cachePath))`.

The `useCloud` details section depends on that auto-creation too: its two-step sharing recipe is "share `getOption("reproducible.cloudFolderID")$id` **after at least one Cache call has been made**", which only works if the first call created and registered the folder. abb3fc22 changed the behaviour and updated NEWS.md but neither doc passage, so the code and `?Cache` have contradicted each other since June. `man/` is unchanged by this PR — that is the point.

The rationale for the skip does not survive inspection either: the derived name is only the **last two** path components, so `~/GitHub/proj/cache` and `D:/work/proj/cache` both derive `proj_cache`. Auto-derive shares correctly whenever project layout matches across machines; it diverges only for tempdir-based paths or a differently-named checkout.

## #541 was chasing a phantom

The issue was filed 2026-08-20, ten weeks after abb3fc22 landed on development (2026-06-05). So the "no `Uploading` message, confirmed pre-existing at the merge-base, under both backends" finding was measured against code that already skipped cloud entirely. The skip *was* the cause; there is no separate `isInCloud`/`filesExist` defect to chase.

## Changes

- `R/cache.R`: drop the skip-and-notify block, so a NULL `cloudFolderID` reaches `checkAndMakeCloudFolderID(create = TRUE)` again.
- `R/cloud.R`: drop `.cloudFolderUnsetMessageOnce()` (its only caller is gone).
- `tests/testthat/test-cloud.R`: mess5/mess6 assert `"Uploading"` again (reverts 95129ec3).
- `tests/testthat/test-cloudFolderID-offline.R`: drop the two tests that asserted the skip. The two `checkAndMakeCloudFolderID` warning tests stay.
- `NEWS.md`: drop the bullet announcing the skip. 3.2.0 is unreleased (latest tag is v3.1.1), so the behaviour never shipped and there is nothing to announce.

The supplied-but-unresolvable-`cloudFolderID` warning is untouched.

## Verification

- `test-cloud.R`: **80 passed, 0 skipped, 0 failed** against a real Drive account. Both restored `"Uploading"` assertions execute and pass — the count is exactly one below the 81 recorded in 95129ec3, matching the net −1 expectation change, which rules out an early skip.
- `test-cloudFolderID-offline.R`: 2/2.
- `roxygenise()` produces no `man/` or `NAMESPACE` diff.
- DESCRIPTION deliberately held at 3.2.0 (the pre-commit hook wanted 3.2.1; every commit since 53d60339 has held 3.2.0, and NEWS.md's heading says 3.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cFzMEgKzwSuxknU4zvEsT