### PR TITLE
showCachePreWarm defaults to interactive()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work with '.ra
 URL: 
     https://reproducible.predictiveecology.org,
     https://github.com/PredictiveEcology/reproducible
-Date: 2026-09-10
-Version: 3.2.1.9027
+Date: 2026-09-11
+Version: 3.2.1.9028
 Authors@R: 
     c(person(given = "Eliot J B",
              family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
-# reproducible 3.2.1.9027
+# reproducible 3.2.1.9028
 
 ## Bug fixes
+
+* `reproducible.showCachePreWarm` now defaults to `interactive()` instead of `TRUE`. The pre-warm
+  only pays off when a later `showCache()` in the same session finds it finished, which is what
+  a person at the console waits for; a batch run (`Rscript`, `R CMD BATCH`, callr or future
+  workers, knitr) rarely does. Set the option or `R_REPRODUCIBLE_SHOWCACHE_PREWARM` to turn it on
+  there. An R session started with `R --interactive`, as the SpaDES.project queue workers are,
+  is interactive, so those workers still switch it off explicitly.
 
 * `prepInputs()`'s `overwrite` now applies only to the `writeTo` file, as its help page
   said. It was also passed to `preProcess()`, where it never caused a re-download (a file

--- a/R/options.R
+++ b/R/options.R
@@ -342,8 +342,9 @@
 #'     Default `FALSE`. Passed to `Cache`.
 #'   }
 #'   \item{`showCachePreWarm`}{
-#'     Default `TRUE` (override with environment variable
-#'     `R_REPRODUCIBLE_SHOWCACHE_PREWARM`). When `TRUE`, a `Cache(showSimilar = TRUE)`
+#'     Default `interactive()` (override with environment variable
+#'     `R_REPRODUCIBLE_SHOWCACHE_PREWARM`): a batch run rarely calls `showCache()` again
+#'     after the pre-warm has finished. When `TRUE`, a `Cache(showSimilar = TRUE)`
 #'     call spawns a one-time background process (a fork; not on Windows) that
 #'     pre-scans the flat-file cache so the subsequent `showCache()`/`showSimilar`
 #'     lookup returns quickly for large caches. This is skipped automatically under
@@ -646,7 +647,7 @@ reproducibleOptions <- function() {
       "R_REPRODUCIBLE_SHOWCACHE_PREWARM",
       # Mirror useDBI: reflect a value already set (e.g. FALSE by tests/covr) so
       # reproducibleOptions() stays identical to options() (see test-misc.R).
-      default = getOption("reproducible.showCachePreWarm", TRUE),
+      default = getOption("reproducible.showCachePreWarm", interactive()),
       allowed = c("true", "false")
     )),
     reproducible.showSimilar = FALSE,

--- a/man/reproducibleOptions.Rd
+++ b/man/reproducibleOptions.Rd
@@ -322,8 +322,9 @@ it will use \code{raster::shapefile}
 Default \code{FALSE}. Passed to \code{Cache}.
 }
 \item{\code{showCachePreWarm}}{
-Default \code{TRUE} (override with environment variable
-\code{R_REPRODUCIBLE_SHOWCACHE_PREWARM}). When \code{TRUE}, a \code{Cache(showSimilar = TRUE)}
+Default \code{interactive()} (override with environment variable
+\code{R_REPRODUCIBLE_SHOWCACHE_PREWARM}): a batch run rarely calls \code{showCache()} again
+after the pre-warm has finished. When \code{TRUE}, a \code{Cache(showSimilar = TRUE)}
 call spawns a one-time background process (a fork; not on Windows) that
 pre-scans the flat-file cache so the subsequent \code{showCache()}/\code{showSimilar}
 lookup returns quickly for large caches. This is skipped automatically under


### PR DESCRIPTION
Split out of #599, which now holds only the detached pre-warm fork.

## Change
`reproducible.showCachePreWarm` now defaults to `interactive()` instead of `TRUE`. The option and `R_REPRODUCIBLE_SHOWCACHE_PREWARM` still override it. The docs (roxygen, Rd) and NEWS are updated.

The pre-warm only helps when a later `showCache()` in the same session finds it already finished, which is a person at the console. Batch runs rarely benefit: `Rscript`, `R CMD BATCH`, callr/future workers, knitr.

Sessions started with `R --interactive` count as interactive, and that includes SpaDES.project's tmux queue workers. Those workers switch the pre-warm off themselves (SpaDES.project #172).

## ⚠️ Known problem: do not merge yet
When this change was part of #599, the **test-downstream / SpaDES.project** check failed on both commits that had it (1ae62251, and the merge 53caf87f). It passed on both commits without it (ea8be181, 2d883697).

In every failing run, all SpaDES.project tests passed (FAIL 0, PASS 1373). R then printed "Error while shutting down parallel: unable to terminate some child processes" and segfaulted while exiting.

I couldn't reproduce this locally with the same R 4.6.1, processx 3.9.0 and callr 3.8.0. SpaDES.project's own tests passed with the pre-warm both on and off, and neither run crashed. So it looks specific to the CI runner, and the cause isn't known yet. This PR's CI run will show whether it still happens.

## Local checks
- **Option value:**
  - `Rscript`: FALSE
  - `Rscript` with `R_REPRODUCIBLE_SHOWCACHE_PREWARM=true`: TRUE
  - `R --interactive`: TRUE
- **Tests:** test-misc.R, test-showCacheAsyncInstall.R and test-lazyAsyncSpawn.R all passed on the combined branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3
