### PR TITLE
fix(.listFilesInArchive): guessed candidate archives broke the system-tool path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-05
-Version: 3.2.1.9007
+Version: 3.2.1.9008
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# reproducible 3.2.1.9008
+
+## bug fixes
+
+* `.listFilesInArchive()` no longer fails with "the condition has length > 1" on the
+  system-tool path. `.checkForSimilar()` passes several *guessed* candidate archives
+  (`<name>.rar`, `.tar`, `.zip`) when a download has no archive extension; the `.rar`
+  first element routed to the 7-Zip/unrar branch, which handed the whole vector to
+  `.testForArchiveExtract()`. Only reached when the `archive` package is not
+  installed, which is why it broke every LandR CI job (and `development` since
+  2026-08-29) while passing on developer machines. Candidates that are not on disk
+  now return `NULL` before any tool probe, and the probe sees the first candidate only.
+
 # reproducible 3.2.1.9007
 
 ## bug fixes

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1301,7 +1301,14 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
       }
 
       if (needSystemCall) {
-        extractSystemCallPath <- .testForArchiveExtract(archive)
+        # `archive` may be several *guessed* candidates (.checkForSimilar() tries
+        # <name>.rar/.tar/.zip when a download has no archive extension). Nothing
+        # can be listed from one that is not on disk, and looking for 7-Zip/unrar
+        # on its behalf can stop() on a machine without them -- so return before
+        # probing, and probe for the first candidate only: passing the whole
+        # vector made the probe's `if` a length-3 condition.
+        if (!isTRUE(file.exists(archive[1]))) return(NULL)
+        extractSystemCallPath <- .testForArchiveExtract(archive[1])
         funWArgs <- list(fun = extractSystemCallPath)
       } else {
         funWArgs <- .whichExtractFn(archive[1], NULL, dontUse = dontUse)
@@ -1526,7 +1533,7 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
   sevenzName <- grep("7z", knownSystemArchiveExtensions, value = TRUE)
 
   extractSystemCallPath <- NULL
-  if (tools::file_ext(archive) == sevenzName) {
+  if (isTRUE(tools::file_ext(archive[1]) == sevenzName)) {
     extractSystemCallPath <- Sys.which(sevenzName)
   }
 

--- a/tests/testthat/test-archiveHelpers.R
+++ b/tests/testthat/test-archiveHelpers.R
@@ -81,3 +81,32 @@ test_that("knownArchiveExtensions and its subsets stay consistent", {
   expect_true(all(knownSystemArchiveExtensions %in% knownArchiveExtensions))
   expect_true("zip" %in% knownInternalArchiveExtensions)
 })
+
+test_that(".listFilesInArchive: guessed candidates that are not on disk never reach the tool probe", {
+  ## .checkForSimilar() guesses <name>.rar/.tar/.zip when a download has no archive
+  ## extension. None exist. The .rar first element routes to the system-tool branch,
+  ## which used to hand the whole vector to .testForArchiveExtract(), whose `if`
+  ## then had a length-3 condition (every LandR CI job, where `archive` is absent).
+  cands <- file.path(withr::local_tempdir(), c("guess.rar", "guess.tar", "guess.zip"))
+  seen <- NULL
+  testthat::local_mocked_bindings(
+    .testForArchiveExtract = function(archive = "") { seen <<- archive; NULL },
+    .package = "reproducible"
+  )
+  expect_no_error(res <- .listFilesInArchive(cands))
+  expect_true(is.null(res) || length(res) == 0L)
+  expect_null(seen)
+})
+
+test_that(".listFilesInArchive probes the system tool for the first candidate only", {
+  td <- withr::local_tempdir()
+  rar <- file.path(td, "real.rar")
+  writeBin(as.raw(rep(1L, 64L)), rar)          # exists, > 10 bytes; listing itself is not exercised
+  seen <- NULL
+  testthat::local_mocked_bindings(
+    .testForArchiveExtract = function(archive = "") { seen <<- archive; NULL },
+    .package = "reproducible"
+  )
+  expect_no_error(.listFilesInArchive(c(rar, file.path(td, "real.tar"))))
+  expect_identical(seen, rar)
+})


### PR DESCRIPTION
## Problem

Every LandR R-CMD-check job (and LandR `development` since 2026-08-29) fails in `test-compareRas.R` with:

```
Error in `.listFilesInArchive(archive)`: Error in if (tools::file_ext(archive) == sevenzName) { : the condition has length > 1
```

`.checkForSimilar()` passes several *guessed* candidate archives (`<name>.rar`, `.tar`, `.zip`) when a download has no archive extension. The `.rar` first element routes `.listFilesInArchive()` to the 7-Zip/unrar branch, which handed the whole vector to `.testForArchiveExtract()`. That branch is only reached when the `archive` package is not installed, which is why it passes on developer machines and fails on CI. Reproduced locally in a library without `archive`: `prepInputs(url = <plain .tif>, targetFile = ...)` fails exactly as on CI.

## Fix

- Candidates that are not on disk return `NULL` before any tool probe: nothing can be listed from them, and the probe can `stop()` on a machine without 7-Zip/unrar.
- The probe sees the first candidate only, and the comparison in `.testForArchiveExtract()` is length-safe.

## Tests

`test-archiveHelpers.R`: (1) guessed candidates not on disk never reach the tool probe; (2) with an existing `.rar` first, the probe receives that single path. Both mock `.testForArchiveExtract` so no system tool is needed. The end-to-end reproduction (no `archive` package) now returns a SpatRaster.

Locally green: archiveHelpers, archiveFormats, destinationPathShared. `test-preProcessWorks.R` had 5 `open.connection()` errors from the GitHub outage during the run, unrelated to this change; CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3