### PR TITLE
fix(gdrive): a transient auth failure must not deauthorize the whole session

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-05
-Version: 3.2.1.9010
+Version: 3.2.1.9011
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# reproducible 3.2.1.9011
+
+## bug fixes
+
+* Google Drive auth cascade: a transient failure no longer calls `googledrive::drive_deauth()`.
+  That call is process-wide, so one network blip during reproducible's first Drive access
+  left the whole R session anonymous, and every later direct `googledrive::drive_ls()` by
+  another package (LandR's SCANFI folder listing, for one) failed with "Does not exist" on
+  a folder that exists. After a genuine 403/404 denial the deauthorisation still happens,
+  and the configured email identity is now put back once reproducible's own read is over.
+
 # reproducible 3.2.1.9010
 
 ## bug fixes

--- a/R/download.R
+++ b/R/download.R
@@ -652,8 +652,12 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
   # token did exactly that. Retry such failures; a 403/404 denial is final.
   retries <- getOption("reproducible.gdriveAuthRetries", 2L)
   .gdriveLastAuth$attempts <- character()
+  .gdriveLastAuth$deauthed <- FALSE
+  .gdriveLastAuth$restoreEmail <- NULL
+  denied <- FALSE
 
-  for (cand in .gdriveAuthCandidates()) {
+  cands <- .gdriveAuthCandidates()
+  for (cand in cands) {
     label <- if (identical(cand$kind, "email")) {
       paste0("gargle_oauth_email = '", paste(cand$email, collapse = "', '"), "'")
     } else {
@@ -680,14 +684,46 @@ dlGoogle <- function(url, archive = NULL, targetFile = NULL,
       Sys.sleep(2L * attempt)
     }
     if (ok) return("token")
-    # This identity authenticated but cannot read the file (or failed to load):
-    # clear its (possibly poisoning) token before trying the next rung.
-    try(googledrive::drive_deauth(), silent = TRUE)
+    if (.gdriveIsDenial(res)) {
+      # This identity authenticated but cannot read the file: clear its (possibly
+      # poisoning) token before trying the next rung, and remember how to put the
+      # email identity back afterwards -- drive_deauth() is process-wide, and a
+      # session left anonymous makes every later direct googledrive call by any
+      # package see private folders as "Does not exist".
+      denied <- TRUE
+      if (identical(cand$kind, "email")) .gdriveLastAuth$restoreEmail <- cand$email
+      try(googledrive::drive_deauth(), silent = TRUE)
+      .gdriveLastAuth$deauthed <- TRUE
+    }
+    # A transient failure leaves the auth state alone: googledrive will try again
+    # itself on the next call, and if the network is still down the caller gets
+    # the real error rather than an anonymous 404.
   }
 
   messagePreProcess("Google Drive: trying anonymous (public) access", verbose = verbose)
-  try(googledrive::drive_deauth(), silent = TRUE)
+  if (denied || !length(cands)) {
+    if (!length(cands)) {
+      # nothing configured: anonymous is the only rung, and it must not prompt
+      try(googledrive::drive_deauth(), silent = TRUE)
+      .gdriveLastAuth$deauthed <- TRUE
+    }
+  }
   "anon"
+}
+
+# Undo a denial-driven drive_deauth() once reproducible's own read is over.
+# Called on exit of the caller of .gdrivePrepareAuth(). Only an OAuth email can
+# be put back silently (its token is in the gargle cache); with nothing
+# configured there is nothing to restore.
+.gdriveRestoreAuth <- function() {
+  if (!isTRUE(.gdriveLastAuth$deauthed)) return(invisible(FALSE))
+  email <- .gdriveLastAuth$restoreEmail
+  if (is.null(email) || !requireNamespace("googledrive", quietly = TRUE)) return(invisible(FALSE))
+  op <- options(rlang_interactive = FALSE)
+  on.exit(options(op), add = TRUE)
+  ok <- !inherits(try(suppressMessages(googledrive::drive_auth(email = email)), silent = TRUE), "try-error")
+  if (ok) .gdriveLastAuth$deauthed <- FALSE
+  invisible(ok)
 }
 
 # A browser-pasteable URL for a Google Drive resource, for use in error messages.
@@ -2400,6 +2436,7 @@ assessGoogle <- function(url, archive = NULL, targetFile = NULL,
   # "Anyone with the link" file -- and the metadata read happens before (so
   # defeats) the no-auth download path.
   .gdrivePrepareAuth(url, team_drive = team_drive, verbose = verbose)
+  on.exit(.gdriveRestoreAuth(), add = TRUE)
 
   # Cache the drive_get / drive_ls result indefinitely. The Cache key
   # includes the URL/ID, so each distinct file pays one API hit ever per

--- a/tests/testthat/test-gdrive-noauth-metadata.R
+++ b/tests/testthat/test-gdrive-noauth-metadata.R
@@ -267,3 +267,42 @@ test_that(".gdriveIsDenial separates 403/404 from transient failures", {
   expect_false(f(simpleError("Failed to connect to oauth2.googleapis.com port 443: Timeout was reached")))
   expect_false(f(simpleError("Server error: (503) Service Unavailable")))
 })
+
+test_that(".gdrivePrepareAuth: a transient exhaustion never deauthorizes the session", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = "a@b.com",
+                       reproducible.gdriveAuthRetries = 0L)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  events <- character()
+  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  testthat::local_mocked_bindings(
+    as_id = function(x) x,
+    drive_auth = function(...) { events <<- c(events, "auth"); invisible() },
+    drive_get = function(...) stop("Timeout was reached [oauth2.googleapis.com]"),
+    drive_deauth = function(...) events <<- c(events, "deauth"),
+    .package = "googledrive")
+  expect_identical(suppressMessages(reproducible:::.gdrivePrepareAuth("u")), "anon")
+  expect_identical(events, "auth")            # no deauth: LandR's later drive_ls() must not go anonymous
+  expect_false(isTRUE(reproducible:::.gdriveLastAuth$deauthed))
+  expect_false(reproducible:::.gdriveRestoreAuth())   # nothing to restore
+})
+
+test_that(".gdrivePrepareAuth: after a denial, .gdriveRestoreAuth() puts the email identity back", {
+  skip_if_not_installed("googledrive")
+  withr::local_options(reproducible.gdriveNoAuth = NULL, gargle_oauth_email = "a@b.com",
+                       reproducible.gdriveAuthRetries = 2L)
+  withr::local_envvar(GOOGLEDRIVE_AUTH = "", GARGLE_SERVICE_ACCOUNT = "")
+  events <- character()
+  testthat::local_mocked_bindings(.gdriveHasToken = function() FALSE)
+  testthat::local_mocked_bindings(
+    as_id = function(x) x,
+    drive_auth = function(...) { events <<- c(events, paste0("auth:", list(...)$email)); invisible() },
+    drive_get = function(...) stop("Client error: (404) Not Found. File not found: u"),
+    drive_deauth = function(...) events <<- c(events, "deauth"),
+    .package = "googledrive")
+  expect_identical(suppressMessages(reproducible:::.gdrivePrepareAuth("u")), "anon")
+  expect_identical(events, c("auth:a@b.com", "deauth"))   # denial: deauth once, no retry
+  expect_true(reproducible:::.gdriveRestoreAuth())
+  expect_identical(events, c("auth:a@b.com", "deauth", "auth:a@b.com"))
+  expect_false(isTRUE(reproducible:::.gdriveLastAuth$deauthed))
+})


### PR DESCRIPTION
## Problem

`.gdrivePrepareAuth()` called `googledrive::drive_deauth()` whenever no identity could read the file, including when the identity merely failed **transiently** (a token-refresh timeout). `drive_deauth()` is process-wide: from then on every direct googledrive call by any package ran anonymously. `LandR::loadSCANFISpeciesLayers()` lists the SCANFI folder with `drive_ls()` directly, so it died with `as_parent(path): Does not exist` on a folder that exists and is shared (verified). Four FireSense fits, one of them eight hours in, were lost that way on 2026-09-07 during a spell of `oauth2.googleapis.com` flapping; the traceback from the worker is what pointed here.

## Fix

- A transient exhaustion leaves the auth state alone: googledrive tries again itself on the next call, and if the network is still down the caller gets the real error rather than an anonymous 404.
- After a genuine 403/404 denial the token is still cleared (it could poison the next rung, which is why the deauth exists), and `.gdriveRestoreAuth()`, hooked with `on.exit()` in `assessGoogle()`, puts the configured email identity back once reproducible's own read is over. With nothing configured, anonymous stays the only rung and still never prompts.

## Tests

`test-gdrive-noauth-metadata.R` (+2, 17 total): transient exhaustion gives `"anon"` with no `drive_deauth` event and nothing to restore; a denial gives one deauth and no retry, and the restore re-authenticates the email. All existing cascade tests pass unchanged.

Follows #587 (retry of transient failures); together they make a network blip cost at most the one Drive call in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3