### PR TITLE
perf(attributesReassign): drop setdiff() from a per-object hot path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-03
-Version: 3.2.1.9002
+Version: 3.2.1.9003
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # reproducible 3.2.1.9002
 
+## enhancements
+
+* `attributesReassign()` no longer uses `setdiff()`, which was ~44% of
+  `SpaDES.core::loadSimList(parse = FALSE)` on a large `simList`. Same result,
+  ~21% faster load.
+
 ## new features
 
 * `padYears()` pads a `c(start, end)` pair of years to a common width, taken from

--- a/R/exportedMethods.R
+++ b/R/exportedMethods.R
@@ -1,6 +1,11 @@
 ## non-exported attribute stuff -------------------------------------------------
 attributesReassign <- function(atts, obj) {
-  attsNames <- setdiff(names(atts), knownAtts)
+  ## not setdiff(): attribute names are unique already, so its unique() is dead
+  ## weight, and its as.vector() coercion path dominates when this is called
+  ## once per object while unwrapping. ~14x faster, same result. This is 44% of
+  ## SpaDES.core::loadSimList(parse = FALSE) on a large simList.
+  nms <- names(atts)
+  attsNames <- nms[!nms %in% knownAtts]
   if (length(attsNames))
     for (att in attsNames) {
       if (is.null(attr(obj, att))) {

--- a/tests/testthat/test-attributesReassign.R
+++ b/tests/testthat/test-attributesReassign.R
@@ -1,0 +1,53 @@
+## attributesReassign(): restores attributes that were stripped, without
+## touching the known/structural ones. Called once per object while unwrapping,
+## so it is a hot path.
+
+test_that("attributesReassign restores unknown attributes only", {
+  obj <- 1:3
+  atts <- list(class = "should-not-apply", myTag = "kept", other = 42)
+
+  out <- attributesReassign(atts, obj)
+
+  expect_identical(attr(out, "myTag"), "kept")
+  expect_identical(attr(out, "other"), 42)
+  ## `class` is a known attribute and must not be reassigned
+  expect_false(identical(class(out), "should-not-apply"))
+})
+
+test_that("attributesReassign does not overwrite an attribute the object has", {
+  obj <- structure(1:3, myTag = "original")
+
+  out <- attributesReassign(list(myTag = "replacement"), obj)
+
+  expect_identical(attr(out, "myTag"), "original")
+})
+
+test_that("attributesReassign is a no-op for empty or all-known attributes", {
+  obj <- 1:3
+  expect_identical(attributesReassign(list(), obj), obj)
+  expect_identical(attributesReassign(list(class = "x", cpp = 1), obj), obj)
+  expect_identical(attributesReassign(NULL, obj), obj)
+})
+
+test_that("attributesReassign matches the setdiff() formulation it replaced", {
+  ## the old body, for reference
+  old <- function(atts, obj) {
+    attsNames <- setdiff(names(atts), knownAtts)
+    if (length(attsNames))
+      for (att in attsNames) {
+        if (is.null(attr(obj, att))) attr(obj, att) <- atts[[att]]
+      }
+    obj
+  }
+  cases <- list(character(0), "class", c("class", "a"), c("a", "b"),
+                c("cpp", "ptr", "z"),
+                ## duplicated names: setdiff() dedupes and the replacement does
+                ## not, so the loop runs twice -- but the second pass finds the
+                ## attribute already set, so the result is the same.
+                c("a", "a"))
+  for (nms in cases) {
+    atts <- stats::setNames(as.list(seq_along(nms)), nms)
+    expect_identical(attributesReassign(atts, 1:3), old(atts, 1:3),
+                     info = paste(nms, collapse = ","))
+  }
+})


### PR DESCRIPTION
Found while profiling `SpaDES.core::loadSimList(parse = FALSE)` on a lazily-saved 139-object `simList`. With module reparsing already off, `.unwrap()` is **96%** of the load, and inside it:

```
.unwrap.default          72%
  attributesReassign     46%
    setdiff              44%
      .set_ops_need_as_vector  32%
```

`attributesReassign()` runs once per object and does `setdiff(names(atts), knownAtts)`. Attribute names are unique by construction, so `setdiff()`s `unique()` is dead weight — and its `as.vector()` coercion path costs more than the membership test:

```r
setdiff()      3.57 s     # 200k calls
names[!%in%]   0.26 s     # identical result, 14x
```

## Measured, end to end

`loadSimList(parse = FALSE)`, median of 3, on a real 3 GB archive:

| | |
|---|---|
| before | 2.37 s |
| after | **1.87 s** (−21%) |

The loaded `simList` is unchanged — same 139 objects, same **118 still-unforced** `delayedAssign()` promises (laziness preserved, nothing accidentally materialised), same 147 `outputs` rows, same digest of object names.

## One deliberate difference

For *duplicated* attribute names `setdiff()` dedupes and this does not, so the loop runs an extra pass. The second pass finds the attribute already set and skips it, so the result is identical. The test suite pins the new implementation against the old one across cases including that one — it was caught by a test, not assumed.

4 tests, 13 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovGxDFz633RChMs8gUoZn