### PR TITLE
fix(gdrive): retry transient auth/probe failures instead of falling to anonymous

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-05
-Version: 3.2.1.9008
+Version: 3.2.1.9009
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# reproducible 3.2.1.9009
+
+## bug fixes
+
+* Google Drive auth cascade: a transient failure while authenticating as the configured
+  identity or probing the file (token refresh against `oauth2.googleapis.com`, DNS, a
+  timeout, a 5xx) no longer demotes the request to anonymous access, which on a private
+  file ended in a misleading 404. Such failures are retried (`reproducible.gdriveAuthRetries`,
+  default 2, with backoff); a 403/404 denial is still final. The eventual
+  "Could not access the Google Drive resource" error now says which authenticated
+  attempts were made and why each failed.
+
 # reproducible 3.2.1.9008
 
 ## bug fixes

--- a/R/download.R
+++ b/R/download.R
@@ -561,15 +561,35 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
 # identity is only accepted when it genuinely grants access to *this* resource
 # (not merely "a token loaded"). `team_drive` is forwarded for shared-drive files.
 .gdriveProbe <- function(url, team_drive = NULL) {
-  isTRUE(tryCatch({
+  isTRUE(.gdriveProbeCond(url, team_drive = team_drive))
+}
+
+# Same probe, but hand back the error condition instead of FALSE, so the cascade
+# can tell a definitive denial from a transient failure and can say why an
+# identity was abandoned.
+.gdriveProbeCond <- function(url, team_drive = NULL) {
+  tryCatch({
     args <- list(googledrive::as_id(url))
     if (!is.null(team_drive))
       args[[if (utils::packageVersion("googledrive") < "2.0.0")
         "team_drive" else "shared_drive"]] <- team_drive
     suppressMessages(do.call(googledrive::drive_get, args))
     TRUE
-  }, error = function(e) FALSE))
+  }, error = function(e) e)
 }
+
+# Is this error a definitive "this identity cannot see the file" (HTTP 403/404),
+# as opposed to a transient failure -- token refresh against oauth2.googleapis.com,
+# DNS, a timeout, a 5xx -- that is worth retrying before giving the identity up?
+.gdriveIsDenial <- function(e) {
+  msg <- conditionMessage(e)
+  isTRUE(grepl("\\((403|404)\\)|\\b40[34]\\b|File not found|insufficient", msg, ignore.case = TRUE))
+}
+
+# What happened to the configured identities during the most recent cascade. Read
+# by .stopGoogleDriveAccess(): when anonymous access then gets a 404 on a private
+# file, the useful fact is *why* the authenticated attempt was abandoned, not the 404.
+.gdriveLastAuth <- new.env(parent = emptyenv())
 
 # The ordered list of auth identities to TRY for a Drive resource, each present
 # only when its prerequisite exists (so we never attempt an identity that cannot
@@ -626,19 +646,39 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   op <- options(rlang_interactive = FALSE)
   on.exit(options(op), add = TRUE)
 
+  # A transient failure (token refresh, DNS, timeout, 5xx) must not demote a
+  # configured identity to anonymous access: on a private file that ends in a
+  # misleading 404. Six workers starting 20 s apart and refreshing one cached
+  # token did exactly that. Retry such failures; a 403/404 denial is final.
+  retries <- getOption("reproducible.gdriveAuthRetries", 2L)
+  .gdriveLastAuth$attempts <- character()
+
   for (cand in .gdriveAuthCandidates()) {
-    ok <- isTRUE(tryCatch({
-      if (identical(cand$kind, "email")) {
-        messagePreProcess("Google Drive: trying option gargle_oauth_email = '",
-                          paste(cand$email, collapse = "', '"), "'", verbose = verbose)
-        suppressMessages(googledrive::drive_auth(email = cand$email))
-      } else {
-        messagePreProcess("Google Drive: trying service-account JSON from $",
-                          cand$envvar, verbose = verbose)
-        suppressMessages(googledrive::drive_auth(path = cand$path))
-      }
-      .gdriveProbe(url, team_drive = team_drive)
-    }, error = function(e) FALSE))
+    label <- if (identical(cand$kind, "email")) {
+      paste0("gargle_oauth_email = '", paste(cand$email, collapse = "', '"), "'")
+    } else {
+      paste0("service-account JSON from $", cand$envvar)
+    }
+    messagePreProcess("Google Drive: trying option ", label, verbose = verbose)
+    ok <- FALSE
+    for (attempt in seq_len(1L + retries)) {
+      res <- tryCatch({
+        if (identical(cand$kind, "email")) {
+          suppressMessages(googledrive::drive_auth(email = cand$email))
+        } else {
+          suppressMessages(googledrive::drive_auth(path = cand$path))
+        }
+        .gdriveProbeCond(url, team_drive = team_drive)
+      }, error = function(e) e)
+      if (isTRUE(res)) { ok <- TRUE; break }
+      .gdriveLastAuth$attempts <- c(.gdriveLastAuth$attempts,
+                                    paste0(label, ": ", conditionMessage(res)))
+      if (.gdriveIsDenial(res) || attempt > retries) break
+      messagePreProcess("Google Drive: transient failure (",
+                        substr(conditionMessage(res), 1L, 80L), "); retrying in ",
+                        2L * attempt, " s", verbose = verbose)
+      Sys.sleep(2L * attempt)
+    }
     if (ok) return("token")
     # This identity authenticated but cannot read the file (or failed to load):
     # clear its (possibly poisoning) token before trying the next rung.
@@ -667,10 +707,15 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
 # front, preserving the original error detail (404 reason/location etc.).
 .stopGoogleDriveAccess <- function(url, e) {
   browserUrl <- .gdriveBrowserUrl(url)
+  tried <- tryCatch(.gdriveLastAuth$attempts, error = function(e) character())
+  authNote <- if (length(tried)) {
+    paste0("\n  Authenticated access was tried first and failed:\n    ",
+           paste(tried, collapse = "\n    "), "\n  ")
+  } else ""
   stop("Could not access the Google Drive resource:\n  ",
        if (!is.na(browserUrl)) browserUrl else url,
        "\n  (open it in a browser to confirm it exists and is shared ",
-       "'Anyone with the link')\n  ",
+       "'Anyone with the link')", authNote, "\n  ",
        conditionMessage(e), call. = FALSE)
 }
 

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -216,3 +216,54 @@ test_that(".stopGoogleDriveAccess surfaces the full URL and the original error",
   # ...and the original googledrive detail is preserved
   expect_error(reproducible:::.stopGoogleDriveAccess(id, err), "File not found")
 })
+
+test_that(".gdrivePrepareAuth: a transient probe failure is retried, not demoted to anonymous", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = "a@b.com",
+                       reproducible.gdriveAuthRetries = 1L)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  events <- character(); n <- 0L
+  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  testthat::local_mocked_bindings(
+    as_id = function(x) x,
+    drive_auth = function(...) { events <<- c(events, "auth"); invisible() },
+    drive_get = function(...) {                 # first probe: refresh/network blip; second: fine
+      n <<- n + 1L; events <<- c(events, paste0("probe", n))
+      if (n == 1L) stop("Failed to connect to oauth2.googleapis.com port 443: Timeout was reached")
+      invisible(TRUE)
+    },
+    drive_deauth = function(...) events <<- c(events, "deauth"),
+    .package = "googledrive")
+  expect_identical(suppressMessages(reproducible:::.gdrivePrepareAuth("u")), "token")
+  expect_identical(events, c("auth", "probe1", "auth", "probe2"))   # retried; never deauthorized
+})
+
+test_that(".gdrivePrepareAuth: a 403/404 denial is final -- no retry -- and is reported", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = "a@b.com",
+                       reproducible.gdriveAuthRetries = 2L)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  probes <- 0L
+  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  testthat::local_mocked_bindings(
+    as_id = function(x) x,
+    drive_auth = function(...) invisible(),
+    drive_get = function(...) { probes <<- probes + 1L; stop("Client error: (404) Not Found. File not found: u") },
+    drive_deauth = function(...) invisible(),
+    .package = "googledrive")
+  expect_identical(suppressMessages(reproducible:::.gdrivePrepareAuth("u")), "anon")
+  expect_identical(probes, 1L)
+  err <- tryCatch(reproducible:::.stopGoogleDriveAccess("u", simpleError("File not found: u")),
+                  error = function(e) conditionMessage(e))
+  expect_match(err, "Authenticated access was tried first and failed", fixed = TRUE)
+  expect_match(err, "gargle_oauth_email = 'a@b.com': Client error: (404)", fixed = TRUE)
+})
+
+test_that(".gdriveIsDenial separates 403/404 from transient failures", {
+  f <- reproducible:::.gdriveIsDenial
+  expect_true(f(simpleError("Client error: (404) Not Found")))
+  expect_true(f(simpleError("404 File not found")))
+  expect_true(f(simpleError("Client error: (403) Forbidden: insufficientPermissions")))
+  expect_false(f(simpleError("Failed to connect to oauth2.googleapis.com port 443: Timeout was reached")))
+  expect_false(f(simpleError("Server error: (503) Service Unavailable")))
+})


### PR DESCRIPTION
## Problem

`.gdrivePrepareAuth()` swallowed every error while authenticating as the configured identity or probing the file (`error = function(e) FALSE`), dropped the token, and fell back to anonymous access. On a private file that ends in a misleading `(404) File not found`.

A transient failure is enough to trigger it. On the FireSense cluster today, six workers starting 20 s apart refreshed the same cached token against `oauth2.googleapis.com`; two of them lost their job to that 404 while the file existed and the token was valid (verified from a fresh session seconds later).

## Fix

- Transient failures (token refresh, DNS, timeout, 5xx) are retried with backoff, `reproducible.gdriveAuthRetries` (default 2).
- A 403/404 denial is still final and still moves on to the next identity (existing behaviour and tests unchanged).
- Each abandoned attempt is recorded, and `.stopGoogleDriveAccess()` reports them, so the eventual "Could not access the Google Drive resource" error says why the authenticated path was given up instead of only echoing the anonymous 404.

## Tests

`test-gdrive-noauth-metadata.R` (+3): transient failure then success gives `"token"` with no deauth and one retry; a 404 gives no retry, `"anon"`, and the final error names the identity and its failure; `.gdriveIsDenial()` classification. All 15 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3