### PR TITLE
fix: register postProcessTo's terra-option restores with add = TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-05
-Version: 3.2.1.9011
+Date: 2026-09-08
+Version: 3.2.1.9012
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # reproducible 3.2.1.9011
 
+* `postProcessTo()` registers its `terraOptions(memfrac)` restore with
+  `add = TRUE`. Without it that `on.exit()` replaced any restore already registered
+  in the same call, so the other option it changes (`memmax`) could be left altered
+  process-wide. Only the order in which the two branches happen to run was keeping
+  that from biting.
+
 ## bug fixes
 
 * Google Drive auth cascade: a transient failure no longer calls `googledrive::drive_deauth()`.

--- a/R/postProcessTo.R
+++ b/R/postProcessTo.R
@@ -189,7 +189,11 @@ postProcessTo <- function(from, to,
         co <- capture.output(origMemFrac <- terra::terraOptions()$memfrac)
         if (identical(origMemFrac, 0.5)) { # 0.5 is the default in `terra` on Dec 15, 2025
           terra::terraOptions(memfrac = 0)
-          on.exit(terra::terraOptions(memfrac = origMemFrac))
+          ## add = TRUE: without it this on.exit *replaces* whatever the function has
+          ## already registered, so a second restore below (or any future one) would be
+          ## dropped and its option left changed process-wide. Ordering happens to save
+          ## it today, which is exactly why it should not be relied on.
+          on.exit(terra::terraOptions(memfrac = origMemFrac), add = TRUE)
         }
       }
       # Cap terra per-raster memory for the duration of this call. On high-RAM

--- a/tests/testthat/test-postProcessTo-onexit.R
+++ b/tests/testthat/test-postProcessTo-onexit.R
@@ -1,0 +1,19 @@
+## `terraOptions()` is process-wide, so postProcessTo() restores what it changes with
+## on.exit(). It changes up to two options -- memfrac and memmax -- and registers a
+## restore for each, so every one of those on.exit() calls must pass `add = TRUE`:
+## without it, a later registration replaces an earlier one and that option is left
+## changed for the rest of the session. Whether the bug bites depends only on which
+## branches happen to run, which is not something to rely on.
+
+test_that("every terra-option restore in postProcessTo is registered with add = TRUE", {
+  f <- testthat::test_path("..", "..", "R", "postProcessTo.R")
+  skip_if_not(file.exists(f), "source not available (installed package)")
+
+  code <- grep("^\\s*#", readLines(f, warn = FALSE), invert = TRUE, value = TRUE)
+  restores <- grep("on\\.exit\\(.*terraOptions", code, value = TRUE)
+  expect_gt(length(restores), 0L)          # the restores still exist at all
+  expect_true(all(grepl("add\\s*=\\s*TRUE", restores)),
+              info = paste("restore(s) without add = TRUE:",
+                           paste(grep("add\\s*=\\s*TRUE", restores, invert = TRUE, value = TRUE),
+                                 collapse = " | ")))
+})


### PR DESCRIPTION
## The problem

`postProcessTo()` changes up to two process-wide terra options and restores each with `on.exit()`. The first registration was missing `add = TRUE`:

```r
terra::terraOptions(memfrac = 0)
on.exit(terra::terraOptions(memfrac = origMemFrac))          # replaces, does not add
...
terra::terraOptions(memmax = .tmMax)
on.exit(terra::terraOptions(memmax = .origMemmax), add = TRUE)
```

`on.exit()` without `add = TRUE` *replaces* everything the function has registered so far. Whether that matters depends only on which branches happen to run and in what order. Today the ordering saves it — the `memfrac` restore is registered first, so the `memmax` one adds to it rather than being discarded — but the guarantee is accidental. Reverse the branches, add a third option, or make either condition fire on its own, and one restore silently disappears, leaving a global terra setting changed for the rest of the session.

That failure mode is not hypothetical in this ecosystem: a leaked `terraOptions(memmax)` from a different package is what left a long-lived worker running at `memmax = 1` after it had deliberately set 4 (PredictiveEcology/LandR#213).

## The change

One argument: `add = TRUE`, plus a comment saying why the ordering must not be relied on.

## Test

`tests/testthat/test-postProcessTo-onexit.R` asserts that every `on.exit()` in `postProcessTo.R` that restores a terra option passes `add = TRUE`, and that such restores still exist at all — so removing them, rather than fixing them, does not pass either.

A behavioural test cannot currently reach the second branch: it requires the incoming `memmax` to be unset, and terra 1.9.46 reports a default of 16 rather than the `-1` the surrounding comment assumes, so `.userSetMemmax` is always `TRUE` and the `memmax` restore never registers. That is worth a separate look; it means the `reproducible.terraMemmax` option is currently inert on this terra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3