### PR TITLE
fix(prepInputs): "similar" must not fetch archive-named siblings of a plain file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-05
-Version: 3.2.1.9009
+Version: 3.2.1.9010
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# reproducible 3.2.1.9010
+
+## bug fixes
+
+* `alsoExtract = "similar"` beside a plain file url no longer fetches archive-named
+  siblings (`rasterTest.zip` next to `rasterTest.tif`). A companion is a `.tfw`, `.prj`,
+  `.aux.xml`; an archive sharing the stem is different data, and once fetched it was
+  handed down the pipeline as an archive to extract from -- which is what has kept
+  LandR's R-CMD-check red since 2026-08-24 on machines without 7-Zip. Archive siblings
+  are still returned when the target itself is an archive.
+
 # reproducible 3.2.1.9009
 
 ## bug fixes

--- a/R/download.R
+++ b/R/download.R
@@ -1943,6 +1943,16 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
     found <- stats::setNames(paste0(parent, cand)[ok], cand[ok])
   }
   found <- found[names(found) != base]
+  # A companion is something needed to read `targetFile` -- a `.tfw`, `.prj`,
+  #   `.aux.xml`. An archive sitting beside a plain file is different data that
+  #   happens to share the stem (`rasterTest.tif` next to `rasterTest.zip`), and
+  #   once fetched it is handed down the pipeline as an archive to extract from,
+  #   which is where LandR's CI died. Keep archive siblings only when the target
+  #   itself is an archive.
+  if (is.null(.isArchive(base))) {
+    arch <- .isArchive(names(found))
+    if (length(arch)) found <- found[!names(found) %in% arch]
+  }
   if (length(found)) {
     messagePreProcess("alsoExtract = 'similar': also fetching ",
                       paste(names(found), collapse = ", "), verbose = verbose)

--- a/tests/testthat/test-downloadHelpers.R
+++ b/tests/testthat/test-downloadHelpers.R
@@ -291,6 +291,21 @@ test_that(".remoteSiblings does not probe extensions on the deny-list", {
   expect_length(.remoteSiblings("https://example.invalid/d/x.tif", "x.tif", "similar"), 0L)
 })
 
+test_that(".remoteSiblings never returns an archive as a companion of a plain file", {
+  testInit()
+  skip_if_not_installed("curl"); skip_if_not_installed("httr2")
+  ## A listable parent whose index holds the target, two true sidecars, and three
+  ## archives that merely share the stem. Fetched, those archives are treated as
+  ## archives to extract from each other -- LandR CI died in exactly that way on
+  ## tati-micheletti/host/data/rasterTest.{tif,rar,tar,zip}.
+  html <- paste0('<a href="rasterTest.', c("tif", "tfw", "tif.aux.xml", "zip", "rar", "tar"),
+                 '">x</a>', collapse = "\n")
+  testthat::local_mocked_bindings(.readUrlLines = function(...) html, .package = "reproducible")
+  sibs <- .remoteSiblings("https://example.org/d/rasterTest.tif", "rasterTest.tif", "similar",
+                          verbose = -1)
+  expect_setequal(names(sibs), c("rasterTest.tfw", "rasterTest.tif.aux.xml"))
+})
+
 test_that(".remoteSiblings finds the sidecars beside a file url", {
   skip_on_cran()
   skip_if_not_installed("curl")


### PR DESCRIPTION
## Problem

This is the remaining cause of LandR R-CMD-check being red (LandR #211 and `development` since 2026-08-24), after #586 removed the first one.

`alsoExtract = "similar"` beside a plain file url lists the parent directory and fetches everything sharing the target's stem. For `tati-micheletti/host/data/rasterTest.tif` that is `rasterTest.rar`, `.tar` and `.zip`, different data that happens to share the name. Once fetched they are handed down the pipeline as archives to extract from one another, and `extractFromArchive()` dies with:

```
Some files are not in the archive (.../rasterTest.tar). Specifically: rasterTest.zip
```

With 7-Zip present the bogus archives fail softly, which is why this passes on developer machines and fails on every CI platform.

## Fix

A companion is a `.tfw`, `.prj`, `.aux.xml`. `.remoteSiblings()` now drops archive-named siblings unless the target itself is an archive (in which case the existing deny-list already governs probing).

## Tests

`test-downloadHelpers.R`: a mocked directory index holding the target, two true sidecars and three archives sharing the stem returns only the two sidecars. Reproduced and verified end to end in a library without the `archive` package and with the 7-Zip/unrar probe mocked to nothing: `prepInputs(url = <rasterTest.tif>)` now returns the raster with only the tif on disk. All 21 tests in the file pass (one network test flaked once and passed on re-run on both branch and development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3