### PR TITLE
fix(linkOrCopy): decide self-reference per element, not per call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-04
-Version: 3.2.1.9005
+Date: 2026-09-05
+Version: 3.2.1.9006
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# reproducible 3.2.1.9006
+
+## bug fixes
+
+* `linkOrCopy()` no longer errors when `from` and `to` contain a self-referential
+  pair alongside real ones. A file already at its destination cannot be linked or
+  copied onto itself -- `file.copy()` raises
+  "file can not be copied both 'from' and 'to'" -- and the guard against this was
+  `!all(normPath(to) %in% normPath(from))`. That is set membership rather than
+  pairwise, and all-or-nothing, while the operation itself is element-wise: a call
+  mixing self-referential pairs with real ones fell straight through and errored,
+  taking the legitimate copies down with it. It could also skip real work, when a
+  `to` happened to equal some unrelated `from`. Self-reference is now decided per
+  element; those elements are reported and skipped, and the rest proceed.
+  Reached in practice through `prepInputs()`/`preProcess()` when some needed files
+  are already in `getOption("reproducible.inputPaths")` and others are not.
+
 # reproducible 3.2.1.9005
 
 ## bug fixes

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1761,6 +1761,28 @@ isGoogleDownloadURL <- function(url) {
 #' }
 linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
                        verbose = getOption("reproducible.verbose", 1)) {
+  ## A file that is already at its destination cannot be linked or copied onto
+  ## itself; file.copy() errors with "file can not be copied both 'from' and
+  ## 'to'". This has to be decided per element: `from` and `to` are parallel
+  ## vectors, and a single call routinely mixes self-referential pairs with real
+  ## ones -- e.g. when some of the needed files are already in
+  ## `getOption("reproducible.inputPaths")` and others are not.
+  ## The previous guard was `!all(normPath(to) %in% normPath(from))`, which is
+  ## (a) set membership rather than pairwise, so it could also skip a legitimate
+  ## copy whose `to` happened to equal some unrelated `from`, and (b)
+  ## all-or-nothing, so any mixed vector fell straight through to file.copy().
+  selfRef <- normPath(from) == normPath(to)
+  if (any(selfRef)) {
+    messagePreProcess(
+      singularPlural(c("File is", "Files are"), l = from[selfRef]),
+      " already at the destination:\n", paste(to[selfRef], collapse = "\n"),
+      "\n", messageNoCopyMade, verbose = verbose)
+    if (all(selfRef))
+      return(TRUE)
+    from <- from[!selfRef]
+    to <- to[!selfRef]
+  }
+
   existsLogical <- file.exists(from)
   existsTo <- file.exists(to)
 
@@ -1768,8 +1790,7 @@ linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
   fromCollapsed <- paste(from, collapse = "\n")
   result <- TRUE
 
-  ## if the filename is the same, you can't copy from self to self
-  if (!all(normPath(to) %in% normPath(from))) {
+  if (length(from)) {
     if (any(existsLogical)) {
       toDirs1 <- unique(dirname(to))
       dirDoesntExist1 <- !dir.exists(toDirs1)

--- a/tests/testthat/test-linkOrCopy.R
+++ b/tests/testthat/test-linkOrCopy.R
@@ -151,3 +151,42 @@ test_that("linkOrCopy tries a symlink before copying on unix", {
   expect_true(file.exists(to))
   expect_identical(readLines(to, warn = FALSE), "payload")
 })
+
+test_that("linkOrCopy tolerates self-referential from/to pairs, alone and mixed", {
+  testInit()
+
+  ## Regression: a file already at its destination cannot be linked or copied
+  ## onto itself -- file.copy() raises "file can not be copied both 'from' and
+  ## 'to'". The guard used to be `!all(normPath(to) %in% normPath(from))`, which
+  ## is set membership rather than pairwise AND all-or-nothing, so a vector that
+  ## mixed self-referential pairs with real ones fell through and errored. This
+  ## is reached in practice via prepInputs when some needed files are already in
+  ## getOption("reproducible.inputPaths") and others are not.
+  a <- file.path(tmpdir, "a.txt")
+  b <- file.path(tmpdir, "b.txt")
+  writeLines("A", a)
+  writeLines("B", b)
+
+  ## 1. Every pair self-referential -- no-op, no error.
+  expect_true(isTRUE(all(suppressMessages(linkOrCopy(a, a, verbose = 0)))))
+  expect_identical(readLines(a, warn = FALSE), "A")
+
+  ## 2. Mixed: one self-referential pair, one real copy. This is the case that
+  ##    used to error out entirely, taking the legitimate copy down with it.
+  bTo <- file.path(tmpdir, "sub", "b-copy.txt")
+  res <- suppressMessages(
+    linkOrCopy(from = c(a, b), to = c(a, bTo), verbose = 0)
+  )
+  expect_true(isTRUE(all(res)))
+  expect_true(file.exists(bTo))
+  expect_identical(readLines(bTo, warn = FALSE), "B")
+  expect_identical(readLines(a, warn = FALSE), "A")
+
+  ## 3. A `to` that merely collides with an unrelated `from` must still copy --
+  ##    the old `%in%` test could skip real work here.
+  c1 <- file.path(tmpdir, "c.txt")
+  writeLines("C", c1)
+  res3 <- suppressMessages(linkOrCopy(from = c1, to = b, verbose = 0))
+  expect_true(isTRUE(all(res3)))
+  expect_identical(readLines(b, warn = FALSE), "C")
+})


### PR DESCRIPTION
## The bug

A file already at its destination cannot be linked or copied onto itself — `file.copy()` raises `file can not be copied both 'from' and 'to'`. `linkOrCopy()` guarded against that with:

```r
if (!all(normPath(to) %in% normPath(from)))
```

which is wrong in two ways:

1. **Set membership, not pairwise.** A `to` that merely collides with some *unrelated* `from` in the same vector suppressed a legitimate copy.
2. **All-or-nothing, but the operation is element-wise.** A call mixing self-referential pairs with real ones fell straight through to `file.copy()` and errored — taking the legitimate copies down with it.

## How it surfaces

Through `prepInputs()`/`preProcess()` whenever *some* of the needed files are already in `getOption("reproducible.inputPaths")` and others are not:

```
Error in file.copy(from[!result], to[!result], overwrite = overwrite) :
  file can not be copied both 'from' and 'to'
Calls: ... pp_link_to_destination -> hardLinkOrCopy -> linkOrCopy
```

## The fix

Self-reference is computed per element. Those elements are reported and skipped; the rest proceed as before. When every pair is self-referential the function short-circuits to `TRUE`, matching the previous behaviour.

## Tests

`tests/testthat/test-linkOrCopy.R` gains a regression test covering three cases: all-self-referential, mixed (the case that errored), and a `to` colliding with an unrelated `from` (the case that silently skipped real work). It **errors without the fix** and passes with it.

Verified green locally with no new failures: `test-linkOrCopy.R`, `test-copy.R`, `test-symlinks.R`, `test-preProcessWorks.R`, `test-preProcessDoesntWork.R`, `test-prepInputs.R` (network/Drive tests skipped — no token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3