### PR TITLE
Read the whole folder id from a Drive folder URL that ends at the id

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-09
-Version: 3.2.1.9024
+Version: 3.2.1.9025
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,15 @@
-# reproducible 3.2.1.9024
+# reproducible 3.2.1.9025
 
 ## Bug fixes
+
+* `Cache(useCloud = TRUE)` now accepts a Google Drive folder URL that ends at the folder id,
+  the form Drive's address bar gives. `checkAndMakeCloudFolderID()` took the id out with a
+  pattern that needed at least one character after it, so
+  `https://drive.google.com/drive/folders/<33-character id>` became a 32-character id. That
+  still looked like an id, so Drive was asked for a folder that does not exist and the call
+  stopped with "File not found". A URL with `?usp=...` after the id was unaffected, which is
+  why this went unnoticed. The id is now read with the same helper `prepInputs()` uses for
+  Drive URLs.
 
 * `linkOrCopy()` no longer replaces a target that already holds byte-identical content.
   It unlinked every existing target before linking, so the same bytes were given a new

--- a/R/cloud.R
+++ b/R/cloud.R
@@ -38,9 +38,13 @@ checkAndMakeCloudFolderID <- function(cloudFolderID = getOption("reproducible.cl
 
     # This is an imperfect test for a google drive ID ... because of this, we try 2x,
     #   first with best guess, then if wrong, try the other branch of "if (isID)"
-    stripHTTP <- gsub("http.+drive.google.com.+folders/(.{32,33})\\?*.+$", "\\1", cloudFolderID)
-    if (isID(stripHTTP))
-      cloudFolderID <- stripHTTP
+    ## .extractDriveId() stops the id at the first character that cannot be in one, so a
+    ## URL ending at the id keeps all of it; the old regex needed a character after it.
+    if (isTRUE(isGoogleDriveURL(cloudFolderID))) {
+      idFromURL <- .extractDriveId(cloudFolderID)
+      if (!is.na(idFromURL))
+        cloudFolderID <- idFromURL
+    }
     isID <- isTRUE(32 <= nchar(cloudFolderID) && nchar(cloudFolderID) <= 33)
     if (packageVersion("googledrive") < "2.0.0") {
       args <- list(temp_drive = team_drive)

--- a/tests/testthat/test-cloudFolderID-url.R
+++ b/tests/testthat/test-cloudFolderID-url.R
@@ -1,0 +1,36 @@
+# checkAndMakeCloudFolderID() must take the folder id out of a Drive folder URL
+# whatever follows the id. Its regex required at least one character after the
+# id, so a URL ending at the id -- the form Drive's address bar gives -- lost the
+# id's last character: "https://.../folders/<33-char id>" became a 32-char id,
+# which still looked like an id, so drive_get() was asked for a folder that does
+# not exist and the call stopped with "File not found". googledrive's drive_get
+# is mocked to record what it is asked for (no network/auth).
+
+test_that("checkAndMakeCloudFolderID extracts the whole id from a Drive folder URL", {
+  skip_if_not_installed("googledrive")
+  id33 <- "1X9-mRjyLMNpgkP_cfqhbr_AQEPOsVCHf"
+  id32 <- strrep("A", 32)
+  cases <- list(
+    "URL ending at a 33-char id" = list(paste0("https://drive.google.com/drive/folders/", id33), id33),
+    "URL with a query"           = list(paste0("https://drive.google.com/drive/folders/", id33, "?usp=drive_link"), id33),
+    "URL with a trailing slash"  = list(paste0("https://drive.google.com/drive/folders/", id33, "/"), id33),
+    "URL ending at a 32-char id" = list(paste0("https://drive.google.com/drive/u/0/folders/", id32), id32),
+    "bare 33-char id"            = list(id33, id33),
+    "bare 32-char id"            = list(id32, id32)
+  )
+  for (nm in names(cases)) {
+    asked <- NULL
+    testthat::with_mocked_bindings(
+      suppressWarnings( # the mock resolves nothing, which warns; only the lookup matters here
+        reproducible:::checkAndMakeCloudFolderID(cases[[nm]][[1]], cachePath = tempdir(),
+                                                 create = FALSE, verbose = 0)
+      ),
+      drive_get = function(x, ...) {
+        if (is.null(asked)) asked <<- as.character(x)
+        data.frame(name = character(0), id = character(0))
+      },
+      .package = "googledrive"
+    )
+    expect_identical(asked, cases[[nm]][[2]], label = nm)
+  }
+})


### PR DESCRIPTION
`checkAndMakeCloudFolderID()` took the folder id out of a Drive URL with a pattern that needs at least one character after the id. So `https://drive.google.com/drive/folders/<33-character id>`, the form Drive's address bar gives, lost the id's last character. The 32 characters left still looked like an id, Drive was asked for a folder that does not exist, and `Cache(useCloud = TRUE)` stopped with "File not found". A URL with `?usp=...` after the id worked, which is why this went unnoticed.

The id is now read with `.extractDriveId()`, the helper `prepInputs()` already uses for Drive URLs. Only Drive URLs are affected; bare ids, folder names and cache paths are unchanged.

## Test

`tests/testthat/test-cloudFolderID-url.R` mocks `googledrive::drive_get()` to record the id it is asked for. It covers URLs ending at 33- and 32-character ids, a URL with a query, a URL with a trailing slash, and bare ids. On `development` the two URLs ending at the id fail; here all six pass. The other cloud and Drive helper tests pass unchanged.

Version 3.2.1.9025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gZhFo9aCTrEgMVrP37sUo