### PR TITLE
Do not replace a target that already holds identical content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-09
-Version: 3.2.1.9023
+Version: 3.2.1.9024
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,23 @@
-# reproducible 3.2.1.9022
+# reproducible 3.2.1.9024
 
 ## Bug fixes
+
+* `linkOrCopy()` no longer replaces a target that already holds byte-identical content.
+  It unlinked every existing target before linking, so the same bytes were given a new
+  inode and every other path hardlinked to the old one was stranded as a private copy.
+  This bit hardest through `extractFromArchive()`, which unpacks to a temp directory and
+  then moves the results to `exdir` -- and `exdir` is `destinationPathShared` itself
+  whenever the lookup has redirected `destinationPath` there. Each extraction therefore
+  destroyed the copy every other destination was sharing, and the next one destroyed that.
+  Measured on a 15-worker run: `CA_FAO_forest_2019.tif` collected three inodes in twenty
+  minutes, each orphaned at `nlink = 1`. Four sequential destinations now hold one inode
+  with `nlink` 2, 3, 4, 5; before, the stash inode changed and the count reset.
+
+* `linkOrCopy()` no longer calls `file.link()` with zero-length input, which errors with
+  `no files to link from` rather than returning `logical(0)`. A set consisting only of
+  directories reached it; inside `extractFromArchive()` the error was swallowed and
+  retried until the extraction fallbacks ran out, surfacing as a misleading
+  `Please install.packages('archive')`.
 
 * `preProcess()` now lets only one process at a time fill `destinationPathShared` for a
   given input, so concurrent callers share one copy instead of each keeping their own.

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -1793,6 +1793,22 @@ isGoogleDownloadURL <- function(url) {
 #'   ## cleanup
 #'   unlink(tmpDir, recursive = TRUE)
 #' }
+## TRUE where `to` already holds byte-identical content to `from`. Size splits almost
+## every non-match without reading anything; only the survivors are digested.
+.sameFileContent <- function(from, to) {
+  same <- rep(FALSE, length(to))
+  if (!length(to)) return(same)
+  ok <- file.exists(from) & file.exists(to) & !dir.exists(from) & !dir.exists(to)
+  if (!any(ok)) return(same)
+  sameSize <- rep(FALSE, length(to))
+  sameSize[ok] <- file.size(from[ok]) == file.size(to[ok])
+  for (i in which(sameSize))
+    same[i] <- isTRUE(tryCatch(
+      identical(.robustDigest(asPath(from[i])), .robustDigest(asPath(to[i]))),
+      error = function(e) FALSE))
+  same
+}
+
 linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
                        verbose = getOption("reproducible.verbose", 1)) {
   ## A file that is already at its destination cannot be linked or copied onto
@@ -1848,12 +1864,32 @@ linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
       isDir <- dir.exists(to)
       dups <- duplicated(from)
 
-      if (any(existsTo)) {
-        unlink(to[existsTo])
+      ## A target that already holds exactly these bytes is left alone. Unlinking and
+      ## re-linking it would give the same content a NEW inode, which strands every other
+      ## path hardlinked to the old one as a private copy -- and buys nothing, since the
+      ## bytes are identical. It matters most when `to` is a shared store: extracting an
+      ## archive into `destinationPathShared` used to overwrite the copy every other
+      ## destination was sharing, so one 0.78 GB input collected three inodes in twenty
+      ## minutes, each orphaned at nlink = 1.
+      keepTo <- rep(FALSE, length(to))
+      canCompare <- existsTo & !isDir
+      if (any(canCompare))
+        keepTo[canCompare] <- .sameFileContent(from[canCompare], to[canCompare])
+      if (any(keepTo))
+        messagePreProcess(sum(keepTo), " file(s) already present at the destination and ",
+                          "identical; keeping ", singularPlural(c("it", "them"), l = which(keepTo)),
+                          verbose = verbose - 1)
+
+      if (any(existsTo & !keepTo)) {
+        unlink(to[existsTo & !keepTo])
       }
       # Try hard link first -- the only type that R deeply recognizes
-      result <- captureWarningsToAttr(
-        file.link(from[!dups & !isDir], to[!dups & !isDir])
+      linkable <- !dups & !isDir & !keepTo
+      ## file.link() ERRORS on zero-length input ("no files to link from") rather than
+      ## returning logical(0), so a set that is all directories -- or, now, all already
+      ## present -- must not reach it.
+      result <- if (!any(linkable)) TRUE else captureWarningsToAttr(
+        file.link(from[linkable], to[linkable])
       )
       warns <- attr(result, "warning")
       attr(result, "warning") <- NULL

--- a/tests/testthat/test-destinationPathShared-archive.R
+++ b/tests/testthat/test-destinationPathShared-archive.R
@@ -121,3 +121,114 @@ test_that("concurrent consumers of one archive converge on one inode in the shar
   expect_equal(length(unique(fs::file_info(got)$inode)), 1L)
   expect_equal(unique(as.integer(fs::file_info(got)$hard_links)), n + 1L)
 })
+
+test_that("a destination arriving later does not replace the copy already in the stash", {
+  skip_on_cran()
+  testInit()
+
+  ## linkOrCopy() unlinks an existing target before linking. Passing it a `to` that the
+  ## stash already holds therefore DELETES the shared copy and replaces it with a link to
+  ## the current caller's file -- orphaning every destination that had linked to the old
+  ## inode, which the next caller then does to this one. On a 15-worker run
+  ## CA_FAO_forest_2019.tif collected three inodes in twenty minutes, each stranded at
+  ## nlink = 1, with only the most recent writer still sharing.
+  ##
+  ## Sequential, deliberately: this is not a race. One destination after another is enough,
+  ## which is why the lock in the preceding test does not cover it.
+  src <- checkPath(file.path(tmpdir, "src"), create = TRUE)
+  inner <- checkPath(file.path(src, "keep", "keep"), create = TRUE)
+  writeBin(as.raw(rep(7L, 2e5)), file.path(inner, "keep.bin"))
+  owd <- setwd(file.path(src, "keep"))
+  zipped <- utils::zip(file.path(src, "keep.zip"), "keep", flags = "-rq")
+  setwd(owd)
+  skip_if_not(identical(zipped, 0L), "no zip utility")
+
+  shared <- checkPath(file.path(tmpdir, "shared"), create = TRUE)
+  withr::local_options(reproducible.destinationPathShared = shared)
+
+  inoOf <- function(p) as.character(fs::file_info(p)$inode)
+  stashed <- NULL
+  inodes <- character()
+  for (i in 1:3) {
+    dest <- checkPath(file.path(tmpdir, paste0("d", i)), create = TRUE)
+    prepInputs(url = paste0("file://", file.path(src, "keep.zip")),
+               destinationPath = dest, fun = NA, useCache = FALSE)
+    if (is.null(stashed))
+      stashed <- list.files(shared, pattern = "keep[.]bin$", recursive = TRUE,
+                            full.names = TRUE)[1L]
+    expect_true(file.exists(stashed))
+    inodes <- c(inodes, inoOf(stashed))
+  }
+
+  ## The stash keeps ONE inode throughout -- it is never unlinked and rewritten...
+  expect_length(unique(inodes), 1L)
+  ## ...and nothing that linked to it earlier has been orphaned.
+  expect_gte(as.integer(fs::file_info(stashed)$hard_links), 2L)
+})
+
+test_that("extracting into the shared stash keeps the copy other destinations are sharing", {
+  skip_on_cran()
+  testInit()
+
+  ## extractFromArchive() unpacks to a temp dir and then moves the results to `exdir` with
+  ## hardLinkOrCopy(). When the lookup has redirected destinationPath at the shared stash,
+  ## `exdir` IS the stash -- and linkOrCopy() unlinks a target before linking to it. So the
+  ## extraction replaced the stash file with a fresh inode holding the same bytes, and
+  ## every destination hardlinked to the old inode was stranded as a private copy; the next
+  ## extraction then stranded that one. On a 15-worker run CA_FAO_forest_2019.tif collected
+  ## three inodes in twenty minutes, each at nlink = 1.
+  ##
+  ## Sequential, not concurrent: the lock added for the stash race does not cover this, and
+  ## one destination after another is enough to show it.
+  src <- checkPath(file.path(tmpdir, "src"), create = TRUE)
+  inner <- checkPath(file.path(src, "arc", "arc"), create = TRUE)
+  writeBin(as.raw(rep(3L, 2e5)), file.path(inner, "arc.bin"))
+  owd <- setwd(file.path(src, "arc"))
+  zipped <- utils::zip(file.path(src, "arc.zip"), "arc", flags = "-rq")
+  setwd(owd)
+  skip_if_not(identical(zipped, 0L), "no zip utility")
+
+  shared <- checkPath(file.path(tmpdir, "shared"), create = TRUE)
+  withr::local_options(reproducible.destinationPathShared = shared)
+  stashed <- file.path(shared, "arc", "arc", "arc.bin")
+  csf     <- file.path(shared, "arc", "CHECKSUMS.txt")
+
+  inodes <- character()
+  links  <- integer()
+  for (i in 1:4) {
+    dest <- checkPath(file.path(tmpdir, paste0("d", i)), create = TRUE)
+    prepInputs(url = paste0("file://", file.path(src, "arc.zip")),
+               destinationPath = dest, fun = NA, useCache = FALSE)
+    ## every destination gets its file -- the guard must not skip the placement
+    expect_true(file.exists(file.path(dest, "arc", "arc.bin")))
+    expect_true(file.exists(stashed))
+    inodes <- c(inodes, as.character(fs::file_info(stashed)$inode))
+    links  <- c(links,  as.integer(fs::file_info(stashed)$hard_links))
+    ## After the first pass, drop the row for the file while leaving the file itself: that
+    ## is the state the affected stash was in -- populated but not findable -- and it is
+    ## what sends later callers back through extraction and onto the stash path.
+    if (i == 1L && file.exists(csf)) {
+      x <- readLines(csf)
+      writeLines(x[!grepl("arc\\.bin", x)], csf)
+    }
+  }
+
+  ## One inode throughout: the stash file is never unlinked and rewritten...
+  expect_length(unique(inodes), 1L)
+  ## ...and each destination adds a link rather than orphaning the last.
+  expect_equal(links, 2:5)
+})
+
+test_that("linkOrCopy handles a set with nothing to link", {
+  skip_on_cran()
+  testInit()
+
+  ## file.link() errors with "no files to link from" on zero-length input rather than
+  ## returning logical(0), so a set that is all directories reached it and threw. In
+  ## extractFromArchive the throw was swallowed and retried until the extraction fallbacks
+  ## ran out, surfacing as a misleading "Please install.packages('archive')".
+  d <- checkPath(file.path(tmpdir, "onlyDirs"), create = TRUE)
+  checkPath(file.path(d, "sub"), create = TRUE)
+  to <- file.path(tmpdir, "dest", "sub")
+  expect_error(linkOrCopy(file.path(d, "sub"), to, symlink = FALSE, verbose = -1), NA)
+})


### PR DESCRIPTION
Follow-on to #595. That PR stopped concurrent callers from each *creating* a private copy. This one stops them from *destroying* the shared copy afterwards — the residual that left 2 of 224 inputs still duplicating on the run it was found on.

## The defect

`linkOrCopy()` unlinks every existing target before linking to it:

```r
if (any(existsTo)) {
  unlink(to[existsTo])
}
# Try hard link first
result <- captureWarningsToAttr(file.link(from[!dups & !isDir], to[!dups & !isDir]))
```

The same bytes therefore get a **new inode**, and every other path hardlinked to the old one is stranded as a private copy.

That is destructive wherever `to` is shared, and `extractFromArchive()` puts it there routinely. It unpacks to a temp directory and then moves the results to `exdir` with `hardLinkOrCopy()` (`prepInputs.R:1200`) — and `exdir` **is** `destinationPathShared` whenever the lookup has redirected `destinationPath` at the stash. So each extraction destroyed the copy every other destination was sharing, and the next extraction destroyed that one.

On a 15-worker run, `CA_FAO_forest_2019.tif` collected three inodes in twenty minutes, each orphaned at `nlink = 1`, while the stash entry kept being replaced:

```
23:09  stash = 13902663 (nlink 2);  inputs/9.3/... = 13914011 (nlink 1, born 23:03:58)
23:14  stash = 13914011 (nlink 2);  13902663 survives only at inputs/9.2.3/... at nlink 1
```

## How it was found

Instrumenting `linkOrCopy` with a `cat()` probe beside the `unlink` and running a sequential reproduction named the caller directly:

```
[PROBE] linkOrCopy UNLINK existing target
  stack: extractFromArchive < .callArchiveExtractFn < ... < hardLinkOrCopy < linkOrCopy
```

The reproduction puts the file in the stash but removes its row from the scoped `CHECKSUMS.txt` — the state the affected stash was actually in, populated but not findable — which sends later callers back through extraction and onto the stash path. No concurrency needed; four sequential destinations are enough.

| | destination 1 | 2 | 3 | 4 |
|---|---|---|---|---|
| **development** | inode A, nlink 2 | inode **B**, nlink 2 | B, nlink 3 | B, nlink 4 |
| **this PR** | inode A, nlink 2 | A, nlink 3 | A, nlink 4 | A, nlink 5 |

On `development` the stash inode changes at destination 2 and the link count resets — destination 1 has been orphaned.

## Second defect, found on the way

`file.link()` **errors** with `no files to link from` on zero-length input rather than returning `logical(0)`. A set consisting only of directories reached it and threw. Inside `extractFromArchive()` that throw was swallowed and retried until the extraction fallbacks ran out, surfacing as a misleading `Please install.packages('archive')` — which is how a first, wrong version of this fix presented, and it would bite any caller passing only directories.

## The change

Both in `linkOrCopy()`, so every caller is covered rather than one call site:

- `.sameFileContent()` marks targets that already hold identical bytes; those are excluded from the `unlink` and from the link, and reported as success. Size is compared first, which separates almost every non-match without reading anything; only the survivors are digested.
- `file.link()` is not called with an empty set.

No behaviour change when the target is absent or differs — the existing unlink-and-link path runs unchanged.

## Tests

Two added to `test-destinationPathShared-archive.R`, both failing on `development` (3 failures) and passing here:

- four sequential destinations against a stash whose index has lost the row: every destination gets its file, the stash keeps **one** inode throughout, and `nlink` grows 2, 3, 4, 5. The per-destination `file.exists` assertion is deliberate — a first attempt at this fix kept the inode stable by silently not placing the file, and this catches that.
- `linkOrCopy()` with a directories-only set does not error.

`test-preProcessWorks.R`, `test-preProcessDoesntWork.R`, `test-prepInputs.R`, `test-destinationPathShared.R`, `test-prepInputsInNestedArchives.R`, `test-checksums.R`, `test-prepInputsCOG.R` and `test-prepInputs-large-files.R` all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3