### PR TITLE
fix(cache): restore file-backed SpatRasters to their original directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-03
-Version: 3.2.1.9003
+Date: 2026-09-04
+Version: 3.2.1.9005
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# reproducible 3.2.1.9005
+
+## bug fixes
+
+* `unwrapSpatRaster()` restores a file-backed `SpatRaster` to the directory it was
+  produced in, rather than to `file.path(cachePath, basename(f))`. It had been
+  unlinking the original file *before* computing the destination, which made
+  `remapFilenames()`'s "is the original location still valid" test
+  (`is_absolute_path(x) && file.exists(x)`) fail on the very files just deleted.
+  For a raster with no resolvable anchor that test always failed, so the
+  destination fell back to the cache root with the `cacheId` dropped -- and two
+  cached calls whose rasters shared a basename silently overwrote one another
+  there, with one call returning the other's data. The unlink now clears only the
+  computed destination, after it is known.
+
 # reproducible 3.2.1.9002
 
 ## enhancements

--- a/R/exportedMethods.R
+++ b/R/exportedMethods.R
@@ -247,15 +247,23 @@ unwrapSpatRaster <- function(obj, cachePath = getOption("reproducible.cachePath"
         filenameInCache <- filenameInCacheWPrefix(filenameInCache, cacheId = cacheId, relative = FALSE)
         # filenameInCache <- .prefix(filenameInCache, prefixCacheId(cacheId))
         # if (!identical(filenameInCache, filenameInCache2)) browser()
-        feObjs <- file.exists(obj)
-        if (any(feObjs))
-          unlink(obj[feObjs])
         # Rebuild the destination from the stored *relative* tags (anchor + relName)
         #   rather than reusing `fns` (the producing machine's embedded absolute path).
         #   Passing `fns` as `obj` here short-circuited remapFilenames() to the verbatim
         #   producer path, which is what made a cloud-cached raster try to write back to
         #   e.g. /home/<producer>/... on a different user's machine.
         newFiles <- remapFilenames(tags = tags, cachePath = cachePath, ...)
+        # Clear the DESTINATION, and only after it has been computed. This used to unlink the
+        #   original files first, which broke remapFilenames(): for a raster with no resolvable
+        #   anchor it tests `is_absolute_path(x) && file.exists(x)` to decide whether the original
+        #   location is still valid, and that test was being asked about files this line had just
+        #   deleted. It therefore always failed, falling through to `file.path(cachePath,
+        #   basename(x))` -- dropping BOTH the original directory and the cacheId, so two cached
+        #   calls whose rasters share a basename silently overwrote one another in the cache root
+        #   and returned each other's data.
+        feNew <- file.exists(newFiles$newName)
+        if (any(feNew))
+          unlink(newFiles$newName[feNew])
         fromFiles <- unlist(filenameInCache)
       } else {
         newFiles <- remapFilenames(tags = tags, cachePath = cachePath, ...)

--- a/tests/testthat/test-unwrapSpatRaster.R
+++ b/tests/testthat/test-unwrapSpatRaster.R
@@ -1,0 +1,74 @@
+## unwrapSpatRaster() restores a file-backed SpatRaster from the cache. It used to unlink the
+## original file BEFORE computing the destination, which broke remapFilenames(): with no resolvable
+## anchor, that function decides whether the original location is still usable by testing
+## `is_absolute_path(x) && file.exists(x)` -- on the very files the unlink had just removed. The test
+## always failed, so the destination fell back to `file.path(cachePath, basename(x))`, dropping both
+## the original directory and the cacheId. Two cached calls whose rasters happened to share a
+## basename then overwrote each other in the cache root, and one silently returned the other's data.
+
+test_that("unwrapSpatRaster restores file-backed rasters to their original path", {
+  skip_if_not_installed("terra")
+  testInit("terra", opts = list(
+    "reproducible.showSimilar" = FALSE,
+    "reproducible.useMemoise" = FALSE
+  ))
+  withr::local_options(reproducible.cachePath = tmpdir)
+
+  ## deliberately OUTSIDE the cachePath: the fallback that this test guards against only engages
+  ## for a raster whose location has no resolvable anchor relative to the cache.
+  dp <- withr::local_tempdir("mapsElsewhere")
+
+  mk <- function(val) {
+    terra::writeRaster(
+      terra::rast(nrows = 10, ncols = 10, vals = val),
+      file.path(dp, "layer.tif"), overwrite = TRUE
+    )
+  }
+
+  onMiss <- Cache(mk(111), .functionName = "mkOne")
+  expect_equal(terra::values(onMiss)[1], 111)
+
+  onHit <- Cache(mk(111), .functionName = "mkOne")
+  expect_equal(terra::values(onHit)[1], 111)
+  ## restored where it was produced, not dumped in the cache root
+  expect_identical(normPath(terra::sources(onHit)), normPath(file.path(dp, "layer.tif")))
+  expect_true(file.exists(file.path(dp, "layer.tif")))
+  expect_false(file.exists(file.path(tmpdir, "layer.tif"))) ## not dumped in the cache root
+})
+
+test_that("two cached calls sharing a raster basename do not collide", {
+  skip_if_not_installed("terra")
+  testInit("terra", opts = list(
+    "reproducible.showSimilar" = FALSE,
+    "reproducible.useMemoise" = FALSE
+  ))
+  withr::local_options(reproducible.cachePath = tmpdir)
+
+  ## both OUTSIDE the cachePath, and unrelated to each other
+  dpA <- withr::local_tempdir("elsewhereA")
+  dpB <- withr::local_tempdir("elsewhereB")
+
+  ## same basename, different directories, different values, different cacheIds
+  mk <- function(val, dp) {
+    list(terra::writeRaster(
+      terra::rast(nrows = 10, ncols = 10, vals = val),
+      file.path(dp, "1.tif"), overwrite = TRUE
+    ))
+  }
+
+  a1 <- Cache(mk(111, dpA), .functionName = "A")
+  b1 <- Cache(mk(222, dpB), .functionName = "B")
+  expect_equal(terra::values(a1[[1]])[1], 111)
+  expect_equal(terra::values(b1[[1]])[1], 222)
+
+  ## the restore path is where they used to clobber one another
+  a2 <- Cache(mk(111, dpA), .functionName = "A")
+  b2 <- Cache(mk(222, dpB), .functionName = "B")
+  expect_equal(terra::values(a2[[1]])[1], 111)
+  expect_equal(terra::values(b2[[1]])[1], 222)
+  expect_false(identical(terra::sources(a2[[1]]), terra::sources(b2[[1]])))
+
+  ## and A stays A after B has also been restored
+  a3 <- Cache(mk(111, dpA), .functionName = "A")
+  expect_equal(terra::values(a3[[1]])[1], 111)
+})


### PR DESCRIPTION
## The bug

Two distinct cached calls whose file-backed rasters happen to share a *basename* silently return each other's data.

```r
mk <- function(val, dp) list(terra::writeRaster(
  terra::rast(nrows = 10, ncols = 10, vals = val), file.path(dp, "1.tif"), overwrite = TRUE))

a1 <- Cache(mk(111, dpA), .functionName = "A")   # A = 111
b1 <- Cache(mk(222, dpB), .functionName = "B")   # B = 222

a2 <- Cache(mk(111, dpA), .functionName = "A")   # A = 222   <-- returns B's raster
```

`dpA` and `dpB` are different directories. No error, no warning.

## Why

`unwrapSpatRaster()` unlinked the original files *before* computing the destination:

```r
feObjs <- file.exists(obj)
if (any(feObjs))
  unlink(obj[feObjs])
newFiles <- remapFilenames(tags = tags, cachePath = cachePath, ...)
```

`remapFilenames()` decides whether the original location is still usable by testing
`is_absolute_path(x) && file.exists(x)` — and it was being asked about the files the line above had
just deleted. For a raster with no resolvable anchor that test therefore *always* failed, so the
destination fell through to the fallback:

```r
if (fs::is_absolute_path(rel)) rel <- basename(rel)
as.character(fs::path_norm(fs::path_join(c(fallbackBase, rel))))   # fallbackBase = cachePath
```

— dropping both the original directory and the `cacheId`. The save side namespaces correctly
(`cacheOutputs/<cacheId>_1.tif`), so the two sides disagreed and every call sharing a basename
landed on the same `cachePath/1.tif`.

Call path, from tracing `hardLinkOrCopy`:
`.unwrap` → `.unwrap.default` → `unwrapSpatRaster` → `remapFilenames` → `hardLinkOrCopy`

```
[hardLinkOrCopy] from: <cachePath>/cacheOutputs/03156a2a2cceb67e_1.tif
                   to: <cachePath>/1.tif          # should be <dpA>/1.tif
```

## The fix

Compute the destination first, then unlink only that destination. The anchor-based remap for
cloud-cached rasters is untouched — that path never depended on `file.exists()` — so this only
restores the intended local behaviour.

## Tests

`tests/testthat/test-unwrapSpatRaster.R`. The rasters are written to directories **unrelated to the
cachePath**, since the fallback only engages when the raster's location has no anchor relative to
the cache; putting them under the cachePath would not exercise the bug.

- restores to the producing directory, and leaves nothing in the cache root
- two calls sharing a basename keep their own data across the restore

5 assertions fail without the `R/exportedMethods.R` change; all pass with it.

Full `cache|Cache|wrap|terra|raster|postProcess` suites pass locally (skips are Drive-token and DBI only).

## Note

The pre-commit hook fired twice during an amend, so `DESCRIPTION` went 3.2.1.9003 → 3.2.1.9005.
`NEWS.md` matches. Happy to squash that back if you'd rather it were a single increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH6MzXGkUCv236pFW6XUhi