### PR TITLE
prepInputs: overwrite is for writeTo only; purge = 7 downloads again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-09
-Version: 3.2.1.9025
+Date: 2026-09-10
+Version: 3.2.1.9026
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL:
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
 Date: 2026-09-10
-Version: 3.2.1.9026
+Version: 3.2.1.9027
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,31 @@
-# reproducible 3.2.1.9025
+# reproducible 3.2.1.9026
 
 ## Bug fixes
+
+* `prepInputs()`'s `overwrite` now applies only to the `writeTo` file, as its help page
+  said. It was also passed to `preProcess()`, where it never caused a re-download (a file
+  matching `CHECKSUMS.txt` is kept either way) but did decide whether a damaged local copy
+  could be replaced: under the default `overwrite = FALSE`, re-running a call over such a
+  file stopped with "already exists ... Use overwrite = TRUE?". A file that fails its
+  checksum is now downloaded again and replaced whatever `overwrite` is, with a message
+  naming the local copies (both, when `reproducible.destinationPathShared` is set).
+* When `overwrite` is not supplied, `prepInputs()` replaces its own `writeTo` output, so
+  re-running a call (e.g., after a `Cache` miss from a changed module set) no longer stops
+  with "already exists and `overwrite = FALSE`". An explicit `overwrite = FALSE` still
+  stops. Seen through `LandR::prepInputs_SCANFI_LCC_FAO()` in `Biomass_borealDataPrep`.
+* `purge = 7` now downloads again. It sets aside every local copy of the call's files --
+  in `destinationPath` and, with `reproducible.destinationPathShared`, in the shared stash --
+  drops their `CHECKSUMS.txt` entries, and downloads, extracts and links them as on a first
+  run; the old copies are put back if the download fails. Before, it only dropped the
+  entries, which were then rebuilt from the files on disk, so nothing was downloaded and a
+  damaged file was accepted. The checksum-mismatch error now names every local copy and
+  suggests `purge = 7` instead of deleting files by hand.
+* A Google Drive folder `url` now decides which files to fetch by `CHECKSUMS.txt`, like a
+  single file: a file whose entry matches is kept, a missing or mismatched one is fetched,
+  and `purge = 7` fetches them all. It used to go by file name only, with `overwrite` as the
+  switch to fetch again.
+* `preProcess(overwrite)` no longer does anything and is deprecated: it is accepted, with a
+  one-time message pointing to `prepInputs(overwrite)` and `purge = 7`.
 
 * `Cache(useCloud = TRUE)` now accepts a Google Drive folder URL that ends at the folder id,
   the form Drive's address bar gives. `checkAndMakeCloudFolderID()` took the id out with a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# reproducible 3.2.1.9026
+# reproducible 3.2.1.9027
 
 ## Bug fixes
 

--- a/R/download.R
+++ b/R/download.R
@@ -12,8 +12,8 @@ utils::globalVariables(c(
 #' @inheritParams preProcess
 #' @inheritParams prepInputs
 #' @inheritParams extractFromArchive
-#' @param overwrite Logical. If `TRUE` then the download will overwrite an existing file
-#'   if it exists.
+#' @param overwrite Passed on to `googledrive::drive_download()`, which writes into a
+#'   temporary directory; it does not decide what is downloaded. See [preProcess()].
 #' @param dlFun Optional "download function" name, such as `"raster::getData"`, which does
 #'              custom downloading, in addition to loading into R. Still experimental.
 #' @param ... Passed to `dlFun`. Still experimental. Can be e.g., `type` for google docs.
@@ -104,6 +104,15 @@ downloadFile <- function(archive, targetFile, neededFiles,
 
     if (missingNeededFiles) {
       if (needChecksums == 0) needChecksums <- 2 # use binary addition -- 1 is new file, 2 is append
+      ## Say which local copies failed their checksum: they are about to be replaced.
+      bad <- checkSums$expectedFile[checkSums$result %in% "FAIL"]
+      bad <- bad[file.exists(makeAbsolute(bad, destinationPath))]
+      if (length(bad)) {
+        badPaths <- unique(normPath(c(makeAbsolute(bad, destinationPath), .sharedCopiesOf(bad, archive))))
+        messagePreProcess("Local cop", if (length(badPaths) > 1) "ies do" else "y does",
+                          " not match CHECKSUMS.txt; downloading again to replace:\n  ",
+                          paste(badPaths, collapse = "\n  "), verbose = verbose)
+      }
     }
 
     if (missingNeededFiles) {
@@ -138,6 +147,7 @@ downloadFile <- function(archive, targetFile, neededFiles,
               dlFun = dlFun,
               destinationPath = destinationPath,
               overwrite = overwrite,
+              purge = purge,
               needChecksums = needChecksums,
               preDigest = preDigest,
               alsoExtract = alsoExtract,
@@ -249,36 +259,18 @@ downloadFile <- function(archive, targetFile, neededFiles,
                                           "checksum (resource changed); skipping remainder of ",
                                           "test on CRAN (policy: fail gracefully)"))
                   }
+                  localCopies <- unique(normPath(c(makeAbsolute(fileToDownload, destinationPath),
+                                                   .sharedCopiesOf(fileToDownload, archive))))
                   stop(
-                    "\nDownloaded version of ",
-                    normPath(fileToDownload),
-                    " from url: ",
-                    url,
-                    " did not match expected file (checksums failed). There are several options:\n",
-                    " 1) This may be an intermittent internet problem -- try to rerun this ",
-                    "current function call.\n",
-                    " 2) The local copy of the file may have been changed or corrupted -- run:\n",
-                    "      file.remove('",
-                    normPath(fileToDownload),
-                    "')\n",
-                    "      then rerun this current function call.\n",
-                    if (!is.null(.getDestinationPathShared())) {
-                      obj <- dir(.getDestinationPathShared(), full.names = TRUE, pattern = basename(fileToDownload))
-                      if (length(obj)) {
-                        paste0(" 2b) The copy of the file in getOption('reproducible.destinationPathShared')",
-                               " may have been changed or corrupted -- run:\n",
-                               "      file.remove(c('",
-                               paste(normPath(obj), collapse = "', '"),
-                               "'))\n",
-                               "      then rerun this current function call.\n")
-                      }
-
-                    },
-                    " 3) The download is correct, and the Checksums should be rewritten for this file:\n",
-                    "      --> rerun this current function call, specifying 'purge = 7' possibly\n",
-                    purgeTry,
-                    " 4) manually run \nreproducible::purgeChecksums('", checksumFile, "', \n               fileToRemove = '", fileToDownload, "')",
-                    "      ",
+                    "\nDownloaded version of ", normPath(fileToDownload), " from url: ", url,
+                    " did not match its entry in ", checksumFile, " (checksums failed).\n",
+                    "Either the download was damaged, or the file at the url has changed since it ",
+                    "was recorded.\n",
+                    " 1) If this may be an intermittent internet problem, rerun this call.\n",
+                    " 2) To download it again and record its new checksum, rerun with purge = 7",
+                    if (nzchar(purgeTry[1])) paste0(":\n      ", paste(purgeTry, collapse = "")) else ".",
+                    "\n    That replaces ", singularPlural(c("the local copy", "all local copies"), l = localCopies),
+                    ":\n      ", paste(localCopies, collapse = "\n      "),
                     call. = FALSE
                   )
                 }
@@ -312,7 +304,7 @@ downloadFile <- function(archive, targetFile, neededFiles,
       if (is.null(targetFile)) {
         messagePreProcess("Skipping download because all needed files are listed in ",
                           "CHECKSUMS.txt file and are present.",
-                          " If this is not correct, rerun prepInputs with purge = TRUE",
+                          " To download them again, rerun with purge = 7.",
                           verbose = verbose
         )
       } else {
@@ -2035,6 +2027,11 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 #' @param messSkipDownload The character string text to pass to messaging if download skipped
 #' @param checkSums TODO
 #' @param fileToDownload TODO
+#' @param overwrite Passed to `googledrive::drive_download()`, which writes into a temporary
+#'   directory; it does not decide what is downloaded. A downloaded file always replaces an
+#'   existing file of the same name, because it is only downloaded when that file is missing
+#'   or fails its checksum.
+#' @param purge `7` fetches every file of a Google Drive folder `url` again; see [prepInputs()].
 #' @inheritParams loadFromCache
 #' @inheritParams prepInputs
 #' @inheritParams preProcess
@@ -2042,7 +2039,7 @@ dlGeneric <- function(url, destinationPath, targetFile = NULL, applyRemap = TRUE
 downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
                            fileToDownload, messSkipDownload,
                            destinationPath, overwrite, needChecksums, .tempPath, preDigest,
-                           alsoExtract = "similar",
+                           alsoExtract = "similar", purge = FALSE,
                            verbose = getOption("reproducible.verbose", 1), .callingEnv = parent.frame(),
                            ...) {
   dots <- list(...)
@@ -2211,15 +2208,25 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
               drive_files <- drive_files[fileIndex, ]
             }
 
-            existingFiles <- drive_files$name %in% dir(destinationPath)
-            if (any(existingFiles)) {
-              messagePreProcess("Local version of files exists")
-              if (isFALSE(overwrite)) {
-                drive_files <- drive_files[!existingFiles, ]
-                messagePreProcess("Overwrite is FALSE; only getting new ones:\n",
-                                  paste0(drive_files$name, collapse = "\n"))
-
-              }
+            ## Which files of the folder to fetch follows the rules for a single file: one
+            ## already in destinationPath whose CHECKSUMS.txt row matches is kept; one that is
+            ## missing, or does not match, is fetched and replaces the local copy. This used to
+            ## go by file name alone, with `overwrite` as the switch to fetch again. purge = 7
+            ## fetches them all.
+            refetchAll <- isTRUE(as.integer(purge) == 7L)
+            keep <- rep(FALSE, NROW(drive_files))
+            present <- drive_files$name %in% dir(destinationPath)
+            csf <- identifyCHECKSUMStxtFile(destinationPath)
+            if (!refetchAll && any(present) && file.exists(csf)) {
+              cs <- Checksums(path = destinationPath, write = FALSE, checksumFile = csf,
+                              files = drive_files$name[present], verbose = verbose - 1)
+              keep <- drive_files$name %in% cs$expectedFile[cs$result %in% "OK"]
+            }
+            if (any(keep)) {
+              messagePreProcess("Keeping file(s) already in destinationPath that match CHECKSUMS.txt:\n",
+                                paste0(drive_files$name[keep], collapse = "\n"), verbose = verbose)
+              filenamesAlreadyHave <- makeAbsolute(drive_files$name[keep], destinationPath)
+              drive_files <- drive_files[!keep, , drop = FALSE]
             }
 
             ids <- drive_files$id
@@ -2245,6 +2252,18 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
                                       needChecksums = max(vapply(downloadResults, function(x) x$needChecksums, FUN.VALUE = numeric(1))))
             } else {
               downloadResults <- list(destFile = character(), needChecksums = 0)
+            }
+            if (refetchAll && NROW(drive_files)) {
+              ## Everything is downloaded, so the local copies can go: the fresh ones replace
+              ## those in destinationPath below. Drop the old rows so the fresh copies are
+              ## recorded rather than rejected, and the stash copies so none is reused.
+              sharedRoots <- .getDestinationPathShared()
+              for (csfi in unique(identifyCHECKSUMStxtFile(c(destinationPath, sharedRoots))))
+                if (file.exists(csfi)) .removeChecksumsRows(csfi, drive_files$name)
+              if (!is.null(sharedRoots)) {
+                stashed <- file.path(sharedRoots, drive_files$name)
+                unlink(stashed[normPath(stashed) != normPath(file.path(destinationPath, drive_files$name))])
+              }
             }
 
           } else {
@@ -2353,19 +2372,11 @@ downloadRemote <- function(url, archive, targetFile, checkSums, dlFun = NULL,
       )) || testFTD) {
         # basename2 is OK because the destFile will be flat; it is just archive extraction that needs to allow nesting
         desiredPath <- makeAbsolute(basename2(downloadResults$destFile), destinationPath)
-        desiredPathExists <- file.exists(desiredPath)
-        if (any(desiredPathExists) && !isTRUE(overwrite)) {
-          stopMess <- paste(desiredPath, " already exists and overwrite = FALSE; would you like to overwrite anyway? Y or N:  ")
-          if (interactive()) {
-            interactiveRes <- readline(stopMess)
-            if (startsWith(tolower(interactiveRes), "y")) {
-              overwrite <- TRUE
-            }
-          }
-          if (!identical(overwrite, TRUE)) {
-            stop(targetFile, " already exists at ", desiredPath, ". Use overwrite = TRUE?")
-          }
-        }
+        ## An existing file at desiredPath is replaced. downloadFile() only downloads when the
+        ## CHECKSUMS.txt check finds the local copy missing or not matching (missingFiles()),
+        ## so a file already here is stale or damaged and the fresh download must take its
+        ## place. This used to stop unless `overwrite = TRUE`, which prepInputs() took from its
+        ## `writeTo` argument: a damaged local file could not be repaired by re-running.
 
         # Try hard link first -- the only type that R deeply recognizes
         # if that fails, fall back to copying the file.

--- a/R/download.R
+++ b/R/download.R
@@ -271,6 +271,8 @@ downloadFile <- function(archive, targetFile, neededFiles,
                     if (nzchar(purgeTry[1])) paste0(":\n      ", paste(purgeTry, collapse = "")) else ".",
                     "\n    That replaces ", singularPlural(c("the local copy", "all local copies"), l = localCopies),
                     ":\n      ", paste(localCopies, collapse = "\n      "),
+                    "\n 3) Or remove only this file's entry from the checksums file, then rerun this call:\n",
+                    "      reproducible::purgeChecksums('", checksumFile, "', fileToRemove = '", fileToDownload, "')",
                     call. = FALSE
                   )
                 }

--- a/R/options.R
+++ b/R/options.R
@@ -237,8 +237,9 @@
 #'     faster, depending on the objects.
 #'   }
 #'   \item{`overwrite`}{
-#'     Default: `FALSE`. Used in [prepInputs()], [preProcess()],
-#'     [downloadFile()], and [postProcess()].
+#'     Default: `FALSE`. Used in [prepInputs()] and [postProcess()] for the `writeTo` file.
+#'     It does not trigger re-downloading; use `purge = 7` (see the "Re-downloading" section
+#'     of [prepInputs()]).
 #'   }
 #'   \item{`parallel.cores`}{
 #'     Default: `NULL`, meaning `parallelly::freeCores()`. Degree of parallelism

--- a/R/preProcess.R
+++ b/R/preProcess.R
@@ -161,6 +161,9 @@ preProcessParams <- function(n = NULL) {
 #'  to get the remove file information (e.g., file name). With that, the connection
 #'  between the `url` and the filename used in the \file{CHECKSUMS.txt} file can be made.
 #'
+#' @param overwrite Deprecated and ignored. A file is downloaded again when it is missing or
+#'   fails its \file{CHECKSUMS.txt} check, and replaces the local copy; use `purge = 7` to
+#'   download again on request, and [prepInputs()]'s `overwrite` for its `writeTo` file.
 #' @inheritParams prepInputs
 #' @inheritParams downloadFile
 #'
@@ -197,6 +200,13 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   ## prepInputs always passes `.tempPath`, so a missing `.tempPath` is the
   ## signal that no load will follow and those messages should be suppressed.
   directCall <- missing(.tempPath)
+  ## `overwrite` no longer decides anything here: a file is downloaded again when it is
+  ## missing or fails its checksum, and `purge = 7` downloads again on request.
+  if (!missing(overwrite) && !"preProcess(overwrite)" %in% .pkgEnv$.deprecMsgEmitted) {
+    message("`preProcess(overwrite)` is deprecated and ignored. Use `prepInputs(overwrite)` ",
+            "for the `writeTo` file, and `purge = 7` to download again.")
+    .pkgEnv$.deprecMsgEmitted <- c(.pkgEnv$.deprecMsgEmitted, "preProcess(overwrite)")
+  }
   ## URL-log hook fires only on direct preProcess() calls. When called from
   ## prepInputs, the prepInputs head already logged (so the COG fast-path,
   ## which bypasses preProcess, is still covered).
@@ -260,6 +270,11 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   ## hardlink out of it, which is the whole point of having one. See .withStashLock() for
   ## why this is not the Cache lock.
   runPipeline <- function(cc) {
+    ## purge = 7 sets this call's local copies aside first, inside the lock, and puts them
+    ## back if the rest does not finish. See .purgeRefreshStart().
+    refresh <- .purgeRefreshStart(cc)
+    finished <- FALSE
+    on.exit(.purgeRefreshFinish(refresh, ok = finished), add = TRUE)
     cc <- pp_checksums_init(cc)
     cc <- pp_purge(cc)
     cc <- pp_resolve_needed_files(cc)
@@ -267,7 +282,9 @@ preProcess <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
     cc <- pp_remote_hash_check(cc)
     cc <- pp_download(cc)
     cc <- pp_extract(cc)
-    pp_link_to_destination(cc)
+    cc <- pp_link_to_destination(cc)
+    finished <- TRUE
+    cc
   }
   lockKey <- .stashLockKey(ctx)
   ctx <- if (is.null(lockKey)) runPipeline(ctx) else
@@ -1728,6 +1745,22 @@ isGoogleDownloadURL <- function(url) {
   )
 }
 
+## TRUE where `to` already holds byte-identical content to `from`. Size splits almost
+## every non-match without reading anything; only the survivors are digested.
+.sameFileContent <- function(from, to) {
+  same <- rep(FALSE, length(to))
+  if (!length(to)) return(same)
+  ok <- file.exists(from) & file.exists(to) & !dir.exists(from) & !dir.exists(to)
+  if (!any(ok)) return(same)
+  sameSize <- rep(FALSE, length(to))
+  sameSize[ok] <- file.size(from[ok]) == file.size(to[ok])
+  for (i in which(sameSize))
+    same[i] <- isTRUE(tryCatch(
+      identical(.robustDigest(asPath(from[i])), .robustDigest(asPath(to[i]))),
+      error = function(e) FALSE))
+  same
+}
+
 #' Hardlink, symlink, or copy a file
 #'
 #' Attempt first to make a hardlink. If that fails, try to make
@@ -1740,6 +1773,8 @@ isGoogleDownloadURL <- function(url) {
 #'                 `to` can alternatively be the path to a single existing directory.
 #' @param symlink  Logical indicating whether to use symlink (instead of hardlink).
 #'                 Default `FALSE`.
+#' @param overwrite Logical. Only used when a link cannot be made and the file is copied
+#'   instead: passed to [file.copy()], so `TRUE` replaces an existing `to`.
 #' @inheritParams prepInputs
 #' @seealso [file.link()], [file.symlink()], [file.copy()].
 #'
@@ -1793,22 +1828,6 @@ isGoogleDownloadURL <- function(url) {
 #'   ## cleanup
 #'   unlink(tmpDir, recursive = TRUE)
 #' }
-## TRUE where `to` already holds byte-identical content to `from`. Size splits almost
-## every non-match without reading anything; only the survivors are digested.
-.sameFileContent <- function(from, to) {
-  same <- rep(FALSE, length(to))
-  if (!length(to)) return(same)
-  ok <- file.exists(from) & file.exists(to) & !dir.exists(from) & !dir.exists(to)
-  if (!any(ok)) return(same)
-  sameSize <- rep(FALSE, length(to))
-  sameSize[ok] <- file.size(from[ok]) == file.size(to[ok])
-  for (i in which(sameSize))
-    same[i] <- isTRUE(tryCatch(
-      identical(.robustDigest(asPath(from[i])), .robustDigest(asPath(to[i]))),
-      error = function(e) FALSE))
-  same
-}
-
 linkOrCopy <- function(from, to, symlink = TRUE, overwrite = TRUE,
                        verbose = getOption("reproducible.verbose", 1)) {
   ## A file that is already at its destination cannot be linked or copied onto
@@ -2669,6 +2688,134 @@ messageChecksummingAllFiles <- "Checksumming all files in archive"
     try(filelock::unlock(lck), silent = TRUE)
   }, add = TRUE)
   force(expr)
+}
+
+## purge = 7: download this call's inputs again.
+##
+## "Delete the file and re-run" is not something a user can be asked to do: with
+## `destinationPathShared` set there are two local copies -- the shared stash and the link or
+## copy in `destinationPath` -- and a stale one left in either is found and reused. So this
+## sets aside every local copy of this call's files (the archive, the target and what is
+## extracted with it; never a directory, never another input's files), drops their
+## CHECKSUMS.txt rows and remote-hash sidecars, and lets the rest of preProcess() download,
+## extract and link as it does on a first run.
+##
+## Set aside is a rename, not a delete: a process still reading the old file keeps its inode,
+## nothing is truncated in place, and if the download fails the old copies are put back
+## (.purgeRefreshFinish()) instead of leaving nothing. It runs inside .withStashLock(), so no
+## other process is filling the stash for this input meanwhile.
+.purgeRefreshStart <- function(ctx) {
+  purge <- ctx$purge
+  if (is.logical(purge)) purge <- as.integer(purge)
+  if (!isTRUE(purge == 7L)) return(NULL)
+
+  sharedRoots <- .getDestinationPathShared()
+  dirs <- unique(c(ctx$destinationPath, .sharedDirsFor(sharedRoots, ctx$archive)))
+  files <- .purgeRefreshFiles(ctx, dirs)
+  if (!length(files)) return(NULL)
+
+  paths <- unique(unlist(lapply(dirs, function(d) file.path(d, files))))
+  ## an archive stashed flat, before the stash was scoped per archive, is migrated back in
+  if (!is.null(sharedRoots) && !isNULLorNA(ctx$archive))
+    paths <- unique(c(paths, file.path(sharedRoots, basename2(ctx$archive[1]))))
+  paths <- paths[file.exists(paths) & !dir.exists(paths)]
+
+  tag <- paste0(".purge7_", Sys.getpid(), "_", rndstr(1, 6))
+  baks <- vapply(paths, function(p) {
+    bak <- file.path(dirname(p), paste0(".", basename(p), tag))
+    if (isTRUE(file.rename(p, bak))) bak else NA_character_
+  }, character(1), USE.NAMES = FALSE)
+
+  csfs <- unique(identifyCHECKSUMStxtFile(c(dirs, sharedRoots)))
+  csfs <- csfs[file.exists(csfs)]
+  csBaks <- vapply(csfs, function(csf) {
+    bak <- file.path(dirname(csf), paste0(".CHECKSUMS.txt", tag))
+    if (!isTRUE(file.copy(csf, bak))) return(NA_character_)
+    .removeChecksumsRows(csf, files)
+    bak
+  }, character(1), USE.NAMES = FALSE)
+
+  sidecarDirs <- unique(c(dirs, sharedRoots))
+  unlink(unlist(lapply(unique(basename2(files)), .findRemoteHashSidecars, dirs = sidecarDirs)))
+
+  if (length(paths))
+    messagePreProcess("purge = 7: downloading again; set aside the local copies:\n  ",
+                      paste(paths, collapse = "\n  "), verbose = ctx$verbose)
+  list(moved = data.frame(orig = paths, bak = baks, stringsAsFactors = FALSE),
+       checksums = data.frame(orig = csfs, bak = csBaks, stringsAsFactors = FALSE),
+       verbose = ctx$verbose)
+}
+
+## On success the set-aside copies are removed. Otherwise each is put back where nothing new
+## took its place, with the CHECKSUMS.txt it was recorded in.
+.purgeRefreshFinish <- function(refresh, ok) {
+  if (is.null(refresh)) return(invisible())
+  moved <- refresh$moved[!is.na(refresh$moved$bak), , drop = FALSE]
+  cs <- refresh$checksums[!is.na(refresh$checksums$bak), , drop = FALSE]
+  if (isTRUE(ok)) {
+    unlink(c(moved$bak, cs$bak))
+  } else {
+    back <- !file.exists(moved$orig)
+    if (any(back)) file.rename(moved$bak[back], moved$orig[back])
+    unlink(moved$bak[!back])
+    if (NROW(cs)) file.rename(cs$bak, cs$orig)
+    if (NROW(moved))
+      messagePreProcess("purge = 7 did not finish; the previous local copies were put back",
+                        verbose = refresh$verbose)
+  }
+  invisible()
+}
+
+## The files, relative to destinationPath, that this call downloads or extracts.
+.purgeRefreshFiles <- function(ctx, dirs) {
+  dp <- ctx$destinationPath
+  archive <- if (isNULLorNA(ctx$archive)) character() else makeRelative(ctx$archive, dp)
+  target <- ctx[["targetFile"]]
+  target <- target[!is.na(target) & nzchar(target)]
+  alsoExtract <- ctx$alsoExtract
+  similar <- "similar" %in% alsoExtract && length(target)
+  also <- alsoExtract[!is.na(alsoExtract) & nzchar(alsoExtract) &
+                        !alsoExtract %in% c("similar", "none", "all")]
+  sameStem <- function(x) filePathSansExt(basename2(x)) %in% filePathSansExt(basename2(target))
+
+  inArchive <- character()
+  if (length(archive)) {
+    local <- unlist(lapply(dirs, function(d) file.path(d, basename2(archive))))
+    local <- local[file.exists(local)]
+    if (length(local)) inArchive <- .listFilesInArchive(local[1])
+  }
+  extracted <- if (length(inArchive)) {
+    if (is.null(alsoExtract) || "all" %in% alsoExtract) inArchive else
+      unique(c(inArchive[inArchive %in% c(target, also) |
+                           basename2(inArchive) %in% basename2(c(target, also))],
+               intersect(.expandAlsoExtractPatterns(also, inArchive), inArchive),
+               if (similar) inArchive[sameStem(inArchive)]))
+  } else if (similar) {
+    unlist(lapply(dirs, function(d) {
+      f <- list.files(d, all.files = FALSE)
+      f[sameStem(f) & !dir.exists(file.path(d, f))]
+    }))
+  } else character()
+
+  unique(c(archive, target, also, extracted))
+}
+
+## Remove the CHECKSUMS.txt rows for `files`, keeping the file's own format.
+.removeChecksumsRows <- function(checkSumFilePath, files) {
+  cs <- try(read.table(checkSumFilePath, header = TRUE, stringsAsFactors = FALSE), silent = TRUE)
+  if (is(cs, "try-error") || !NROW(cs) || is.null(cs$file)) return(invisible(FALSE))
+  drop <- cs$file %in% files
+  if (any(drop)) writeChecksumsTable(cs[!drop, , drop = FALSE], checkSumFilePath, dots = list())
+  invisible(any(drop))
+}
+
+## The copies of `files` in destinationPathShared, for messages that need to name them.
+.sharedCopiesOf <- function(files, archive = NULL) {
+  sharedRoots <- .getDestinationPathShared()
+  if (is.null(sharedRoots) || !length(files)) return(character())
+  dirs <- unique(c(.sharedDirsFor(sharedRoots, archive), sharedRoots))
+  p <- unlist(lapply(dirs, function(d) file.path(d, basename2(files))))
+  unique(p[file.exists(p)])
 }
 
 # may already have been changed above

--- a/R/prepInputs.R
+++ b/R/prepInputs.R
@@ -105,12 +105,31 @@ utils::globalVariables(c(
 #'     \item{`3`}{delete entry with same `archive`}
 #'     \item{`5`}{delete entry with same `targetFile` & `alsoExtract`}
 #'     \item{`6`}{delete entry with same `targetFile`, `alsoExtract` & `archive`}
-#'     \item{`7`}{delete entry that same `targetFile`, `alsoExtract` & `archive` & `url`}
+#'     \item{`7`}{download again: set aside the local copies of `targetFile`, `archive` and
+#'       the files extracted with them -- in `destinationPath` and, when
+#'       `reproducible.destinationPathShared` is set, in the shared stash -- drop their
+#'       entries, then download, extract and link them as on a first run. If the download
+#'       fails, the previous copies are put back.}
 #'   }
-#' will only remove entries in the `CHECKSUMS.txt` that are associated with
-#'   `targetFile`, `alsoExtract` or `archive` When `prepInputs` is called,
-#'   it will write or append to a (if already exists) `CHECKSUMS.txt` file.
-#'   If the `CHECKSUMS.txt` is not correct, use this argument to remove it.
+#' Values `1` to `6` only remove entries in the `CHECKSUMS.txt`; the entries are then
+#'   rebuilt from the files already on disk, so they do not download anything.
+#'   When `prepInputs` is called, it will write or append to a (if already exists)
+#'   `CHECKSUMS.txt` file.
+#'
+#' @section Re-downloading:
+#'
+#' Whether a file is downloaded is decided by the \file{CHECKSUMS.txt} file in
+#' `destinationPath`, not by `overwrite`. A file that is missing, or whose checksum does not
+#' match its entry, is downloaded again and replaces the local copy (and its copy in
+#' `reproducible.destinationPathShared`). A file that matches is kept.
+#'
+#' To download again on request -- for example because the file at the `url` has changed --
+#' pass `purge = 7`. It does this for every local copy of the call's files, including the one
+#' in `reproducible.destinationPathShared`, so there is nothing to find and delete by hand.
+#'
+#' For `http(s)` and Google Drive urls, a local file that has once been matched to the remote
+#' is trusted without asking the remote again; set
+#' `options(reproducible.checkRemoteHash = TRUE)` to re-check the remote on each call.
 #'
 #' @param targetFile Character string giving the filename (without relative or
 #'   absolute path) to the eventual file
@@ -196,7 +215,10 @@ utils::globalVariables(c(
 #'   `prepInputs` will write or append to it. `1/TRUE` will deleted the entire `CHECKSUMS.txt` file.
 #'    Other options, see details.
 #'
-#' @param overwrite Logical. Passed to `writeTo` (possibly inside `postProcess`) and `postProcess`.
+#' @param overwrite Logical. Only used for the `writeTo` file (see [postProcessTo()]): whether
+#'   an existing `writeTo` file may be replaced. If not supplied, it is replaced, so re-running
+#'   a call rewrites its own output; `overwrite = FALSE` stops instead. It has no effect on
+#'   downloading: see the "Re-downloading" section.
 #'
 #' @param ... Additional arguments passed to
 #'   [postProcess()] and [reproducible::Cache()].
@@ -435,7 +457,8 @@ prepInputs <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
       destinationPath = destinationPath,
       fun = funCaptured,
       quick = quick,
-      overwrite = overwrite,
+      ## `overwrite` is not passed: it is only for the writeTo file below. preProcess()
+      ## replaces a missing or damaged download by itself, and purge = 7 downloads again.
       purge = purge,
       useCache = useCache,
       .tempPath = .tempPath,
@@ -477,8 +500,13 @@ prepInputs <- function(targetFile = NULL, url = NULL, archive = NULL, alsoExtrac
   )
   if (any(needPostProcess)) {
     TopoErrors <- list() # eventually to update a Google ID #TODO
+    ## `overwrite` is only for this write. The `writeTo` file is this call's own output, so
+    ## unless the caller chose, keep postProcessTo()'s default of TRUE: the
+    ## reproducible.overwrite default (FALSE) made any re-run of the same call (e.g., after a
+    ## Cache miss) stop with "already exists and `overwrite = FALSE`".
+    overwritePost <- if (missing(overwrite)) TRUE else overwrite
     x <- withCallingHandlers(
-      postProcessTo(from = x, ..., destinationPath = destinationPath, overwrite = overwrite),
+      postProcessTo(from = x, ..., destinationPath = destinationPath, overwrite = overwritePost),
       message = function(m) {
         hasTopoExcError <- grepl("TopologyException: Input geom 0 is invalid", m$message)
         if (any(hasTopoExcError)) {
@@ -1300,8 +1328,12 @@ appendChecksumsTable <- function(checkSumFilePath, filesToChecksum,
           if (fsArch <= 10) {
             # corrupted
             unlink(archive[1])
-            message("archive (", archive[1], ") appears corrupted; deleting it; ",
-                    "you may have to manually delete it and the copy in `reproducible.destinationPathShared` if using ")
+            shared <- setdiff(.sharedCopiesOf(archive[1], archive[1]), normPath(archive[1]))
+            message("archive (", archive[1], ") appears corrupted; deleting it.",
+                    if (length(shared))
+                      paste0(" Its copy in reproducible.destinationPathShared (",
+                             paste(shared, collapse = ", "), ") may be corrupted too."),
+                    " Rerun with purge = 7 to download it again.")
             return(NULL)
           }
           needSystemCall <- needSystemCall || fsArch > 2e9

--- a/man/CacheGeo.Rd
+++ b/man/CacheGeo.Rd
@@ -65,7 +65,10 @@ its nested \verb{*Input} functions (e.g., \code{cropInputs}, \code{projectInputs
 mean internal caching is more time consuming. We recommend caching the full
 \code{prepInputs} call instead (e.g. \code{prepInputs(...) |> Cache()}).}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Logical. Only used for the \code{writeTo} file (see \code{\link[=postProcessTo]{postProcessTo()}}): whether
+an existing \code{writeTo} file may be replaced. If not supplied, it is replaced, so re-running
+a call rewrites its own output; \code{overwrite = FALSE} stops instead. It has no effect on
+downloading: see the "Re-downloading" section.}
 
 \item{action}{A character string, with one of c("nothing", "update",
 "replace", "append"). Partial matching is used ("n" is sufficient).

--- a/man/dlGoogle.Rd
+++ b/man/dlGoogle.Rd
@@ -50,7 +50,9 @@ search for the file before attempting to download. Default for that option is
 \code{options("reproducible.inputPaths")} is still accepted as a backwards-compatible
 alias.}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Deprecated and ignored. A file is downloaded again when it is missing or
+fails its \file{CHECKSUMS.txt} check, and replaces the local copy; use \code{purge = 7} to
+download again on request, and \code{\link[=prepInputs]{prepInputs()}}'s \code{overwrite} for its \code{writeTo} file.}
 
 \item{verbose}{Numeric, -1 silent (where possible), 0 being very quiet,
 1 showing more messaging, 2 being more messaging, etc.

--- a/man/downloadFile.Rd
+++ b/man/downloadFile.Rd
@@ -83,8 +83,8 @@ in subsequent calls to
 
 \item{preDigest}{The list of \code{preDigest} that comes from \code{CacheDigest} of an object}
 
-\item{overwrite}{Logical. If \code{TRUE} then the download will overwrite an existing file
-if it exists.}
+\item{overwrite}{Passed on to \code{googledrive::drive_download()}, which writes into a
+temporary directory; it does not decide what is downloaded. See \code{\link[=preProcess]{preProcess()}}.}
 
 \item{alsoExtract}{Which files to fetch or extract in addition to
 \code{targetFile}. Spatial data rarely arrives as one file -- a shapefile is

--- a/man/downloadRemote.Rd
+++ b/man/downloadRemote.Rd
@@ -18,6 +18,7 @@ downloadRemote(
   .tempPath,
   preDigest,
   alsoExtract = "similar",
+  purge = FALSE,
   verbose = getOption("reproducible.verbose", 1),
   .callingEnv = parent.frame(),
   ...
@@ -69,7 +70,10 @@ search for the file before attempting to download. Default for that option is
 \code{options("reproducible.inputPaths")} is still accepted as a backwards-compatible
 alias.}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Passed to \code{googledrive::drive_download()}, which writes into a temporary
+directory; it does not decide what is downloaded. A downloaded file always replaces an
+existing file of the same name, because it is only downloaded when that file is missing
+or fails its checksum.}
 
 \item{needChecksums}{Logical indicating whether to generate checksums. ## TODO: add overwrite arg to the function?}
 
@@ -107,6 +111,8 @@ basename), it is passed to \code{grep()} against the archive's file list and all
 matching members are extracted. For example,
 \code{alsoExtract = "CMD_sm|CMD_sp"} extracts every file whose name contains
 \code{CMD_sm} or \code{CMD_sp}. See table in \code{\link[=preProcess]{preProcess()}}.}
+
+\item{purge}{\code{7} fetches every file of a Google Drive folder \code{url} again; see \code{\link[=prepInputs]{prepInputs()}}.}
 
 \item{verbose}{Numeric, -1 silent (where possible), 0 being very quiet,
 1 showing more messaging, 2 being more messaging, etc.

--- a/man/linkOrCopy.Rd
+++ b/man/linkOrCopy.Rd
@@ -19,7 +19,8 @@ linkOrCopy(
 \item{symlink}{Logical indicating whether to use symlink (instead of hardlink).
 Default \code{FALSE}.}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Logical. Only used when a link cannot be made and the file is copied
+instead: passed to \code{\link[=file.copy]{file.copy()}}, so \code{TRUE} replaces an existing \code{to}.}
 
 \item{verbose}{Numeric, -1 silent (where possible), 0 being very quiet,
 1 showing more messaging, 2 being more messaging, etc.

--- a/man/preProcess.Rd
+++ b/man/preProcess.Rd
@@ -112,7 +112,9 @@ custom downloading, in addition to loading into R. Still experimental.}
 \code{\link[=Cache]{Cache()}} (the quick argument). This results in faster, though
 less robust checking of inputs. See the respective functions.}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Deprecated and ignored. A file is downloaded again when it is missing or
+fails its \file{CHECKSUMS.txt} check, and replaces the local copy; use \code{purge = 7} to
+download again on request, and \code{\link[=prepInputs]{prepInputs()}}'s \code{overwrite} for its \code{writeTo} file.}
 
 \item{purge}{Logical or Integer. \code{0/FALSE} (default) keeps existing \code{CHECKSUMS.txt} file and
 \code{prepInputs} will write or append to it. \code{1/TRUE} will deleted the entire \code{CHECKSUMS.txt} file.

--- a/man/prepInputs.Rd
+++ b/man/prepInputs.Rd
@@ -101,7 +101,10 @@ as the file path to the file to load. See details and examples below.}
 \code{\link[=Cache]{Cache()}} (the quick argument). This results in faster, though
 less robust checking of inputs. See the respective functions.}
 
-\item{overwrite}{Logical. Passed to \code{writeTo} (possibly inside \code{postProcess}) and \code{postProcess}.}
+\item{overwrite}{Logical. Only used for the \code{writeTo} file (see \code{\link[=postProcessTo]{postProcessTo()}}): whether
+an existing \code{writeTo} file may be replaced. If not supplied, it is replaced, so re-running
+a call rewrites its own output; \code{overwrite = FALSE} stops instead. It has no effect on
+downloading: see the "Re-downloading" section.}
 
 \item{purge}{Logical or Integer. \code{0/FALSE} (default) keeps existing \code{CHECKSUMS.txt} file and
 \code{prepInputs} will write or append to it. \code{1/TRUE} will deleted the entire \code{CHECKSUMS.txt} file.
@@ -245,12 +248,33 @@ In options for control of purging the \code{CHECKSUMS.txt} file are:
 \item{\code{3}}{delete entry with same \code{archive}}
 \item{\code{5}}{delete entry with same \code{targetFile} & \code{alsoExtract}}
 \item{\code{6}}{delete entry with same \code{targetFile}, \code{alsoExtract} & \code{archive}}
-\item{\code{7}}{delete entry that same \code{targetFile}, \code{alsoExtract} & \code{archive} & \code{url}}
+\item{\code{7}}{download again: set aside the local copies of \code{targetFile}, \code{archive} and
+the files extracted with them -- in \code{destinationPath} and, when
+\code{reproducible.destinationPathShared} is set, in the shared stash -- drop their
+entries, then download, extract and link them as on a first run. If the download
+fails, the previous copies are put back.}
 }
-will only remove entries in the \code{CHECKSUMS.txt} that are associated with
-\code{targetFile}, \code{alsoExtract} or \code{archive} When \code{prepInputs} is called,
-it will write or append to a (if already exists) \code{CHECKSUMS.txt} file.
-If the \code{CHECKSUMS.txt} is not correct, use this argument to remove it.
+Values \code{1} to \code{6} only remove entries in the \code{CHECKSUMS.txt}; the entries are then
+rebuilt from the files already on disk, so they do not download anything.
+When \code{prepInputs} is called, it will write or append to a (if already exists)
+\code{CHECKSUMS.txt} file.
+}
+
+\section{Re-downloading}{
+
+
+Whether a file is downloaded is decided by the \file{CHECKSUMS.txt} file in
+\code{destinationPath}, not by \code{overwrite}. A file that is missing, or whose checksum does not
+match its entry, is downloaded again and replaces the local copy (and its copy in
+\code{reproducible.destinationPathShared}). A file that matches is kept.
+
+To download again on request -- for example because the file at the \code{url} has changed --
+pass \code{purge = 7}. It does this for every local copy of the call's files, including the one
+in \code{reproducible.destinationPathShared}, so there is nothing to find and delete by hand.
+
+For \code{http(s)} and Google Drive urls, a local file that has once been matched to the remote
+is trusted without asking the remote again; set
+\code{options(reproducible.checkRemoteHash = TRUE)} to re-check the remote on each call.
 }
 
 \examples{

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -244,8 +244,9 @@ be time consuming, so setting this to \code{FALSE} will make caching up to 10\%
 faster, depending on the objects.
 }
 \item{\code{overwrite}}{
-Default: \code{FALSE}. Used in \code{\link[=prepInputs]{prepInputs()}}, \code{\link[=preProcess]{preProcess()}},
-\code{\link[=downloadFile]{downloadFile()}}, and \code{\link[=postProcess]{postProcess()}}.
+Default: \code{FALSE}. Used in \code{\link[=prepInputs]{prepInputs()}} and \code{\link[=postProcess]{postProcess()}} for the \code{writeTo} file.
+It does not trigger re-downloading; use \code{purge = 7} (see the "Re-downloading" section
+of \code{\link[=prepInputs]{prepInputs()}}).
 }
 \item{\code{parallel.cores}}{
 Default: \code{NULL}, meaning \code{parallelly::freeCores()}. Degree of parallelism

--- a/tests/testthat/test-prepInputs-purge7.R
+++ b/tests/testthat/test-prepInputs-purge7.R
@@ -1,0 +1,191 @@
+## purge = 7 downloads a call's inputs again. "Delete the file and re-run" cannot be the way
+## to do that: with reproducible.destinationPathShared set there are two local copies, and a
+## stale one left in either is found and reused. Before, purge = 7 only dropped CHECKSUMS.txt
+## entries, which were then rebuilt from the files already on disk -- nothing was downloaded,
+## and a damaged local file was accepted as correct.
+
+purge7FileUrl <- function(p) {
+  p <- gsub("\\\\", "/", normPath(p))
+  paste0("file://", ifelse(startsWith(p, "/"), "", "/"), p)
+}
+purge7Inode <- function(p) as.character(fs::file_info(p)$inode)
+purge7Leftovers <- function(dirs) list.files(dirs, pattern = "purge7", all.files = TRUE)
+
+test_that("purge = 7 downloads a changed or damaged file again", {
+  testInit(opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL,
+                       reproducible.destinationPathShared = NULL,
+                       reproducible.interactiveOnDownloadFail = FALSE))
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  remote <- file.path(src, "data.csv")
+  local <- file.path(dest, "data.csv")
+  writeLines("v1", remote)
+  prep <- function(...)
+    prepInputs(url = purge7FileUrl(remote), targetFile = "data.csv", destinationPath = dest,
+               fun = NA, useCache = FALSE, ...)
+
+  prep()
+  expect_identical(readLines(local), "v1")
+
+  ## the file at the url changes
+  writeLines("v2", remote)
+  expect_no_error(prep(purge = 7))
+  expect_identical(readLines(local), "v2")
+  ## and v2 is what CHECKSUMS.txt now records
+  expect_no_error(prep())
+  expect_identical(readLines(local), "v2")
+
+  ## a damaged local copy is replaced, not accepted
+  writeLines("damaged", local)
+  expect_no_error(prep(purge = 7))
+  expect_identical(readLines(local), "v2")
+  expect_length(purge7Leftovers(dest), 0L)
+})
+
+test_that("purge = 7 replaces both copies with destinationPathShared, and only this call's files", {
+  skip_on_os("windows") # inodes, and renaming a file that is open
+  testInit(opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL,
+                       reproducible.interactiveOnDownloadFail = FALSE))
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  shared <- checkPath(file.path(tmpdir, "shared"), create = TRUE)
+  withr::local_options(reproducible.destinationPathShared = shared)
+  remote <- file.path(src, "data.csv")
+  other <- file.path(src, "other.csv")
+  writeLines("v1", remote)
+  writeLines("keep", other)
+  prep <- function(f, ...)
+    prepInputs(url = purge7FileUrl(f), targetFile = basename(f), destinationPath = dest,
+               fun = NA, useCache = FALSE, ...)
+
+  prep(remote)
+  prep(other)
+  local <- file.path(dest, "data.csv")
+  stashed <- file.path(shared, "data.csv")
+  expect_true(file.exists(stashed))
+  expect_identical(purge7Inode(local), purge7Inode(stashed))
+  otherPaths <- c(file.path(dest, "other.csv"), file.path(shared, "other.csv"))
+  otherInodes <- purge7Inode(otherPaths)
+
+  ## a process still reading the old file
+  con <- file(local, "r")
+  withr::defer(close(con))
+
+  writeLines("v2", remote)
+  expect_no_error(prep(remote, purge = 7))
+  expect_identical(readLines(local), "v2")
+  expect_identical(readLines(stashed), "v2")
+  ## one fresh inode, shared again -- the stash is not left holding the old one
+  expect_identical(purge7Inode(local), purge7Inode(stashed))
+  ## the old file was replaced, not truncated under its reader
+  expect_identical(readLines(con), "v1")
+  ## another input in the same destinationPath and stash is untouched
+  expect_identical(purge7Inode(otherPaths), otherInodes)
+  expect_length(purge7Leftovers(c(dest, shared)), 0L)
+})
+
+test_that("purge = 7 puts the previous copies back if the download fails", {
+  withr::local_envvar(NOT_CRAN = "true") # a failed download would otherwise skip() on CRAN
+  testInit(opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL,
+                       reproducible.destinationPathShared = NULL,
+                       reproducible.interactiveOnDownloadFail = FALSE))
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  remote <- file.path(src, "data.csv")
+  local <- file.path(dest, "data.csv")
+  writeLines("v1", remote)
+  prep <- function(...)
+    prepInputs(url = purge7FileUrl(remote), targetFile = "data.csv", destinationPath = dest,
+               fun = NA, useCache = FALSE, ...)
+  prep()
+
+  unlink(remote) # the url no longer answers
+  expect_error(suppressWarnings(prep(purge = 7)))
+  expect_identical(readLines(local), "v1")
+  expect_length(purge7Leftovers(dest), 0L)
+  ## CHECKSUMS.txt still describes the restored copy, so nothing needs downloading
+  expect_no_error(prep())
+  expect_identical(readLines(local), "v1")
+})
+
+test_that("purge = 7 downloads an archive again and re-extracts from it", {
+  testInit(opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL,
+                       reproducible.destinationPathShared = NULL,
+                       reproducible.interactiveOnDownloadFail = FALSE))
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  zipPath <- file.path(src, "arc.zip")
+  mkZip <- function(content) {
+    unlink(zipPath)
+    writeLines(content, file.path(src, "a.csv"))
+    owd <- setwd(src)
+    on.exit(setwd(owd), add = TRUE)
+    zipped <- utils::zip(zipPath, "a.csv", flags = "-q")
+    skip_if_not(identical(zipped, 0L), "no zip utility")
+  }
+  mkZip("v1")
+  prep <- function(...)
+    prepInputs(url = purge7FileUrl(zipPath), targetFile = "a.csv", destinationPath = dest,
+               fun = NA, useCache = FALSE, ...)
+  prep()
+  expect_identical(readLines(file.path(dest, "a.csv")), "v1")
+
+  mkZip("v2")
+  expect_no_error(prep(purge = 7))
+  expect_identical(readLines(file.path(dest, "a.csv")), "v2")
+  expect_length(purge7Leftovers(dest), 0L)
+})
+
+test_that("a Google Drive folder url fetches by CHECKSUMS.txt, and everything on purge = 7", {
+  skip_if_not_installed("googledrive")
+  testInit(opts = list(reproducible.inputPaths = NULL, reproducible.destinationPathShared = NULL))
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  writeLines("x1", file.path(src, "x.csv"))
+  writeLines("y1", file.path(src, "y.csv"))
+  ## no network: the folder is listed from a "mirror" whose files are local file urls
+  local_mocked_bindings(
+    .driveDirRemap = function(url, ...) "https://mirror.invalid/listing/",
+    .bucketDirList = function(...)
+      data.frame(name = c("x.csv", "y.csv"),
+                 url = purge7FileUrl(file.path(src, c("x.csv", "y.csv"))),
+                 stringsAsFactors = FALSE)
+  )
+  folder <- "https://drive.google.com/drive/folders/1AbCdEfGhIjKlMnOpQrStUvWxYz012345"
+  fetch <- function(purge = FALSE)
+    downloadRemote(url = folder, archive = NULL, targetFile = NULL,
+                   checkSums = .emptyChecksumsResult, fileToDownload = NULL,
+                   messSkipDownload = "", destinationPath = dest, overwrite = FALSE,
+                   needChecksums = 0, .tempPath = tempdir2(rndstr(1, 6)), preDigest = NULL,
+                   alsoExtract = NULL, purge = purge, verbose = 0)
+
+  fetch()
+  Checksums(dest, write = TRUE)
+
+  writeLines("x2", file.path(src, "x.csv"))       # the remote copy of x changes
+  writeLines("damaged", file.path(dest, "y.csv")) # the local copy of y is damaged
+  fetch()
+  expect_identical(readLines(file.path(dest, "x.csv")), "x1") # matches its entry: kept
+  expect_identical(readLines(file.path(dest, "y.csv")), "y1") # fails its entry: fetched again
+
+  fetch(purge = 7)
+  expect_identical(readLines(file.path(dest, "x.csv")), "x2")
+  ## the old rows are dropped so the fresh copies get recorded, not rejected
+  cs <- read.table(file.path(dest, "CHECKSUMS.txt"), header = TRUE)
+  expect_false(any(c("x.csv", "y.csv") %in% cs$file))
+})
+
+test_that("preProcess(overwrite) is accepted and ignored, with a one-time deprecation message", {
+  testInit(opts = list(reproducible.inputPaths = NULL, reproducible.destinationPathShared = NULL))
+  .pkgEnv$.deprecMsgEmitted <- setdiff(.pkgEnv$.deprecMsgEmitted, "preProcess(overwrite)")
+  src <- checkPath(file.path(tmpdir, "remote"), create = TRUE)
+  dest <- checkPath(file.path(tmpdir, "dest"), create = TRUE)
+  writeLines("v1", file.path(src, "data.csv"))
+  pp <- function()
+    preProcess(url = purge7FileUrl(file.path(src, "data.csv")), targetFile = "data.csv",
+               destinationPath = dest, fun = NA, overwrite = TRUE)
+
+  expect_message(pp(), "deprecated and ignored")
+  expect_no_message(pp(), message = "deprecated")
+  expect_identical(readLines(file.path(dest, "data.csv")), "v1")
+})

--- a/tests/testthat/test-prepInputs.R
+++ b/tests/testthat/test-prepInputs.R
@@ -2286,3 +2286,84 @@ test_that(".guessAtTargetAndFun ignores OS archive metadata when auto-picking", 
   )
   expect_identical(out2$targetFilePath, "data/__MACOSX/._clean_NMC_20kmBuff.shp")
 })
+
+test_that("prepInputs rewrites its own writeTo output when overwrite is not supplied", {
+  ## `overwrite` defaults to reproducible.overwrite (FALSE), a setting about replacing
+  ## downloaded sources, and prepInputs() used to pass it on to postProcessTo() too. So
+  ## re-running the same call -- as after any Cache miss -- found its own writeTo file and
+  ## stopped with "already exists and `overwrite = FALSE`". Seen through
+  ## LandR::prepInputs_SCANFI_LCC_FAO() in Biomass_borealDataPrep.
+  testInit("terra", opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL))
+
+  src <- terra::rast(nrows = 20, ncols = 20, xmin = 0, xmax = 20, ymin = 0, ymax = 20,
+                     crs = "EPSG:3005", vals = 1)
+  terra::writeRaster(src, file.path(tmpdir, "src.tif"))
+  cropTo <- terra::rast(nrows = 10, ncols = 10, xmin = 5, xmax = 15, ymin = 5, ymax = 15,
+                        crs = "EPSG:3005")
+  outFile <- file.path(tmpdir, "out.tif")
+  prep <- function(...)
+    prepInputs(targetFile = "src.tif", destinationPath = tmpdir, cropTo = cropTo,
+               writeTo = "out.tif", ...)
+
+  prep(useCache = FALSE)
+  expect_true(file.exists(outFile))
+
+  ## the same call again must replace the output, not stop
+  Sys.setFileTime(outFile, Sys.time() - 3600)
+  expect_no_error(prep(useCache = FALSE))
+  expect_gt(as.numeric(file.mtime(outFile)), as.numeric(Sys.time() - 600))
+
+  ## and through Cache, on a miss, which is how modules call it
+  Sys.setFileTime(outFile, Sys.time() - 3600)
+  expect_no_error(Cache(prep(), cachePath = tmpCache))
+  expect_gt(as.numeric(file.mtime(outFile)), as.numeric(Sys.time() - 600))
+
+  ## an explicit overwrite = FALSE is still honoured
+  expect_error(prep(useCache = FALSE, overwrite = FALSE), "already exists")
+})
+
+test_that("prepInputs' overwrite does not reach downloading; a damaged file is replaced anyway", {
+  ## prepInputs() passed `overwrite` to preProcess() as well as to the writeTo write. It never
+  ## caused a re-download (a file matching CHECKSUMS.txt is kept), but it did decide whether a
+  ## damaged local copy could be replaced: under overwrite = FALSE a re-run stopped in
+  ## downloadRemote() with "already exists ... Use overwrite = TRUE?".
+  testInit(opts = list(reproducible.overwrite = FALSE, reproducible.inputPaths = NULL,
+                       reproducible.destinationPathShared = NULL,
+                       reproducible.interactiveOnDownloadFail = FALSE))
+
+  src <- file.path(tmpdir, "remote")
+  dest <- file.path(tmpdir, "dest")
+  dir.create(src)
+  dir.create(dest)
+  remote <- file.path(src, "data.csv")
+  local <- file.path(dest, "data.csv")
+  writeLines("v1", remote)
+  p <- gsub("\\\\", "/", normPath(remote))
+  url <- paste0("file://", if (!startsWith(p, "/")) "/", p)
+  prep <- function(...)
+    prepInputs(url = url, targetFile = "data.csv", destinationPath = dest, fun = NA,
+               useCache = FALSE, ...)
+
+  prep()
+  expect_identical(readLines(local), "v1")
+
+  ## overwrite = TRUE does not re-download a file that matches CHECKSUMS.txt
+  writeLines("v2", remote)
+  prep(overwrite = TRUE)
+  expect_identical(readLines(local), "v1")
+
+  ## a damaged local file is downloaded again and replaced, whatever overwrite is
+  writeLines("v1", remote)
+  writeLines("damaged", local)
+  expect_no_error(prep())
+  expect_identical(readLines(local), "v1")
+  writeLines("damaged", local)
+  expect_no_error(prep(overwrite = FALSE))
+  expect_identical(readLines(local), "v1")
+
+  ## a remote file that has changed is downloaded again on request with purge = 7 (more in
+  ## test-prepInputs-purge7.R)
+  writeLines("v2", remote)
+  expect_no_error(prep(purge = 7))
+  expect_identical(readLines(local), "v2")
+})


### PR DESCRIPTION
`prepInputs(overwrite)` now applies only to the `writeTo` file, as its help page said, and there is one documented way to download again: `purge = 7`.

## What `overwrite` did before

`prepInputs()` passed `overwrite` to `preProcess()` as well as to the `writeTo` write.

| Where | `TRUE` | `FALSE` (default) |
|---|---|---|
| deciding whether to download (`downloadFile()`) | not consulted: a file matching `CHECKSUMS.txt` is never downloaded again | same |
| a damaged or stale local file, re-run (`downloadRemote()`) | replaced | **stopped**: "already exists ... Use overwrite = TRUE?" |
| Google Drive folder url | fetched every file again | kept files present **by name**, damaged or not |
| `writeTo` output (`postProcessTo()`) | replaced | **stopped**: "already exists and `overwrite = FALSE`" |
| archive extraction, `linkOrCopy()` | not passed | not passed |

So `overwrite = TRUE` never forced a re-download, and the default made a re-run over a damaged file, or over a call's own `writeTo` output (e.g. after a `Cache` miss), stop.

## Now

- **writeTo:** if `overwrite` is not supplied, a re-run replaces the call's own output; an explicit `overwrite = FALSE` still stops.
- **Damaged or stale local file:** downloaded again and replaced whatever `overwrite` is, with a message naming the local copies (both, when `reproducible.destinationPathShared` is set).
- **Google Drive folder url:** same rules as a single file. A file whose `CHECKSUMS.txt` entry matches is kept; a missing or mismatched one is fetched; `purge = 7` fetches them all.
- **`preProcess(overwrite)`:** no longer does anything. It is accepted, with a one-time deprecation message. SpaDES.project's direct calls (`setupProject.R:2452`, `download.R:45`) were checked in both call shapes and still work.

## Re-downloading: `purge = 7`

"Delete the file and re-run" isn't workable: with `destinationPathShared` there are two local copies, and a stale one left in either is found and reused. `purge = 7` used to only drop `CHECKSUMS.txt` entries, which were then rebuilt from the files on disk. It downloaded nothing, and accepted a damaged file.

`purge = 7` now:
1. sets aside every local copy of this call's files: the archive, the target and what is extracted with them, in `destinationPath` and the shared stash (including a legacy flat stash copy). It never touches a directory or another input's files.
2. drops their `CHECKSUMS.txt` rows and remote-hash sidecars.
3. lets `preProcess()` download, extract and link as on a first run.

- **How files are set aside:** it renames them, so a process still reading an old file keeps its inode. Nothing is truncated in place. If the download fails, the old copies and `CHECKSUMS.txt` are put back.
- **Concurrency:** it runs inside the per-input stash lock from #595.
- **Why 7:** its documented meaning, dropping the entries for `targetFile`, `alsoExtract`, `archive` and `url`, is part of this, and the checksum-mismatch error already told users to rerun with `purge = 7`. That error now names every local copy and suggests `purge = 7` instead of deleting files by hand. The "Skipping download" and corrupted-archive messages point to `purge = 7` too.

## Tests

`tests/testthat/test-prepInputs-purge7.R` uses local file urls and mocks for the Drive folder, so it needs no network. All 6 tests fail on development (11 failures) and pass here:
- a changed or damaged file is downloaded again;
- with `destinationPathShared`, both copies get one fresh shared inode, an open reader still reads the old bytes, and another input's files keep their inodes;
- a failed download restores the old copies;
- an archive is downloaded again and re-extracted;
- a Drive folder keeps matching files, re-fetches a damaged one, and fetches all on `purge = 7`;
- the `preProcess(overwrite)` deprecation message appears once.

`test-prepInputs.R` adds two tests, covering the `writeTo` re-run and damaged-file replacement, which fail on development.

19 test files were run on development (b1d4020c) and on this branch, loaded the same way (CRAN mode). They are prepInputs, preProcessWorks/DoesntWork, postProcess/Terra/Coverage, download/Helpers/-helpers/LocalArchive, destinationPathShared/-archive, linkOrCopy, cran-graceful-download, parallel-download-remap, checksums, cacheGeo-helpers, prepInputs-purge7 and cloudFolderID-url.
- **Failures and errors:** 0 in all of them.
- **Counts:** identical to development, except `test-prepInputs.R`, which has 21 tests and 89 expectations here against 19 and 75 on development.
- **New file:** `test-prepInputs-purge7.R` has 6 tests and 33 expectations.

## Callers passing `overwrite`

- **Now affects only the `writeTo` write:** `prepInputs(writeTo = , overwrite = TRUE)` in LandR `maps.R`, and LandR's `prepInputs_SCANFI_LCC_FAO` / `prepInputs_NTEMS_LCC_FAO`, which pass it to the inner `raw_` write (also via fireSenseUtils `makeFireSenseLCC.R`).
- **No longer needed:** LandR `prepRawBiomassMap()` defaults `overwrite = TRUE` to recover a corrupted download, and that now happens without it.
- **No effect now (no `writeTo`):**
  - `prepInputs(url, overwrite = TRUE)` in BBDP `:785`, climateData `makeClimateDEM.R`, scfmutils `utils_fireRegimePolys.R` and LandR `studyArea.R`. Damaged files are replaced automatically.
  - `CacheGeo()` passing `overwrite` to `prepInputs()`.
- **Behaviour change:** fireSenseUtils `fireSenseCloudParameters()` calls `prepInputs(purge = 7)` every time, so it now downloads the ledger fresh on every call. Before, it returned whatever copy was on disk.

## Not changed, for discussion

`purge = 2` to `6` still rebuild entries from the files on disk. A damaged file plus `purge = 2` is still accepted as correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gZhFo9aCTrEgMVrP37sUo