### PR TITLE
fix(preProcess): scope destinationPathShared by archive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-05
-Version: 3.2.1.9006
+Version: 3.2.1.9007
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# reproducible 3.2.1.9007
+
+## bug fixes
+
+* `reproducible.destinationPathShared`: files extracted from an archive are now
+  stored under `<shared>/<archive stem>/` (with the archive and their own
+  `CHECKSUMS.txt`) instead of flat in the shared root. The flat layout keyed
+  extracted files by their archive-relative name alone, so two archives with the
+  same inner path -- every ClimateNA tile zip contains `Year_1991MSY/CMD_sm.asc` --
+  shared one file: `preProcess()` redirected into the shared root, found the name
+  in the root `CHECKSUMS.txt`, skipped extraction, and hardlinked the first
+  archive's file into every later request. An archive already sitting flat in a
+  pre-existing shared root is migrated into its scoped directory on first use, so
+  downloads are still reused; flat extracted files are left alone and no longer
+  consulted for archive contents. (#585)
+
 # reproducible 3.2.1.9006
 
 ## bug fixes

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -352,7 +352,8 @@ pp_checksums_init <- function(ctx) {
   # local re-verification.
   filesPreVerified <- character()
   if (length(filesToCheck)) {
-    sidecarDirs <- unique(c(ctx$destinationPath, .getDestinationPathShared()))
+    sharedRoots <- .getDestinationPathShared()
+    sidecarDirs <- unique(c(ctx$destinationPath, .sharedDirsFor(sharedRoots, ctx$archive), sharedRoots))
     hasSidecar <- vapply(filesToCheck, function(f) {
       length(.findRemoteHashSidecars(basename2(f), sidecarDirs)) > 0L &&
         file.exists(f)
@@ -364,7 +365,8 @@ pp_checksums_init <- function(ctx) {
     }
   }
 
-  inputPaths <- runChecksums(ctx$destinationPath, ctx$checkSumFilePath, filesToCheck, ctx$verbose)
+  inputPaths <- runChecksums(ctx$destinationPath, ctx$checkSumFilePath, filesToCheck, ctx$verbose,
+                             archive = ctx$archive)
 
   ctx$reproducible.inputPaths <- inputPaths$reproducible.inputPaths
   ctx$destinationPathUser     <- inputPaths$destinationPathUser
@@ -1126,6 +1128,15 @@ pp_link_to_destination <- function(ctx) {
           messagePreProcess("... linking to getOption('reproducible.destinationPathShared')...",
                             verbose = ctx$verbose)
           hardLinkOrCopy(from, to, verbose = ctx$verbose)
+          # An archive's shared dir keeps its own CHECKSUMS.txt -- the root index is
+          # never consulted for archive contents -- so record what was just linked.
+          if (!isNULLorNA(ctx$archive)) {
+            linked <- to[file.exists(to)]
+            if (length(linked))
+              appendChecksumsTable(checkSumFilePath = identifyCHECKSUMStxtFile(riP),
+                                   filesToChecksum = linked, destinationPath = riP,
+                                   append = TRUE, verbose = ctx$verbose - 1L)
+          }
         } else {
           messagePreProcess("Skipping copy from destinationPathShared; all files present",
                             verbose = ctx$verbose)
@@ -1673,7 +1684,9 @@ isGoogleDownloadURL <- function(url) {
     }
     # do a check here that destinationPath is already the destinationPathShared
     #   need to emulate the above behaviour
-    reproducible.inputPaths <- .getDestinationPathShared()
+    # `otherPaths` is already this request's shared dir (archive-scoped when there is
+    # an archive); re-reading the option here would compare against the root.
+    reproducible.inputPaths <- otherPaths
     if (!is.null(reproducible.inputPaths)) {
       reproducible.inputPaths <- normPath(reproducible.inputPaths)
     }
@@ -2338,13 +2351,46 @@ setupArchive <- function(archive, destinationPath) {
   archive
 }
 
-runChecksums <- function(destinationPath, checkSumFilePath, filesToCheck, verbose) {
-  reproducible.inputPaths <- .getDestinationPathShared()
-  if (!is.null(reproducible.inputPaths)) {
-    reproducible.inputPaths <- checkPath(reproducible.inputPaths, create = TRUE)
+# Files extracted from an archive are only meaningful together with that archive.
+# Every ClimateNA tile zip contains `Year_1991MSY/CMD_sm.asc`; a shared store keyed
+# by that archive-relative name alone handed tile 55 the file extracted from tile 34
+# (one inode, 32 hardlinks across seven projects). So a request that involves an
+# archive uses its own directory inside destinationPathShared,
+# `<shared>/<archive stem>/`, holding the archive, whatever was extracted from it,
+# and their CHECKSUMS.txt. Requests for plain files keep using the shared root.
+.sharedDirsFor <- function(sharedRoots, archive) {
+  if (is.null(sharedRoots) || isNULLorNA(archive)) return(sharedRoots)
+  stem <- tools::file_path_sans_ext(basename2(archive[1]), compression = TRUE)
+  file.path(sharedRoots, stem)
+}
+
+# A shared root populated before archive scoping holds the archive flat at
+# `<shared>/<archive>`. Bring it into the scoped dir once so the download is still
+# reused. Flat *extracted* files are deliberately left where they are: nothing
+# records which archive they came from, which is the defect being fixed.
+.migrateFlatArchive <- function(sharedRoot, sharedDir, archive, verbose) {
+  flat <- file.path(sharedRoot, basename2(archive[1]))
+  scoped <- file.path(sharedDir, basename2(archive[1]))
+  if (!file.exists(flat) || file.exists(scoped)) return(invisible(FALSE))
+  hardLinkOrCopy(flat, scoped, verbose = verbose - 1L)
+  appendChecksumsTable(checkSumFilePath = identifyCHECKSUMStxtFile(sharedDir),
+                       filesToChecksum = scoped, destinationPath = sharedDir,
+                       append = TRUE, verbose = verbose - 1L)
+  invisible(TRUE)
+}
+
+runChecksums <- function(destinationPath, checkSumFilePath, filesToCheck, verbose,
+                         archive = NULL) {
+  sharedRoots <- .getDestinationPathShared()
+  if (!is.null(sharedRoots)) {
+    sharedRoots <- checkPath(sharedRoots, create = TRUE)
+    sharedRoots <- path.expand(sharedRoots)
   }
-  if (!is.null(reproducible.inputPaths)) {
-    reproducible.inputPaths <- path.expand(reproducible.inputPaths)
+  reproducible.inputPaths <- .sharedDirsFor(sharedRoots, archive)
+  if (!identical(reproducible.inputPaths, sharedRoots)) {
+    reproducible.inputPaths <- checkPath(reproducible.inputPaths, create = TRUE)
+    Map(.migrateFlatArchive, sharedRoots, reproducible.inputPaths,
+        MoreArgs = list(archive = archive, verbose = verbose))
   }
 
   destinationPathUser <- NULL

--- a/tests/testthat/test-destinationPathShared.R
+++ b/tests/testthat/test-destinationPathShared.R
@@ -1236,3 +1236,99 @@ test_that("C6: deleted local file + stale sidecar + nothing in shared → downlo
   # The file should now exist locally (downloaded from `file://src/foo.csv`).
   expect_true(file.exists(file.path(dest, "foo.csv")))
 })
+
+# ---------------------------------------------------------------------------
+# A: archive-scoped shared directory
+#
+# Every ClimateNA tile zip contains `Year_1991MSY/CMD_sm.asc`. A shared store keyed
+# by that archive-relative name alone handed tile 55 the file extracted from tile
+# 34 (one inode, 32 hardlinks across seven projects on the FireSense cluster).
+# Files that come out of an archive live under <shared>/<archive stem>/ together
+# with the archive and their own CHECKSUMS.txt; the root index is never consulted
+# for archive contents.
+# ---------------------------------------------------------------------------
+
+# A zip whose single member sits at a relative inner path, built from a scratch
+# dir so the archive records that path. Returns the absolute zip path.
+makeZipFixture <- function(dir, zipName, inner, content) {
+  scratch <- file.path(dir, paste0("build_", tools::file_path_sans_ext(zipName)))
+  dir.create(file.path(scratch, dirname(inner)), recursive = TRUE, showWarnings = FALSE)
+  writeBin(charToRaw(content), file.path(scratch, inner))
+  zp <- file.path(normPath(dir), zipName)
+  withr::with_dir(scratch, suppressWarnings(utils::zip(zp, inner, flags = "-q")))
+  zp
+}
+
+test_that("A1: two archives with the same inner path each deliver their own file", {
+  testInit("digest")
+  skip_if(!nzchar(Sys.which("zip")), "zip binary not available")
+  shared <- normPath(file.path(tmpdir, "shared"))
+  destA  <- normPath(file.path(tmpdir, "destA"))
+  destB  <- normPath(file.path(tmpdir, "destB"))
+  srcA   <- normPath(file.path(tmpdir, "srcA"))
+  srcB   <- normPath(file.path(tmpdir, "srcB"))
+  for (d in c(shared, destA, destB, srcA, srcB)) dir.create(d, recursive = TRUE)
+
+  inner <- "Year_1991MSY/CMD_sm.asc"
+  zipA <- makeZipFixture(srcA, "34_MSY_1990.zip", inner, "tile34\n")
+  zipB <- makeZipFixture(srcB, "55_MSY_1990.zip", inner, "tile55\n")
+
+  withr::local_options(list(reproducible.destinationPathShared = shared))
+
+  capture.output(type = "output",
+    preProcess(url = toFileUrl(zipA), targetFile = inner,
+               destinationPath = destA, fun = NA, verbose = -1))
+  capture.output(type = "output",
+    preProcess(url = toFileUrl(zipB), targetFile = inner,
+               destinationPath = destB, fun = NA, verbose = -1))
+
+  expect_identical(readLines(file.path(destA, inner)), "tile34")
+  expect_identical(readLines(file.path(destB, inner)), "tile55")
+
+  # nothing extracted lands flat in the shared root; each archive has its own dir
+  expect_false(file.exists(file.path(shared, inner)))
+  expect_true(file.exists(file.path(shared, "34_MSY_1990", "34_MSY_1990.zip")))
+  expect_true(file.exists(file.path(shared, "55_MSY_1990", "55_MSY_1990.zip")))
+  expect_true(file.exists(file.path(shared, "55_MSY_1990", inner)))
+  expect_identical(readLines(file.path(shared, "55_MSY_1990", inner)), "tile55")
+})
+
+test_that("A2: legacy flat shared root: archive is migrated and reused, flat extracted file is not", {
+  testInit("digest")
+  skip_if(!nzchar(Sys.which("zip")), "zip binary not available")
+  shared <- normPath(file.path(tmpdir, "shared"))
+  destB  <- normPath(file.path(tmpdir, "destB"))
+  src    <- normPath(file.path(tmpdir, "src"))
+  for (d in c(shared, destB, src)) dir.create(d, recursive = TRUE)
+
+  inner <- "Year_1991MSY/CMD_sm.asc"
+  zipB <- makeZipFixture(src, "55_MSY_1990.zip", inner, "tile55\n")
+
+  # The pre-fix layout: the archive flat in the root, plus a flat extracted file
+  # that came from a DIFFERENT archive, both indexed in the root CHECKSUMS.txt.
+  file.copy(zipB, file.path(shared, "55_MSY_1990.zip"))
+  dir.create(file.path(shared, dirname(inner)), recursive = TRUE)
+  writeBin(charToRaw("tile34\n"), file.path(shared, inner))
+  csRows <- vapply(c("55_MSY_1990.zip", inner), function(f) {
+    p <- file.path(shared, f)
+    sprintf('"%s" "%s" "%d" "xxhash64"', f, digest::digest(file = p, algo = "xxhash64"),
+            file.info(p)$size)
+  }, character(1))
+  writeLines(c('"file" "checksum" "filesize" "algorithm"', csRows),
+             file.path(shared, "CHECKSUMS.txt"))
+
+  withr::local_options(list(reproducible.destinationPathShared = shared))
+
+  # The url points at a file that no longer exists: the only way to succeed is to
+  # reuse the archive already in the shared store.
+  gone <- file.path(src, "not_here_55_MSY_1990.zip")
+  capture.output(type = "output",
+    preProcess(url = toFileUrl(gone), archive = "55_MSY_1990.zip", targetFile = inner,
+               destinationPath = destB, fun = NA, verbose = -1))
+
+  expect_identical(readLines(file.path(destB, inner)), "tile55")
+  expect_true(file.exists(file.path(shared, "55_MSY_1990", "55_MSY_1990.zip")))
+  expect_true(file.exists(file.path(shared, "55_MSY_1990", inner)))
+  # the poisoned flat file is left alone, and was not used
+  expect_identical(readLines(file.path(shared, inner)), "tile34")
+})


### PR DESCRIPTION
## Problem

`reproducible.destinationPathShared` stored files extracted from archives **flat in the shared root**, indexed by their archive-relative name in one `CHECKSUMS.txt`. Every ClimateNA tile zip contains `Year_1991MSY/CMD_sm.asc`, so:

1. `runChecksums()` redirected `destinationPath` into the shared root because the root `CHECKSUMS.txt` had a row for that name;
2. `pp_extract()` saw the row marked OK and skipped extraction;
3. `pp_link_to_destination()` hardlinked the **first tile's** file into the new tile's directory.

On the FireSense cluster one inode ended up with 32 hardlinks standing in for ten different tiles across seven projects (`/mnt/fast/data/Year_1991MSY/CMD_sm.asc`). Per-year mosaics then had inconsistent extents, and `canClimateData:init` failed with `[rast] extents do not match` (or, for four-tile study areas, silently produced single-tile climate).

## Fix

An archive-based request uses `<shared>/<archive stem>/` as its shared directory: the archive, whatever is extracted from it, and their `CHECKSUMS.txt` live together, and the root index is never consulted for archive contents.

- `runChecksums()` takes `archive`; `.sharedDirsFor()` derives the scoped dir; `.migrateFlatArchive()` brings a legacy flat archive (and its checksum row) into the scoped dir on first use, so downloads are still reused.
- `pp_checksums_init()` includes the scoped dir when looking for `.hash` sidecars.
- `.checkLocalSources()` compares against the request's shared dir rather than re-reading the root option.
- `pp_link_to_destination()` records what it links into an archive's shared dir in that dir's `CHECKSUMS.txt`.

Legacy flat extracted files are left where they are (nothing records which archive they came from). Requests for plain files are unchanged.

## Tests

`tests/testthat/test-destinationPathShared.R`:
- **A1** two zips with identical inner paths each deliver their own content through the shared store (fails on `development`: the second request returned the first archive's file and downloaded nothing).
- **A2** legacy flat root holding the archive plus a poisoned flat extracted file: the archive is migrated and reused (the URL points at a file that no longer exists), and the right content is delivered.

Locally green: destinationPathShared (42), preProcessWorks (33), preProcessDoesntWork, archiveFormats, archiveHelpers, linkOrCopy, symlinks, prepInputsUrlTiles, tileGridOffline, checksums, cacheHelpers, prepInputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3
