### PR TITLE
fix: destinationPathShared did not link files extracted from an archive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-08
-Version: 3.2.1.9020
+Version: 3.2.1.9021
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-08
-Version: 3.2.1.9019
+Version: 3.2.1.9020
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # reproducible 3.2.1.9012
 
+## Bug fixes
+
+* `destinationPathShared` now links files that came out of an archive, instead of leaving
+  every destination with its own copy. The shared stash is scoped per archive by
+  `.sharedDirsFor()`, and `runChecksums()` reads back from that scoped directory, but
+  `appendChecksumsTable()` wrote its copy of the rows to the unscoped shared root -- where
+  the read side never looks. An archive-derived file was therefore never found in the
+  stash, so `preProcess()` re-downloaded it and then reached the "already exists at
+  \<stash\>" branch of `downloadRemote()`: an error under the default
+  `overwrite = FALSE`, and a private re-extraction that replaced the stash under
+  `overwrite = TRUE`. Either way the hardlink count never climbed past 2. Found on a run
+  with ~70 study areas sharing one stash, where hardlinking was saving 70% overall but
+  148 archive-derived files still accounted for 588 GB of duplicate copies -- e.g.
+  `CA_FAO_forest_2019.tif` present as 71 copies across 50 inodes.
+
 ## New features
 
 * `whyNoCacheHit()` answers, after the fact, the question a cache miss always

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -524,7 +524,8 @@ pp_resolve_needed_files <- function(ctx) {
         checkSumFilePath = ctx$checkSumFilePath,
         filesToChecksum  = unique(filesToChecksum),
         destinationPath  = ctx$destinationPath,
-        append           = results$needChecksums >= 2L
+        append           = results$needChecksums >= 2L,
+        archive          = ctx$archive
       )
       ctx$needChecksums <- 0L
     }
@@ -1197,7 +1198,8 @@ pp_finalize <- function(ctx) {
         checkSumFilePath = csfp,
         filesToChecksum  = basename2(unique(filesToChecksum)),
         destinationPath  = csp,
-        append           = needChecksums >= 2L
+        append           = needChecksums >= 2L,
+        archive          = ctx$archive
       )
     }
     if (!is.null(ctx$reproducible.inputPaths) && needChecksums != 3L) {
@@ -1206,7 +1208,8 @@ pp_finalize <- function(ctx) {
         filesToChecksum  = unique(filesToChecksum),
         destinationPath  = ctx$destinationPath,
         append           = needChecksums == 2L,
-        verbose          = ctx$verbose - 1L
+        verbose          = ctx$verbose - 1L,
+        archive          = ctx$archive
       )
     }
   }
@@ -1989,7 +1992,8 @@ linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
           checkSumFilePath = checkSumFilePath,
           filesToChecksum = unique(filesToChecksum),
           destinationPath = destinationPath,
-          append = needChecksums >= 2
+          append = needChecksums >= 2,
+          archive = archive
         )
         needChecksums <- 0
       }
@@ -2375,7 +2379,7 @@ setupArchive <- function(archive, destinationPath) {
   hardLinkOrCopy(flat, scoped, verbose = verbose - 1L)
   appendChecksumsTable(checkSumFilePath = identifyCHECKSUMStxtFile(sharedDir),
                        filesToChecksum = scoped, destinationPath = sharedDir,
-                       append = TRUE, verbose = verbose - 1L)
+                       append = TRUE, verbose = verbose - 1L, archive = archive)
   invisible(TRUE)
 }
 

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -1238,7 +1238,8 @@ extractFromArchive <- function(archive,
 #' @importFrom data.table rbindlist as.data.table setDT setDF
 appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
                                  destinationPath = getOption("reproducible.destinationPath", "."),
-                                 append = TRUE, verbose = getOption("reproducible.verbose", 1)) {
+                                 append = TRUE, verbose = getOption("reproducible.verbose", 1),
+                                 archive = NULL) {
   csf <- tempfile(fileext = ".TXT")
   areAbs <- isAbsolutePath(filesToChecksum)
   if (any(!areAbs)) {
@@ -1253,7 +1254,14 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
     )
   })
 
-  rip <- .getDestinationPathShared()
+  ## The shared stash is scoped per archive by .sharedDirsFor(), and runChecksums()
+  ## reads back from that scoped directory. Writing to the unscoped root instead put the
+  ## rows somewhere the read side never looks, so an archive-derived file was never found
+  ## in the stash: preProcess re-downloaded, then hit the "already exists at <stash>"
+  ## branch in downloadRemote() -- an error under the default overwrite = FALSE, and a
+  ## private re-extraction that replaced the stash under overwrite = TRUE. Either way the
+  ## hardlink count never climbed past 2, so every study area kept its own copy.
+  rip <- .sharedDirsFor(.getDestinationPathShared(), archive)
   checkSumFilePaths <- if (!is.null(rip)) {
     unique(c(checkSumFilePath, file.path(rip, basename(checkSumFilePath))))
   } else {

--- a/tests/testthat/test-destinationPathShared-archive.R
+++ b/tests/testthat/test-destinationPathShared-archive.R
@@ -24,8 +24,9 @@ test_that("destinationPathShared links archive-derived files across destinations
     file.path(src, paste0(name, ".zip"))
   }
 
-  nlink <- function(p) as.integer(system2("stat", c("-c", "%h", shQuote(p)), stdout = TRUE))
-  skip_if(is.na(nlink(file.path(src))), "stat(1) unavailable")
+  ## fs, not `stat -c`: that spelling is GNU-only and returns nothing on macOS, where
+  ## BSD stat wants `-f %l`. fs is already an Import and reports hard_links everywhere.
+  nlink <- function(p) as.integer(fs::file_info(p)$hard_links)
 
   linksAcrossDestinations <- function(zip, label) {
     shared <- checkPath(file.path(tmpdir, paste0("shared_", label)), create = TRUE)

--- a/tests/testthat/test-destinationPathShared-archive.R
+++ b/tests/testthat/test-destinationPathShared-archive.R
@@ -1,0 +1,48 @@
+test_that("destinationPathShared links archive-derived files across destinations", {
+  skip_on_cran()
+  testInit("terra")
+
+  ## The shared stash is scoped per archive by .sharedDirsFor(), and runChecksums()
+  ## reads back from that scoped directory. appendChecksumsTable() used to write its
+  ## copy of the rows to the UNSCOPED shared root, where the read side never looks. An
+  ## archive-derived file was therefore never found in the stash: preProcess
+  ## re-downloaded, then hit the "already exists at <stash>" branch in downloadRemote(),
+  ## which errors under the default overwrite = FALSE. Every study area sharing one
+  ## destinationPathShared kept its own copy of every archive-derived input.
+  src <- checkPath(file.path(tmpdir, "src"), create = TRUE)
+
+  mkZip <- function(name, nested) {
+    d <- file.path(src, name)
+    inner <- if (nested) file.path(d, name) else d
+    checkPath(inner, create = TRUE)
+    writeBin(as.raw(rep(1:255, length.out = 1e5)), file.path(inner, paste0(name, ".bin")))
+    owd <- setwd(d)
+    on.exit(setwd(owd), add = TRUE)
+    zipped <- utils::zip(file.path(src, paste0(name, ".zip")),
+                         if (nested) name else paste0(name, ".bin"), flags = "-rq")
+    skip_if_not(identical(zipped, 0L), "no zip utility")
+    file.path(src, paste0(name, ".zip"))
+  }
+
+  nlink <- function(p) as.integer(system2("stat", c("-c", "%h", shQuote(p)), stdout = TRUE))
+  skip_if(is.na(nlink(file.path(src))), "stat(1) unavailable")
+
+  linksAcrossDestinations <- function(zip, label) {
+    shared <- checkPath(file.path(tmpdir, paste0("shared_", label)), create = TRUE)
+    withr::local_options(reproducible.destinationPathShared = shared)
+    vapply(1:3, function(i) {
+      dest <- checkPath(file.path(tmpdir, paste0(label, i)), create = TRUE)
+      prepInputs(url = paste0("file://", zip), destinationPath = dest,
+                 fun = NA, useCache = FALSE)
+      f <- list.files(dest, pattern = "[.]bin$", recursive = TRUE, full.names = TRUE)
+      expect_length(f, 1L)
+      nlink(f[1L])
+    }, integer(1L))
+  }
+
+  ## One inode in the stash, one extra link per destination: 2, 3, 4.
+  ## Both archive shapes matter -- a top-level folder inside the zip is what
+  ## CA_FAO_forest_2019.zip looks like, files at the root is CA_forest_VLCE2_2000.zip.
+  expect_equal(linksAcrossDestinations(mkZip("nestarc", TRUE), "nested"), 2:4)
+  expect_equal(linksAcrossDestinations(mkZip("flatarc", FALSE), "flat"), 2:4)
+})


### PR DESCRIPTION
Fixes #593.

The shared stash is scoped per archive by `.sharedDirsFor()`, and `runChecksums()` reads back from that scoped directory. `appendChecksumsTable()` wrote its copy of the rows to the **unscoped shared root** instead — where the read side never looks:

```r
rip <- .getDestinationPathShared()                    # <shared>
checkSumFilePaths <- unique(c(checkSumFilePath, file.path(rip, basename(checkSumFilePath))))
```

So an archive-derived file was never found in the stash. `preProcess()` re-downloaded it and then reached the `desiredPath` check in `downloadRemote()` (`R/download.R:2357-2367`), where `destinationPath` has by then been redirected to the stash — so the shared copy's *existence* is treated as a conflict rather than the hit it is:

- `overwrite = FALSE` → `stop("... already exists at <stash>. Use overwrite = TRUE?")`
- `overwrite = TRUE` → overwrite the stash, hardlink only this destination

Either way the link count never climbed past 2, and every destination kept its own copy.

## Before and after

Same three destinations sharing one `destinationPathShared`, no `targetFile`, default `overwrite`:

| archive shape | before | after |
|---|---|---|
| top-level folder inside the zip (`CA_FAO_forest_2019.zip`) | 2, **ERROR**, **ERROR** | **2, 3, 4** |
| files at the archive root (`CA_forest_VLCE2_2000.zip`) | 2, **ERROR**, **ERROR** | **2, 3, 4** |

2, 3, 4 is the correct result: one inode in the stash, one extra link per destination.

## The change

`appendChecksumsTable()` gains an `archive` argument and scopes its shared write with `.sharedDirsFor()` — the same call the read side already uses. The five call sites that know the archive pass it. The `NULL` default preserves today's behaviour for non-archive inputs, which were already linking correctly (a directly-downloaded file gives 2, 3, 4 both before and after).

## Testing

`test-destinationPathShared-archive.R` covers both archive shapes, since a flat archive and one with a top-level folder failed identically and could plausibly have been fixed one but not the other. The existing `test-destinationPathShared.R` is unchanged and still passes. Across the `prepInputs` / `preProcess` / `checksums` / `download` / `postProcess` files: **692 assertions pass, 0 failures, 0 errors** (21 skips, all "No Drive token" or network).

## Why it mattered

Found on a 15-node run with ~70 study areas sharing one stash. Hardlinking was doing its job overall — 1,963 GB saved, 70%, with one 6.2 GB SCANFI tif carrying 18 links — but 148 archive-derived files accounted for **588 GB** of duplicate copies, growing about 10 GB/hour while the run was live:

| file | copies | distinct inodes |
|---|---|---|
| `CA_FAO_forest_2019.tif` | 71 | 50 |
| `NFDB_poly_1972to2020_20250630.shp` | 57 | 34 |
| `CA_forest_VLCE2_2000.tif.ovr` | 43 | 43 |

The functional half matters more than the space: under the default `overwrite = FALSE`, the second module wanting an archive-derived input in a different `destinationPath` got an error instead of the file. Callers work around it by passing `overwrite = TRUE` — `LandR::prepInputsFireYear()` and `Biomass_speciesParameters`' `cohortDataFactorial` fetch both do — which hides the error and pays in disk. Those workarounds can come out once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3