### PR TITLE
DO NOT MERGE: prove the Fedora leg catches the apt regression

### DIFF
--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -15,6 +15,12 @@
 #     R keeps them visible so vignettes can be re-built, and `NA` would leave
 #     them uninstalled ("vignette builder 'knitr' not found")
 #
+# p7zip is REQUIRED here, not incidental: .archiveExtractBinary() only reaches
+# the branch that shells out when Sys.which("7z") finds something, and
+# test-archiveExtractBinary.R skips itself when no 7z/unrar exists. Without it
+# this leg silently skips the very code path it was created to cover -- CRAN's
+# Fedora has 7z, which is why the bug fired there.
+#
 # R-RELEASE deliberately, not R-devel: that is already covered by the ubuntu and
 # Windows legs. An r-hub devel container was tried and failed building `lobstr`,
 # because its R-devel snapshot runs ahead of CRAN's -- upstream churn unrelated
@@ -50,7 +56,8 @@ jobs:
           dnf -y install --setopt=install_weak_deps=False \
             R-core R-core-devel gcc gcc-c++ gfortran make \
             git tar which libcurl-devel openssl-devel libxml2-devel \
-            glibc-langpack-en pandoc qpdf ghostscript
+            glibc-langpack-en pandoc qpdf ghostscript \
+            p7zip p7zip-plugins
           R --version
 
       - uses: actions/checkout@v4

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -1,0 +1,53 @@
+# A Fedora leg, because our matrix has none and CRAN's does.
+#
+# reproducible 3.2.0 shipped a check ERROR on CRAN's
+# r-devel-linux-x86_64-fedora-{clang,gcc}: a `system("apt ...", intern = TRUE)`
+# call, which *errors* where the command does not exist. macOS never reached it
+# and Debian/Ubuntu has apt, so all nine legs of the usual matrix were green.
+# One non-Debian Linux leg would have caught it on the PR.
+#
+# Deliberately cheap: reproducible's heavy dependencies (terra, sf, raster) are
+# Suggests, so this installs hard dependencies only. Fedora has no P3M binaries,
+# and building the geospatial stack from source here would cost far more than
+# this leg is worth -- the failure class it targets (shelling out to a missing
+# binary) needs none of it.
+
+name: R-CMD-check-fedora
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fedora:
+    runs-on: ubuntu-latest
+    # Fedora with R preinstalled, maintained by r-hub for exactly this purpose.
+    container: ghcr.io/r-hub/containers/gcc14:latest
+    name: fedora (hard deps only)
+
+    steps:
+      # r-hub's checkout, not actions/checkout: these containers are built for
+      # this and the r-hub action handles their node/glibc expectations.
+      - uses: r-hub/actions/checkout@v1
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # hard deps only; testthat and rcmdcheck added explicitly so the
+          # tests actually run rather than being skipped wholesale.
+          dependencies: '"hard"'
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+          cache: always
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"warning"'
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -50,7 +50,7 @@ jobs:
           dnf -y install --setopt=install_weak_deps=False \
             R-core R-core-devel gcc gcc-c++ gfortran make \
             git tar which libcurl-devel openssl-devel libxml2-devel \
-            glibc-langpack-en pandoc
+            glibc-langpack-en pandoc qpdf ghostscript
           R --version
 
       - uses: actions/checkout@v4

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -6,11 +6,19 @@
 # and Debian/Ubuntu has apt, so all nine legs of the usual matrix were green.
 # One non-Debian Linux leg would have caught it on the PR.
 #
-# Deliberately cheap: reproducible's heavy dependencies (terra, sf, raster) are
-# Suggests, so this installs hard dependencies only. Fedora has no P3M binaries,
-# and building the geospatial stack from source here would cost far more than
-# this leg is worth -- the failure class it targets (shelling out to a missing
-# binary) needs none of it.
+# Deliberately R-RELEASE, not R-devel. This leg exists to vary ONE thing -- the
+# distribution -- so it catches "we shelled out to a binary that is not here".
+# R-devel is already covered by the ubuntu and Windows legs, and an r-hub devel
+# container was tried first: it failed building `lobstr`, because its R-devel
+# snapshot runs ahead of CRAN's and `R_envSymbols()` had changed. That is
+# upstream churn unrelated to this package, and a leg that reddens for reasons
+# no one here can fix is worse than no leg at all.
+#
+# Also deliberately cheap: terra, sf and raster are Suggests, so hard
+# dependencies only. Fedora has no P3M binaries and building the geospatial
+# stack from source would cost far more than this leg is worth -- the failure
+# class it targets needs none of it. Same dependency scope as the existing
+# `nosuggests` matrix leg, which has long run green.
 
 name: R-CMD-check-fedora
 
@@ -27,19 +35,23 @@ concurrency:
 jobs:
   fedora:
     runs-on: ubuntu-latest
-    # Fedora with R preinstalled, maintained by r-hub for exactly this purpose.
-    container: ghcr.io/r-hub/containers/gcc14:latest
-    name: fedora (hard deps only)
+    container: fedora:41
+    name: fedora (R-release, hard deps only)
 
     steps:
-      # r-hub's checkout, not actions/checkout: these containers are built for
-      # this and the r-hub action handles their node/glibc expectations.
-      - uses: r-hub/actions/checkout@v1
+      - name: Install R and build tools
+        run: |
+          dnf -y install --setopt=install_weak_deps=False \
+            R-core R-core-devel gcc gcc-c++ gfortran make \
+            git tar which libcurl-devel openssl-devel libxml2-devel
+          R --version
+
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # hard deps only; testthat and rcmdcheck added explicitly so the
-          # tests actually run rather than being skipped wholesale.
+          # hard deps only; testthat and rcmdcheck added explicitly so the tests
+          # actually run rather than being skipped wholesale.
           dependencies: '"hard"'
           extra-packages: |
             any::rcmdcheck

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -17,8 +17,14 @@
 # Also deliberately cheap: terra, sf and raster are Suggests, so hard
 # dependencies only. Fedora has no P3M binaries and building the geospatial
 # stack from source would cost far more than this leg is worth -- the failure
-# class it targets needs none of it. Same dependency scope as the existing
-# `nosuggests` matrix leg, which has long run green.
+# class it targets needs none of it.
+#
+# NOTE this is a stricter scope than the existing `nosuggests` matrix leg, which
+# INSTALLS everything and merely sets _R_CHECK_DEPENDS_ONLY_ for the check. Here
+# Suggests are genuinely absent, so `knitr` is too -- and DESCRIPTION declares
+# `VignetteBuilder: knitr`, which makes the package unbuildable rather than
+# merely unvignetted. Vignettes are therefore skipped outright: they are covered
+# by the ubuntu legs, and rendering them is not what this leg is for.
 
 name: R-CMD-check-fedora
 
@@ -60,6 +66,8 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          args: 'c("--no-manual", "--as-cran")'
+          # no vignettes: knitr is a Suggests and is deliberately not installed
+          args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
+          build_args: 'c("--no-build-vignettes")'
           error-on: '"warning"'
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -76,12 +76,18 @@ jobs:
             echo "__EOF__"
           } >> "$GITHUB_OUTPUT"
 
+      # testthat is a Suggests, so `dependencies: NA` leaves it out and
+      # tests/test-all.R dies at its bare `library(testthat)`: the suite is
+      # skipped entirely and the leg goes green having checked nothing. The
+      # ubuntu nosuggests leg gets testthat from RSPM incidentally; this
+      # container does not, so it is named explicitly below. Do not remove.
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: stable
           dependencies: 'NA'
           extra-packages: |
             any::rcmdcheck
+            any::testthat
             ${{ steps.vignette-builder.outputs.packages }}
           cache: always
 

--- a/.github/workflows/R-CMD-check-fedora.yaml
+++ b/.github/workflows/R-CMD-check-fedora.yaml
@@ -6,25 +6,20 @@
 # and Debian/Ubuntu has apt, so all nine legs of the usual matrix were green.
 # One non-Debian Linux leg would have caught it on the PR.
 #
-# Deliberately R-RELEASE, not R-devel. This leg exists to vary ONE thing -- the
-# distribution -- so it catches "we shelled out to a binary that is not here".
-# R-devel is already covered by the ubuntu and Windows legs, and an r-hub devel
-# container was tried first: it failed building `lobstr`, because its R-devel
-# snapshot runs ahead of CRAN's and `R_envSymbols()` had changed. That is
-# upstream churn unrelated to this package, and a leg that reddens for reasons
-# no one here can fix is worse than no leg at all.
+# This mirrors the `nosuggests` leg of the shared matrix as closely as possible,
+# so the DISTRIBUTION is the only variable and a red here is a real finding:
+#   * dependencies: NA          -- hard dependencies only
+#   * _R_CHECK_DEPENDS_ONLY_    -- so check EXPECTS Suggests to be absent;
+#                                  without it their absence is a WARNING
+#   * VignetteBuilder packages installed explicitly, read out of DESCRIPTION --
+#     R keeps them visible so vignettes can be re-built, and `NA` would leave
+#     them uninstalled ("vignette builder 'knitr' not found")
 #
-# Also deliberately cheap: terra, sf and raster are Suggests, so hard
-# dependencies only. Fedora has no P3M binaries and building the geospatial
-# stack from source would cost far more than this leg is worth -- the failure
-# class it targets needs none of it.
-#
-# NOTE this is a stricter scope than the existing `nosuggests` matrix leg, which
-# INSTALLS everything and merely sets _R_CHECK_DEPENDS_ONLY_ for the check. Here
-# Suggests are genuinely absent, so `knitr` is too -- and DESCRIPTION declares
-# `VignetteBuilder: knitr`, which makes the package unbuildable rather than
-# merely unvignetted. Vignettes are therefore skipped outright: they are covered
-# by the ubuntu legs, and rendering them is not what this leg is for.
+# R-RELEASE deliberately, not R-devel: that is already covered by the ubuntu and
+# Windows legs. An r-hub devel container was tried and failed building `lobstr`,
+# because its R-devel snapshot runs ahead of CRAN's -- upstream churn unrelated
+# to this package, and a leg that reddens for reasons nobody here can fix is
+# worse than no leg at all.
 
 name: R-CMD-check-fedora
 
@@ -42,32 +37,49 @@ jobs:
   fedora:
     runs-on: ubuntu-latest
     container: fedora:41
-    name: fedora (R-release, hard deps only)
+    name: fedora (R-release, no-suggests)
+
+    env:
+      # check expects only hard dependencies; without this, absent Suggests are
+      # reported as a WARNING rather than being the point of the leg
+      _R_CHECK_DEPENDS_ONLY_: true
 
     steps:
       - name: Install R and build tools
         run: |
           dnf -y install --setopt=install_weak_deps=False \
             R-core R-core-devel gcc gcc-c++ gfortran make \
-            git tar which libcurl-devel openssl-devel libxml2-devel
+            git tar which libcurl-devel openssl-devel libxml2-devel \
+            glibc-langpack-en pandoc
           R --version
 
       - uses: actions/checkout@v4
 
+      # Read the VignetteBuilder packages out of DESCRIPTION rather than
+      # hard-coding knitr/rmarkdown, exactly as the shared workflow does.
+      - name: Resolve VignetteBuilder packages
+        id: vignette-builder
+        shell: bash
+        run: |
+          pkgs=$(Rscript -e 'd <- read.dcf("DESCRIPTION"); vb <- if ("VignetteBuilder" %in% colnames(d)) d[1, "VignetteBuilder"] else ""; vb <- trimws(unlist(strsplit(vb, ","))); vb <- vb[nzchar(vb)]; if (length(vb)) cat(paste0("any::", vb), sep = "\n")')
+          echo "VignetteBuilder packages: ${pkgs:-<none>}"
+          {
+            echo "packages<<__EOF__"
+            printf '%s\n' "$pkgs"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # hard deps only; testthat and rcmdcheck added explicitly so the tests
-          # actually run rather than being skipped wholesale.
-          dependencies: '"hard"'
+          pak-version: stable
+          dependencies: 'NA'
           extra-packages: |
             any::rcmdcheck
-            any::testthat
+            ${{ steps.vignette-builder.outputs.packages }}
           cache: always
 
       - uses: r-lib/actions/check-r-package@v2
         with:
-          # no vignettes: knitr is a Suggests and is deliberately not installed
-          args: 'c("--no-manual", "--as-cran", "--no-vignettes")'
-          build_args: 'c("--no-build-vignettes")'
+          args: 'c("--no-manual", "--as-cran", "--run-dontrun", "--run-donttest")'
           error-on: '"warning"'
           upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-25
-Version: 3.2.2
+Version: 3.2.1
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-08-25
-Version: 3.2.1
+Version: 3.2.2
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1438,29 +1438,17 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
   } else {
     ""
   }
-  ## Ask 7z itself whether it supports .rar -- `7z i` lists the compiled-in
-  ## codecs and formats -- instead of querying a package manager.
-  ##
-  ## This previously ran `apt -qq list p7zip-rar`, which was wrong three ways:
-  ## it answered a proxy question (is a Debian package installed) rather than
-  ## the real one; its advice is meaningless off Debian/Ubuntu; and
-  ## system(intern = TRUE) *errors* when the command does not exist, so it blew
-  ## up wherever `apt` is absent. Gating it by OS did not help -- "Linux" is not
-  ## "has apt" (Fedora, RHEL, Arch, SUSE) -- and that is exactly how 3.2.0
-  ## reached CRAN with a test ERROR on r-devel-linux-x86_64-fedora-{clang,gcc}.
-  ## `extractSystemCallPath` came from Sys.which(), so this call cannot hit that
-  ## failure mode.
-  if (grepl("7z", extractSystemCallPath)) {
-    sevenZipInfo <- tryCatch(
-      system(paste0("\"", extractSystemCallPath, "\" i"),
-             intern = TRUE, ignore.stderr = TRUE),
-      error = function(e) character(0),
-      warning = function(w) character(0)
-    )
-    ## only advise when 7z answered AND reported no Rar codec; an empty result
-    ## means we could not tell, which is not grounds for a message
-    if (length(sevenZipInfo) && !any(grepl("Rar", sevenZipInfo))) {
-      messagePreProcess(.message$sevenZipNoRar(), verbose = verbose)
+  ## TEMPORARY: deliberately reinstated pre-3.2.1 code, to prove this CI leg
+  ## catches the regression it was built for. `apt` does not exist on Fedora and
+  ## system(..., intern = TRUE) errors on a missing command.
+  if (isLinux()) {
+    if (grepl("7z", extractSystemCallPath)) {
+      SevenZrarExists <- system("apt -qq list p7zip-rar", intern = TRUE, ignore.stderr = TRUE)
+      SevenZrarExists <- grepl(SevenZrarExists, pattern = "installed")
+      if (isFALSE(SevenZrarExists)) {
+        messagePreProcess("To extract .rar files, you will need p7zip-rar, not just p7zip-full.",
+                          verbose = verbose)
+      }
     }
   }
 


### PR DESCRIPTION
**Do not merge.** This branch deliberately reinstates the pre-3.2.1 bug to check the new Fedora leg actually catches it.

Restores the code CRAN's `r-devel-linux-x86_64-fedora-{clang,gcc}` failed on:

```r
if (isLinux()) {
  SevenZrarExists <- system("apt -qq list p7zip-rar", intern = TRUE, ...)
```

**Expected:** the Fedora leg goes red with `error in running command`, while every other leg stays green — exactly the pattern that let this ship in 3.2.0.

## Already worth it

Setting this up exposed that the leg would **not** have caught the bug as configured. `.archiveExtractBinary()` only shells out when `Sys.which("7z")` finds a binary, and `test-archiveExtractBinary.R` skips itself when no 7z/unrar exists. The container installed no p7zip, so the leg would have skipped the very branch the bug lives in — CI theatre. CRAN's Fedora has 7z, which is why it fired there.

`p7zip p7zip-plugins` added, with a comment explaining why it is load-bearing rather than incidental.