### PR TITLE
fix: take the per-key lock for both cache backends, not only the file one

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-08
-Version: 3.2.1.9012
+Version: 3.2.1.9013
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-08
-Version: 3.2.1.9013
+Version: 3.2.1.9014
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,15 @@
   in the same call, so the other option it changes (`memmax`) could be left altered
   process-wide. Only the order in which the two branches happen to run was keeping
   that from biting.
+* the per-key file lock around "is it cached? -> compute -> store" is now taken for
+  both cache backends. It was inside `if (!useDBI())`, so with the DBI backend no
+  lock was taken and two concurrent workers reaching the same uncached key both
+  computed it. SQLite's own locking cannot prevent that: the function call happens
+  between two independent database operations and no transaction spans them, so WAL
+  and `busy_timeout` keep the database consistent without deduplicating the
+  computation. No deadlock is introduced, since this package holds no transactions,
+  so a database lock never outlives a single statement and every caller takes the
+  file lock first.
 
 ## bug fixes
 

--- a/R/cache-repo.R
+++ b/R/cache-repo.R
@@ -144,10 +144,23 @@ releaseLockFile <- function(locked) {
 
 
 #' @importFrom stats runif
+## Taken for BOTH backends. The lock serializes *callers* around
+## "is it cached? -> compute -> store"; SQLite's own locking (WAL plus
+## busy_timeout, set in createConns()) keeps the *database* consistent. Those are
+## different jobs: the function call happens between two independent database
+## operations, and no transaction spans them, so SQLite cannot deduplicate a
+## computation no matter how it is configured. While this was inside
+## `if (!useDBI())`, the DBI backend had no protection at all and two workers
+## reaching the same cold key both computed it.
+##
+## No deadlock is possible: there are no transactions in this package, so a
+## database lock is only ever held for the duration of one statement and never
+## across an acquisition of this lock. Every caller therefore takes this lock
+## first and any database lock second, which is a single consistent ordering.
 lockFile <- function(cachePath, cache_key,
                      envir   = parent.frame(),
                      verbose = getOption("reproducible.verbose")) {
-  if (!useDBI()) {
+  {
     csd <- CacheStorageDir(cachePath)
     checkPath(csd, create = TRUE)
 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -233,14 +233,17 @@ test_that("test file-backed raster caching", {
       sc <- showCache(tmpCache)
       origFile <- sc[tagKey == "origFilename"]$cacheId
       hasFilenameInCache <- NROW(sc[tagKey %in% tagFilenamesInCache])
-      ## On-disk file count is backend-dependent. Both backends write the object
-      ## .rds and the file-backed .tif (2 files). The flat-file backend ALSO
-      ## writes the tag store and the filename-tag file to disk, whereas useDBI()
-      ## keeps those in the SQLite DB -- so gate both flat-file-only files on
-      ## !useDBI(). (Previously `hasFilenameInCache` was added unconditionally,
-      ## over-counting by one under useDBI = TRUE.)
+      ## On-disk file count is backend-dependent. BOTH backends write the object
+      ## .rds, the file-backed .tif, and the per-key .lock -- the lock is taken for
+      ## both backends now, not only the flat-file one, so that two workers reaching
+      ## the same uncached key cannot both compute it. The flat-file backend ALSO
+      ## writes its tag store, whereas useDBI() keeps that in the SQLite DB.
+      ##
+      ## The previous formula counted 2 for useDBI() and folded the lock into the
+      ## flat-file-only term as `hasFilenameInCache + 1L`, which happened to total
+      ## correctly while the lock existed on one backend only.
       expect_true(length(dir(CacheStorageDir(tmpCache), pattern = origFile)) ==
-                    (2L + as.integer(!useDBI()) * (hasFilenameInCache + 1L) + 2L * savePreDigest))
+                    (3L + as.integer(!useDBI()) * hasFilenameInCache + 2L * savePreDigest))
       # expect_true(length(dir(CacheStorageDir(tmpCache), pattern = origFile)) == 1 + !useDBI())
     }
 

--- a/tests/testthat/test-cluster-lock-per-key.R
+++ b/tests/testthat/test-cluster-lock-per-key.R
@@ -1,0 +1,63 @@
+## One compute per key, whichever backend is in use.
+##
+## `Cache()` runs the function between two independent database operations -- "is it
+## cached?" and "store it" -- and no transaction spans them. SQLite's own locking
+## (WAL, busy_timeout) therefore cannot deduplicate the *computation*, only keep the
+## database consistent. The per-key file lock is what deduplicates, and it used to be
+## taken only when `!useDBI()`, so under the DBI backend two workers reaching the same
+## cold key both computed it.
+##
+## test-cluster.R can see that as an off-by-one in a count of 20, and only when the
+## timing lines up: development stayed green for many runs while the hole was open.
+## This makes it deterministic -- two workers, one cold key, and a function slow
+## enough that the second worker is certain to arrive while the first is still in it.
+## Unlocked that gives two computes; locked it gives one.
+##
+## Two workers, not more: R CMD check sets _R_CHECK_LIMIT_CORES_, and
+## parallel::makeCluster() refuses a third ("3 simultaneous processes spawned").
+##
+## NB the workers `require("reproducible")`, so this exercises the *installed*
+## package, which is what R CMD check runs against. Running it interactively after
+## `pkgload::load_all()` tests the installed build too, not the sources -- so a
+## source change appears to have no effect until it is installed.
+
+test_that("a cold key is computed once, not once per worker, on both backends", {
+  skip_on_cran()
+  skip_if_not_installed("parallel")
+
+  testInit("parallel")
+
+  nWorkers <- min(2L, parallel::detectCores())
+  skip_if(nWorkers < 2L, "needs 2 cores to have two workers race for one key")
+
+  computesForOneColdKey <- function(useDBIhere, secs = 0.5) {
+    cachePath <- file.path(tmpdir, paste0("lockPerKey_", useDBIhere))
+    checkPath(cachePath, create = TRUE)
+    withr::local_options(reproducible.useDBI = useDBIhere)
+    if (isTRUE(useDBIhere) && !file.exists(CacheDBFile(cachePath)))
+      createCache(cachePath)
+
+    cl <- parallel::makeCluster(nWorkers)
+    on.exit(parallel::stopCluster(cl), add = TRUE)
+
+    ## clusterApply, so both workers start their single task at once
+    out <- parallel::clusterApply(
+      cl = cl, x = seq_len(nWorkers),
+      fun = function(i, cachePath, secs, useDBIhere) {
+        suppressWarnings(require("reproducible", quietly = TRUE))
+        options(reproducible.useDBI = useDBIhere, reproducible.verbose = -2)
+        slowly <- function(sd, secs) { Sys.sleep(secs); stats::rnorm(5, sd = sd) }
+        reproducible::Cache(slowly, sd = 1, secs = secs, cachePath = cachePath)
+      },
+      cachePath = cachePath, secs = secs, useDBIhere = useDBIhere
+    )
+    sum(vapply(out, function(x) isTRUE(attr(x, ".Cache")[["newCache"]]), logical(1)))
+  }
+
+  ## the file backend, which always had the lock
+  expect_equal(computesForOneColdKey(FALSE), 1L)
+
+  ## the DBI backend, which did not
+  if (requireNamespace("RSQLite", quietly = TRUE) && requireNamespace("DBI", quietly = TRUE))
+    expect_equal(computesForOneColdKey(TRUE), 1L)
+})

--- a/tests/testthat/test-fileTypeAndLock.R
+++ b/tests/testthat/test-fileTypeAndLock.R
@@ -64,15 +64,22 @@ test_that("lockFile takes a lock on the file-backed backend", {
   filelock::unlock(lock)
 })
 
-test_that("lockFile is a no-op under the DBI backend", {
+test_that("lockFile takes a real lock under the DBI backend too", {
   skip_if_not_installed("RSQLite")
+  skip_if_not_installed("filelock")
   testInit()
 
   withr::local_options(reproducible.useDBI = TRUE)
   skip_if_not(useDBI())
   cp <- checkPath(file.path(tmpdir, "cacheDBI"), create = TRUE)
 
-  ## SQLite does its own locking, so no file lock is taken and no lock file is
-  ## left behind for a later run to trip over.
-  expect_null(lockFile(cp, "abc123"))
+  ## This used to expect NULL, on the reasoning that "SQLite does its own locking".
+  ## SQLite's locking -- WAL plus busy_timeout -- serialises writes to the database
+  ## file. It says nothing about the user's function: two processes with a cold key
+  ## both miss, both compute, and both then write their result. Deduplicating the
+  ## COMPUTE is what this per-key lock is for, so it is needed under both backends.
+  lock <- lockFile(cp, "abc123")
+  expect_s3_class(lock, "filelock_lock")
+  expect_true(any(grepl("abc123", dir(CacheStorageDir(cp)))))
+  filelock::unlock(lock)
 })


### PR DESCRIPTION
## What breaks

`Cache()` runs the cached function *between* two independent database operations — "is this key present?" and "store the result" — and no transaction spans them. So two workers that reach the same uncached key in that window both see an honest miss and both compute it.

The per-key file lock is what prevents that, and it was only taken for one backend. `lockFile()` in `R/cache-repo.R` was a single `if (!useDBI()) { ... }` with no else, so under the DBI backend the call site in `R/cache.R` received nothing and the critical section was unprotected.

## Why SQLite's own locking does not cover it

It is configured and it works: `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000` are set in `createConns()`, which is why concurrent use does not corrupt the database or fail with "database is locked". But those protect the *database*. The computation happens outside SQLite entirely, between two statements, so no journal mode or timeout can deduplicate it. Deduplicating a computation needs a lock held across the call, which is exactly what the file lock does.

## Evidence

Controlled comparison, same code and cluster, four cold keys, a deliberately slow function so the window is reliably open, one variable changed:

| `reproducible.useDBI` | computes for 4 distinct keys, 3 trials |
|---|---|
| `TRUE` | 4, 6, 6 |
| `FALSE` | 4, 4, 4 |

And the same two-worker, one-cold-key case against the patched build actually installed, since PSOCK workers load the installed package rather than a `pkgload`ed source tree: `useDBI = TRUE` now gives 1 compute and 1 lock file, where it gave 2 before.

In the wild this shows up as `test-cluster.R:74` ("test parallel collisions") reporting `sum(news)` of 21 against an expected 20 — one duplicate compute in twenty keys — on whichever CI job happens to be slow enough. It is intermittent because the window is narrow: the same test has been passing on `development` while the hole was open.

## The change

Hoist the lock out of the conditional so both backends take it. Nothing else changes: the lock is still per key, still acquired before the presence check at both call sites (`R/cache.R:156` and `:275`), and still released by the existing `on.exit2(releaseLockFile(...))` in the caller's frame.

**No deadlock is possible.** This package contains no transactions — there is no `dbBegin`, `dbCommit`, `BEGIN IMMEDIATE` or `BEGIN EXCLUSIVE` anywhere in `R/` — so a database lock is only ever held for one statement and never across an acquisition of the file lock. Every caller takes the file lock first and any database lock second: one consistent ordering.

Two consequences worth stating plainly. Concurrent callers on the *same* key now wait for the first to finish instead of racing, which is the point, but it does mean a long computation blocks its duplicates for its duration. And the DBI backend now depends on the filesystem for coordination, which carries the same network-filesystem caveat the file backend already documents in `releaseLockFile()`.

## One visible consequence, and the test that caught it

The lock file is per key and lives in `CacheStorageDir()`, and `releaseLockFile()` deliberately does not delete it (see its comment: deleting and recreating under concurrent load lets two callers hold locks on different inodes). So the DBI backend now has one extra file per key on disk, and `test-cache.R:242` — which counts files matching a cacheId — caught exactly that.

Measured rather than reasoned about, with the patched build installed:

| backend | files per key |
|---|---|
| `useDBI = TRUE` | `<cacheId>.rds`, `<cacheId>_r.tif`, `<cacheId>.lock` |
| `useDBI = FALSE` | the same three, plus `<cacheId>.dbFile.rds` |

The old expectation was `2L + !useDBI() * (hasFilenameInCache + 1L)`, which counted 2 for DBI and folded the lock into the flat-file-only term as the `+ 1L`. That totalled correctly only while the lock existed on one backend. It is now `3L + !useDBI() * hasFilenameInCache`, which says what the layout actually is. `test-cache.R` passes on both backends locally: 295 passing, 0 failed, 0 errors under `useDBI = TRUE`.

## Test

`tests/testthat/test-cluster-lock-per-key.R` asserts one compute per cold key for each backend, using a function slow enough that a second worker is certain to arrive inside the window. That makes the failure deterministic rather than relying on a collision, which matters here: `test-cluster.R` can be green for many runs with the hole wide open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3