### PR TITLE
Serialise shared-stash population per input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-08
-Version: 3.2.1.9022
+Date: 2026-09-09
+Version: 3.2.1.9023
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-08
-Version: 3.2.1.9021
+Version: 3.2.1.9022
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,19 @@
-# reproducible 3.2.1.9012
+# reproducible 3.2.1.9022
 
 ## Bug fixes
+
+* `preProcess()` now lets only one process at a time fill `destinationPathShared` for a
+  given input, so concurrent callers share one copy instead of each keeping their own.
+  Filling the stash for one input takes several steps -- read `CHECKSUMS.txt`, download,
+  extract, hardlink in, append the rows -- and nothing serialised them. Every process read
+  the stash before any of them had written it, so every process downloaded and extracted
+  its own copy and kept it; a process could also read the stash mid-write and match a
+  `CHECKSUMS.txt` row whose file was not linked in yet, failing with
+  `No archive exists with filename: <stash>/x.zip`. Measured with 15 concurrent consumers
+  of one archive: 2 of 15 succeeded, onto 2 inodes; now 15 of 15 succeed onto 1 inode. On
+  a 15-worker run, one 0.78 GB input had accumulated 86 paths across 36 inodes. The lock
+  is keyed on the input, so unrelated inputs never wait on each other, and it times out
+  (`reproducible.stashLockTimeout`, default one hour) rather than ever blocking a run.
 
 * `destinationPathShared` now links files that came out of an archive, instead of leaving
   every destination with its own copy. The shared stash is scoped per archive by

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -247,14 +247,32 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   ctx$loadWillFollow <- !directCall
 
   ctx <- pp_resolve_files(ctx)
-  ctx <- pp_checksums_init(ctx)
-  ctx <- pp_purge(ctx)
-  ctx <- pp_resolve_needed_files(ctx)
-  ctx <- pp_check_local_sources(ctx)
-  ctx <- pp_remote_hash_check(ctx)
-  ctx <- pp_download(ctx)
-  ctx <- pp_extract(ctx)
-  ctx <- pp_link_to_destination(ctx)
+
+  ## One process at a time may fill the shared stash for a given input.
+  ##
+  ## Each caller has its own `destinationPath`, so those never collide; what they share is
+  ## `destinationPathShared`, and filling it for one input spans checksum, download,
+  ## extract and link. Concurrent workers used to interleave those steps: each read the
+  ## stash before any of them had written it, so each downloaded and extracted its own
+  ## copy, and a reader could also see the stash half-populated -- a CHECKSUMS.txt row
+  ## whose file was not there yet, giving "No archive exists with filename:
+  ## <stash>/x.zip". Serialising per input makes the waiters find the finished stash and
+  ## hardlink out of it, which is the whole point of having one. See .withStashLock() for
+  ## why this is not the Cache lock.
+  runPipeline <- function(cc) {
+    cc <- pp_checksums_init(cc)
+    cc <- pp_purge(cc)
+    cc <- pp_resolve_needed_files(cc)
+    cc <- pp_check_local_sources(cc)
+    cc <- pp_remote_hash_check(cc)
+    cc <- pp_download(cc)
+    cc <- pp_extract(cc)
+    pp_link_to_destination(cc)
+  }
+  lockKey <- .stashLockKey(ctx)
+  ctx <- if (is.null(lockKey)) runPipeline(ctx) else
+    .withStashLock(lockKey, verbose = verbose, expr = runPipeline(ctx))
+
   out <- pp_finalize(ctx)
 
   reportTime(st, mess = "`preProcess` done; took ", minSeconds = 10)
@@ -2540,6 +2558,82 @@ linkOrCopyUpdateOnly <- function(from, to, verbose) {
 messageChecksummingAllFiles <- "Checksumming all files in archive"
 
 
+
+## Serialise stash population for one input.
+##
+## Callers each have their own `destinationPath`; `destinationPathShared` is the one thing
+## they all write to, and filling it for a single input takes several steps -- read
+## CHECKSUMS.txt, download, extract, hardlink the results in, append the rows. Nothing
+## stopped N processes from running those steps interleaved, and two things went wrong as
+## a result. Every worker read the stash before any of them had written it, so every
+## worker downloaded and extracted its own copy and kept it: in production, 15 workers on
+## one 0.78 GB input left 84 paths across 34 inodes, which is the opposite of what a
+## shared stash is for. And a worker could read the stash mid-write, matching a
+## CHECKSUMS.txt row whose file was not linked in yet; preProcess then redirected
+## `destinationPath` at the stash and failed with "No archive exists with filename:
+## <stash>/x.zip".
+##
+## The key is the input, not a digest of an unknown result -- unlike the Cache lock, the
+## file names here are known before the work starts -- so different inputs never wait on
+## each other. `lockFile()` is not reusable for this: it is rooted at CacheStorageDir()
+## and is skipped entirely under the DBI backend, neither of which applies here.
+##
+## Lock files live in a hidden directory at the shared root. Hidden, because Checksums()
+## lists the stash with `list.files()`, which would otherwise checksum the locks.
+.stashLockDir <- function(sharedRoot) {
+  file.path(sharedRoot[1], ".stashLocks")
+}
+
+## The identity of the thing being fetched into the stash: the archive if there is one
+## (the stash is scoped per archive by .sharedDirsFor()), otherwise the target file.
+## NULL means there is nothing shared to serialise on, so the caller runs unlocked.
+.stashLockKey <- function(ctx) {
+  sharedRoot <- .getDestinationPathShared()
+  if (is.null(sharedRoot)) return(NULL)
+  nm <- if (!isNULLorNA(ctx$archive)) basename2(ctx$archive[1]) else
+    if (!is.null(ctx$targetFile)) basename2(ctx$targetFile[1]) else
+      if (!is.null(ctx$url)) basename2(ctx$url[1]) else NULL
+  if (is.null(nm) || !nzchar(nm)) return(NULL)
+  list(dir = .stashLockDir(sharedRoot), name = nm)
+}
+
+.stashLockPath <- function(key) {
+  checkPath(key$dir, create = TRUE)
+  ## The digest keeps the file name bounded and legal while staying one-to-one with the
+  ## input; the readable prefix is there so a stale lock can be identified by eye.
+  file.path(key$dir, paste0(substr(gsub("[^A-Za-z0-9._-]", "_", key$name), 1, 60),
+                            "_", .robustDigest(key$name), ".lock"))
+}
+
+## Locks held by this process, so a nested prepInputs() for the same input does not wait
+## on itself.
+.stashLocksHeld <- new.env(parent = emptyenv())
+
+.withStashLock <- function(key, expr,
+                           timeout = getOption("reproducible.stashLockTimeout", 60 * 60 * 1000),
+                           verbose = getOption("reproducible.verbose")) {
+  lp <- tryCatch(.stashLockPath(key), error = function(e) NULL)
+  if (is.null(lp) || !requireNamespace("filelock", quietly = TRUE)) return(force(expr))
+  if (isTRUE(.stashLocksHeld[[lp]])) return(force(expr))
+
+  lck <- tryCatch(filelock::lock(lp, timeout = timeout), error = function(e) NULL)
+  if (is.null(lck)) {
+    ## Never fail or hang a run on the lock: without it the worst case is the duplication
+    ## that happened before it existed. This is also what breaks the one deadlock this
+    ## could otherwise create -- a dlFun that itself calls prepInputs for a second input,
+    ## in the opposite order to another process.
+    messagePreProcess("could not acquire the shared-input lock at ", lp,
+                      "; proceeding unsynchronised", verbose = verbose - 1)
+    return(force(expr))
+  }
+  assign(lp, TRUE, envir = .stashLocksHeld)
+  on.exit({
+    if (exists(lp, envir = .stashLocksHeld, inherits = FALSE))
+      rm(list = lp, envir = .stashLocksHeld)
+    try(filelock::unlock(lck), silent = TRUE)
+  }, add = TRUE)
+  force(expr)
+}
 
 # may already have been changed above
 copyFromDPtoReproducibleIPs <- function(targetFilePath, destinationPathUser, destinationPath,

--- a/tests/testthat/test-destinationPathShared-archive.R
+++ b/tests/testthat/test-destinationPathShared-archive.R
@@ -78,12 +78,14 @@ test_that("concurrent consumers of one archive converge on one inode in the shar
   script <- file.path(tmpdir, "consumer.R")
   ## Under devtools/pkgload the installed reproducible is not the one being tested, and a
   ## fresh child process would silently load the installed one -- so the child loads the
-  ## same source tree the parent did.
-  devPath <- if (isNamespaceLoaded("pkgload") &&
-                 isTRUE(pkgload::is_dev_package("reproducible")))
-    normalizePath(getNamespaceInfo("reproducible", "path"), mustWork = FALSE)
-  loadLine <- if (!is.null(devPath) && file.exists(file.path(devPath, "DESCRIPTION")))
-    sprintf('pkgload::load_all("%s", quiet = TRUE)', devPath) else
+  ## same source tree the parent did. An installed package has R/reproducible.rdb where a
+  ## source tree has R/*.R; that is the difference, and it needs no extra dependency to
+  ## ask (pkgload is not one of reproducible's).
+  pkgPath <- normalizePath(getNamespaceInfo("reproducible", "path"), mustWork = FALSE)
+  fromSource <- !file.exists(file.path(pkgPath, "R", "reproducible.rdb")) &&
+    file.exists(file.path(pkgPath, "DESCRIPTION"))
+  loadLine <- if (fromSource)
+    sprintf('library(pkgload); load_all("%s", quiet = TRUE)', pkgPath) else
       'suppressMessages(library(reproducible))'
   writeLines(c(
     sprintf('.libPaths(%s)', paste0("c(", paste0('"', libs, '"', collapse = ", "), ")")),

--- a/tests/testthat/test-destinationPathShared-archive.R
+++ b/tests/testthat/test-destinationPathShared-archive.R
@@ -47,3 +47,75 @@ test_that("destinationPathShared links archive-derived files across destinations
   expect_equal(linksAcrossDestinations(mkZip("nestarc", TRUE), "nested"), 2:4)
   expect_equal(linksAcrossDestinations(mkZip("flatarc", FALSE), "flat"), 2:4)
 })
+
+test_that("concurrent consumers of one archive converge on one inode in the shared stash", {
+  skip_on_cran()
+  skip_on_ci()
+  skip_if_not_installed("filelock")
+  testInit()
+
+  ## Filling destinationPathShared for one input is a multi-step transaction -- read
+  ## CHECKSUMS.txt, download, extract, hardlink in, append rows -- and nothing serialised
+  ## it. Every process read the stash before any of them had written it, so every process
+  ## kept a private copy: 15 workers on one 0.78 GB input left 84 paths across 34 inodes
+  ## (measured, 2026-09-09), which is the opposite of what the stash is for. A reader
+  ## could also catch the stash half-written and match a CHECKSUMS.txt row whose file was
+  ## not linked in yet, failing with "No archive exists with filename: <stash>/x.zip".
+  ##
+  ## Separate R processes, not parallel::mclapply: the defect is a filesystem race between
+  ## processes, and forked children of one session share too much to exercise it.
+  src <- checkPath(file.path(tmpdir, "src"), create = TRUE)
+  inner <- checkPath(file.path(src, "arc", "arc"), create = TRUE)
+  writeBin(as.raw(sample(0:255, 2e5, TRUE)), file.path(inner, "arc.bin"))
+  owd <- setwd(file.path(src, "arc"))
+  zipped <- utils::zip(file.path(src, "arc.zip"), "arc", flags = "-rq")
+  setwd(owd)
+  skip_if_not(identical(zipped, 0L), "no zip utility")
+
+  shared <- checkPath(file.path(tmpdir, "shared"), create = TRUE)
+  libs <- .libPaths()
+  n <- 6L
+  script <- file.path(tmpdir, "consumer.R")
+  ## Under devtools/pkgload the installed reproducible is not the one being tested, and a
+  ## fresh child process would silently load the installed one -- so the child loads the
+  ## same source tree the parent did.
+  devPath <- if (isNamespaceLoaded("pkgload") &&
+                 isTRUE(pkgload::is_dev_package("reproducible")))
+    normalizePath(getNamespaceInfo("reproducible", "path"), mustWork = FALSE)
+  loadLine <- if (!is.null(devPath) && file.exists(file.path(devPath, "DESCRIPTION")))
+    sprintf('pkgload::load_all("%s", quiet = TRUE)', devPath) else
+      'suppressMessages(library(reproducible))'
+  writeLines(c(
+    sprintf('.libPaths(%s)', paste0("c(", paste0('"', libs, '"', collapse = ", "), ")")),
+    loadLine,
+    'a <- commandArgs(trailingOnly = TRUE)',
+    sprintf('options(reproducible.destinationPathShared = "%s", reproducible.verbose = -1)', shared),
+    'dest <- a[1]; dir.create(dest, recursive = TRUE, showWarnings = FALSE)',
+    sprintf('prepInputs(url = "file://%s", destinationPath = dest, fun = NA, useCache = FALSE)',
+            file.path(src, "arc.zip"))
+  ), script)
+
+  dests <- file.path(tmpdir, paste0("dest", seq_len(n)))
+  logs  <- file.path(tmpdir, paste0("log", seq_len(n), ".txt"))
+  Rscript <- file.path(R.home("bin"), "Rscript")
+  ## Launched with wait = FALSE so they overlap; the marker line is how a finished
+  ## process is told from one still running, since the exit status is not returned here.
+  Map(function(d, lg) system2(Rscript, c(shQuote(script), shQuote(d)),
+                              stdout = lg, stderr = lg, wait = FALSE), dests, logs)
+  deadline <- Sys.time() + 300
+  repeat {
+    done <- file.exists(file.path(dests, "arc", "arc.bin")) |
+      vapply(logs, function(lg) any(grepl("^Error", readLines(lg, warn = FALSE))), logical(1))
+    if (all(done) || Sys.time() > deadline) break
+    Sys.sleep(1)
+  }
+
+  got <- file.path(dests, "arc", "arc.bin")
+  ## Every consumer gets its file -- concurrency is not an error.
+  errs <- unlist(lapply(logs, function(lg) grep("^Error", readLines(lg, warn = FALSE), value = TRUE)))
+  expect_length(errs, 0L)
+  expect_true(all(file.exists(got)))
+  ## ...and all of them, plus the stash copy, are the SAME inode: one file on disk.
+  expect_equal(length(unique(fs::file_info(got)$inode)), 1L)
+  expect_equal(unique(as.integer(fs::file_info(got)$hard_links)), n + 1L)
+})


### PR DESCRIPTION
## The defect

Each caller of `prepInputs()`/`preProcess()` has its own `destinationPath`, so those never collide. `destinationPathShared` is the one place they all write to, and filling it for a single input takes several steps — read `CHECKSUMS.txt`, download, extract, hardlink the results in, append the rows — with nothing serialising them.

Two failures followed from that.

**Every process kept a private copy.** They all read the stash before any of them had written it, so they all missed, and they all downloaded and extracted their own copy. On the 15-worker run this was found on, `CA_FAO_forest_2019.tif` was present as **86 paths across 36 inodes**, and 54 inputs accounted for **170 GB of redundant storage** — the opposite of what a shared stash is for.

**A process could read the stash mid-write.** It matched a `CHECKSUMS.txt` row whose file had not been linked in yet, `preProcess()` then redirected `destinationPath` at the stash, and the run died with

```
Error in try({ : No archive exists with filename: <stash>/nest/nest.zip.
  Please pass an archive name to a path that exists
```

This is the follow-on to #594. That fix made archive-derived files *findable* in the stash; this one makes concurrent callers actually share them.

## The fix

`preProcess()` holds a per-input lock across `pp_checksums_init()` .. `pp_link_to_destination()`. Waiters then re-read a *finished* stash, take the `destinationPathUser` branch, and hardlink out of it — which is the intended path and was previously unreachable under concurrency.

- **Keyed on the input**, not on a digest of an unknown result: the archive (or target file) name is known before the work starts, so unrelated inputs never wait on each other. This is why `lockFile()` is not reusable here — it is rooted at `CacheStorageDir()` and is skipped entirely under the DBI backend.
- **Never blocks a run.** It times out (`reproducible.stashLockTimeout`, default one hour) and proceeds unsynchronised, which is also what breaks the one deadlock this could create (a `dlFun` that itself calls `prepInputs` for a second input, in the opposite order to another process).
- **Re-entrant within a process**, so a nested `prepInputs()` for the same input does not wait on itself.
- Lock files live in a hidden `.stashLocks/` at the shared root, because `Checksums()` lists the stash with `list.files()` and would otherwise checksum the locks.
- No behaviour change when `destinationPathShared` is unset: `.stashLockKey()` returns `NULL` and the pipeline runs exactly as before.

## Measurements

Concurrent consumers of one archive over a `file://` URL, both archive shapes (a top-level folder inside the zip, as in `CA_FAO_forest_2019.zip`, and files at the root, as in `CA_forest_VLCE2_2000.zip`):

| | consumers with the file | distinct inodes | failures |
|---|---|---|---|
| before, 6 workers, nested | 1 / 6 | 1 | 5 |
| before, 15 workers, nested | 2 / 15 | 2 | 13 |
| before, 15 workers, flat | 1 / 15 | 1 | 14 |
| **after, 6 workers, nested** | **6 / 6** | **1** | **0** |
| **after, 15 workers, nested** | **15 / 15** | **1** | **0** |
| **after, 15 workers, flat** | **15 / 15** | **1** | **0** |

## Test

`tests/testthat/test-destinationPathShared-archive.R` gains a concurrency case: six separate R processes — not `mclapply` children, since the defect is a race between processes over the filesystem — consume one archive at once, and the test asserts every one of them gets the file, on a single inode, with `n + 1` links. It fails on `development` (10 errors, 2 inodes) and passes here.

`test-preProcessWorks.R`, `test-preProcessDoesntWork.R`, `test-prepInputs.R`, `test-destinationPathShared.R`, `test-prepInputsInNestedArchives.R`, `test-checksums.R` and `test-prepInputsCOG.R` all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3